### PR TITLE
Add red outline visual indicators for infeasible arms in ScatterPlot and ArmEffectsPlot

### DIFF
--- a/ax/analysis/plotly/arm_effects.py
+++ b/ax/analysis/plotly/arm_effects.py
@@ -17,9 +17,13 @@ from ax.analysis.plotly.utils import (
     get_arm_tooltip,
     get_trial_statuses_with_fallback,
     get_trial_trace_name,
+    INFEASIBLE_LEGEND_NAME,
+    INFEASIBLE_OUTLINE_COLOR,
+    INFEASIBLE_OUTLINE_WIDTH,
     LEGEND_BASE_OFFSET,
     LEGEND_POSITION,
     MARGIN_REDUCUTION,
+    MINIMUM_P_FEASIBLE,
     MULTIPLE_CANDIDATE_TRIALS_LEGEND,
     SINGLE_CANDIDATE_TRIAL_LEGEND,
     trial_index_to_color,
@@ -491,6 +495,32 @@ def _prepare_figure(
                 showlegend=True,
                 hoverinfo="skip",
                 legendgroup="candidate_trials",
+            )
+        )
+
+    # Add toggle-able infeasible indicators if any arms are infeasible
+    infeasible_df = df[df["p_feasible_mean"] < MINIMUM_P_FEASIBLE]
+    infeasible_df = infeasible_df[~infeasible_df[f"{metric_name}_mean"].isna()]
+    if is_relative and status_quo_arm_name is not None:
+        infeasible_df = infeasible_df[infeasible_df["arm_name"] != status_quo_arm_name]
+    if not infeasible_df.empty:
+        figure.add_trace(
+            go.Scatter(
+                x=infeasible_df["x_key_order"],
+                y=infeasible_df[f"{metric_name}_mean"],
+                mode="markers",
+                marker={
+                    "color": "rgba(0,0,0,0)",
+                    "size": 10,
+                    "line": {
+                        "color": INFEASIBLE_OUTLINE_COLOR,
+                        "width": INFEASIBLE_OUTLINE_WIDTH,
+                    },
+                },
+                name=INFEASIBLE_LEGEND_NAME,
+                showlegend=True,
+                hoverinfo="skip",
+                legendgroup="infeasible",
             )
         )
 

--- a/ax/analysis/plotly/scatter.py
+++ b/ax/analysis/plotly/scatter.py
@@ -24,8 +24,12 @@ from ax.analysis.plotly.utils import (
     get_arm_tooltip,
     get_trial_statuses_with_fallback,
     get_trial_trace_name,
+    INFEASIBLE_LEGEND_NAME,
+    INFEASIBLE_OUTLINE_COLOR,
+    INFEASIBLE_OUTLINE_WIDTH,
     LEGEND_POSITION,
     MARGIN_REDUCUTION,
+    MINIMUM_P_FEASIBLE,
     MULTIPLE_CANDIDATE_TRIALS_LEGEND,
     SINGLE_CANDIDATE_TRIAL_LEGEND,
     trial_index_to_color,
@@ -521,6 +525,33 @@ def _prepare_figure(
                 legendgroup="candidate_trials",
             )
         )
+
+    # Add toggle-able infeasible indicators if any arms are infeasible
+    infeasible_df = df[df["p_feasible_mean"] < MINIMUM_P_FEASIBLE]
+    if not infeasible_df.empty:
+        mean_x = infeasible_df[f"{x_metric_name}_mean"]
+        mean_y = infeasible_df[f"{y_metric_name}_mean"]
+        valid = ~(mean_x.isna() & mean_y.isna())
+        if valid.any():
+            figure.add_trace(
+                go.Scatter(
+                    x=mean_x[valid],
+                    y=mean_y[valid],
+                    mode="markers",
+                    marker={
+                        "color": "rgba(0,0,0,0)",
+                        "size": 10,
+                        "line": {
+                            "color": INFEASIBLE_OUTLINE_COLOR,
+                            "width": INFEASIBLE_OUTLINE_WIDTH,
+                        },
+                    },
+                    name=INFEASIBLE_LEGEND_NAME,
+                    showlegend=True,
+                    hoverinfo="skip",
+                    legendgroup="infeasible",
+                )
+            )
 
     # Add horizontal and vertical lines for the status quo.
     if "status_quo" in df["arm_name"].values:

--- a/ax/analysis/plotly/tests/test_arm_effects.py
+++ b/ax/analysis/plotly/tests/test_arm_effects.py
@@ -307,6 +307,108 @@ class TestArmEffectsPlot(TestCase):
                             )
 
 
+class TestArmEffectsPlotInfeasibility(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.client = Client()
+        self.client.configure_experiment(
+            name="test_infeasibility",
+            parameters=[
+                RangeParameterConfig(
+                    name="x1",
+                    parameter_type="float",
+                    bounds=(0, 1),
+                ),
+                RangeParameterConfig(
+                    name="x2",
+                    parameter_type="float",
+                    bounds=(0, 1),
+                ),
+            ],
+        )
+        # Constraint on "bar" (non-objective) so it stays as an OutcomeConstraint.
+        self.client.configure_optimization(
+            objective="foo",
+            outcome_constraints=["bar >= 0.5"],
+        )
+
+        # Trial data: (foo, bar). Arms with bar < 0.5 are infeasible.
+        trial_data = [
+            {"foo": 1.0, "bar": (0.9, 0.01)},  # feasible
+            {"foo": 0.5, "bar": (0.8, 0.01)},  # feasible
+            {"foo": 0.8, "bar": (0.1, 0.01)},  # infeasible
+            {"foo": 0.3, "bar": (0.2, 0.01)},  # infeasible
+        ]
+
+        for raw_data in trial_data:
+            for trial_index, _ in self.client.get_next_trials(max_trials=1).items():
+                self.client.complete_trial(trial_index=trial_index, raw_data=raw_data)
+
+    def test_infeasible_arms_have_red_outline(self) -> None:
+        card = ArmEffectsPlot(metric_name="bar", use_model_predictions=False).compute(
+            experiment=self.client._experiment,
+            generation_strategy=self.client._generation_strategy,
+        )
+        fig_data = json.loads(none_throws(card.blob))
+
+        # All infeasible arms are in a single trace with legendgroup="infeasible"
+        infeasible_traces = [
+            t for t in fig_data["data"] if t.get("legendgroup") == "infeasible"
+        ]
+        # Single trace containing all infeasible arms
+        self.assertEqual(len(infeasible_traces), 1)
+        trace = infeasible_traces[0]
+        self.assertEqual(trace["marker"]["line"]["color"], "red")
+        self.assertGreater(trace["marker"]["line"]["width"], 0)
+        # The trace should contain 2 infeasible points
+        self.assertEqual(len([x for x in trace["x"] if x is not None]), 2)
+        # Legend entry is on the same trace
+        self.assertTrue(trace["showlegend"])
+        self.assertEqual(trace["legendgroup"], "infeasible")
+
+    def test_no_infeasible_legend_when_all_feasible(self) -> None:
+        # Create an experiment where all arms satisfy the constraint
+        client = Client()
+        client.configure_experiment(
+            name="all_feasible",
+            parameters=[
+                RangeParameterConfig(
+                    name="x1",
+                    parameter_type="float",
+                    bounds=(0, 1),
+                ),
+                RangeParameterConfig(
+                    name="x2",
+                    parameter_type="float",
+                    bounds=(0, 1),
+                ),
+            ],
+        )
+        client.configure_optimization(
+            objective="foo",
+            outcome_constraints=["bar >= 0.5"],
+        )
+
+        for bar_val in [0.9, 0.8, 0.7, 0.6]:
+            for trial_index, _ in client.get_next_trials(max_trials=1).items():
+                client.complete_trial(
+                    trial_index=trial_index,
+                    raw_data={"foo": 1.0, "bar": (bar_val, 0.01)},
+                )
+
+        card = ArmEffectsPlot(metric_name="bar", use_model_predictions=False).compute(
+            experiment=client._experiment,
+            generation_strategy=client._generation_strategy,
+        )
+        fig_data = json.loads(none_throws(card.blob))
+
+        legend_traces = [
+            t for t in fig_data["data"] if t.get("name") == "Likely Infeasible"
+        ]
+        self.assertEqual(len(legend_traces), 0)
+
+
 class TestArmEffectsPlotRel(TestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -364,3 +364,170 @@ class TestScatterPlot(TestCase):
                                 experiment=experiment,
                                 adapter=adapter,
                             )
+
+
+class TestScatterPlotInfeasibility(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.client = Client()
+        self.client.configure_experiment(
+            name="test_infeasibility",
+            parameters=[
+                RangeParameterConfig(
+                    name="x1",
+                    parameter_type="float",
+                    bounds=(0, 1),
+                ),
+                RangeParameterConfig(
+                    name="x2",
+                    parameter_type="float",
+                    bounds=(0, 1),
+                ),
+            ],
+        )
+        # Constraint on "bar" (non-objective) so it stays as an OutcomeConstraint.
+        self.client.configure_optimization(
+            objective="foo",
+            outcome_constraints=["bar >= 0.5"],
+        )
+
+        # Trial data: (foo, bar). Arms with bar < 0.5 are infeasible.
+        trial_data = [
+            {"foo": 1.0, "bar": (0.9, 0.01)},  # feasible
+            {"foo": 0.5, "bar": (0.8, 0.01)},  # feasible
+            {"foo": 0.8, "bar": (0.1, 0.01)},  # infeasible
+            {"foo": 0.3, "bar": (0.2, 0.01)},  # infeasible
+        ]
+
+        for raw_data in trial_data:
+            for trial_index, _ in self.client.get_next_trials(max_trials=1).items():
+                self.client.complete_trial(trial_index=trial_index, raw_data=raw_data)
+
+    def test_infeasible_arms_have_red_outline(self) -> None:
+        card = ScatterPlot(
+            x_metric_name="foo",
+            y_metric_name="bar",
+            use_model_predictions=False,
+        ).compute(
+            experiment=self.client._experiment,
+            generation_strategy=self.client._generation_strategy,
+        )
+        fig_data = json.loads(none_throws(card.blob))
+
+        # All infeasible arms are in a single trace with legendgroup="infeasible"
+        infeasible_traces = [
+            t for t in fig_data["data"] if t.get("legendgroup") == "infeasible"
+        ]
+        # Single trace containing all infeasible arms
+        self.assertEqual(len(infeasible_traces), 1)
+        trace = infeasible_traces[0]
+        self.assertEqual(trace["marker"]["line"]["color"], "red")
+        self.assertGreater(trace["marker"]["line"]["width"], 0)
+        # The trace should contain 2 infeasible points
+        self.assertEqual(len([x for x in trace["x"] if x is not None]), 2)
+        # Legend entry is on the same trace
+        self.assertTrue(trace["showlegend"])
+        self.assertEqual(trace["legendgroup"], "infeasible")
+
+    def test_no_infeasible_legend_when_all_feasible(self) -> None:
+        client = Client()
+        client.configure_experiment(
+            name="all_feasible",
+            parameters=[
+                RangeParameterConfig(
+                    name="x1",
+                    parameter_type="float",
+                    bounds=(0, 1),
+                ),
+                RangeParameterConfig(
+                    name="x2",
+                    parameter_type="float",
+                    bounds=(0, 1),
+                ),
+            ],
+        )
+        client.configure_optimization(
+            objective="foo",
+            outcome_constraints=["bar >= 0.5"],
+        )
+
+        for bar_val in [0.9, 0.8, 0.7, 0.6]:
+            for trial_index, _ in client.get_next_trials(max_trials=1).items():
+                client.complete_trial(
+                    trial_index=trial_index,
+                    raw_data={"foo": 1.0, "bar": (bar_val, 0.01)},
+                )
+
+        card = ScatterPlot(
+            x_metric_name="foo",
+            y_metric_name="bar",
+            use_model_predictions=False,
+        ).compute(
+            experiment=client._experiment,
+            generation_strategy=client._generation_strategy,
+        )
+        fig_data = json.loads(none_throws(card.blob))
+
+        legend_traces = [
+            t for t in fig_data["data"] if t.get("name") == "Likely Infeasible"
+        ]
+        self.assertEqual(len(legend_traces), 0)
+
+    def test_infeasible_when_constraint_metric_not_plotted(self) -> None:
+        """Red outlines should appear even when the constraint metric is not
+        one of the plotted metrics."""
+        client = Client()
+        client.configure_experiment(
+            name="constraint_not_plotted",
+            parameters=[
+                RangeParameterConfig(
+                    name="x1",
+                    parameter_type="float",
+                    bounds=(0, 1),
+                ),
+                RangeParameterConfig(
+                    name="x2",
+                    parameter_type="float",
+                    bounds=(0, 1),
+                ),
+            ],
+        )
+        # Constraint on "bar", but we will plot "foo" vs "baz"
+        client.configure_optimization(
+            objective="foo",
+            outcome_constraints=["bar >= 0.5"],
+        )
+        client.configure_tracking_metrics(metric_names=["baz"])
+
+        trial_data = [
+            {"foo": 1.0, "baz": 5.0, "bar": (0.9, 0.01)},  # feasible
+            {"foo": 0.5, "baz": 3.0, "bar": (0.8, 0.01)},  # feasible
+            {"foo": 0.8, "baz": 4.0, "bar": (0.1, 0.01)},  # infeasible
+            {"foo": 0.3, "baz": 2.0, "bar": (0.2, 0.01)},  # infeasible
+        ]
+
+        for raw_data in trial_data:
+            for trial_index, _ in client.get_next_trials(max_trials=1).items():
+                client.complete_trial(trial_index=trial_index, raw_data=raw_data)
+
+        card = ScatterPlot(
+            x_metric_name="foo",
+            y_metric_name="baz",
+            use_model_predictions=False,
+        ).compute(
+            experiment=client._experiment,
+            generation_strategy=client._generation_strategy,
+        )
+        fig_data = json.loads(none_throws(card.blob))
+
+        # All infeasible arms are in a single trace with legendgroup="infeasible"
+        infeasible_traces = [
+            t for t in fig_data["data"] if t.get("legendgroup") == "infeasible"
+        ]
+        # Single trace containing all infeasible arms
+        self.assertEqual(len(infeasible_traces), 1)
+        # The trace should contain 2 infeasible points
+        self.assertEqual(
+            len([x for x in infeasible_traces[0]["x"] if x is not None]), 2
+        )

--- a/ax/analysis/plotly/utils.py
+++ b/ax/analysis/plotly/utils.py
@@ -19,10 +19,8 @@ from plotly import express as px
 
 MAX_LABEL_LEN: int = 50
 
-# Because normal distributions have long tails, every arm has a non-zero
-# probability of violating the constraint. But below a certain threshold, we
-# consider probability of violation to be negligible.
-MINIMUM_CONTRAINT_VIOLATION_THRESHOLD = 0.01
+# Minimum p_feasible to mark an arm as infeasible
+MINIMUM_P_FEASIBLE = 0.1
 
 # Z-score for 95% confidence interval
 Z_SCORE_95_CI = 1.96
@@ -74,6 +72,10 @@ MAX_HOVER_LABEL_LEN: int = 300
 
 SINGLE_CANDIDATE_TRIAL_LEGEND: str = "Candidate Trial"
 MULTIPLE_CANDIDATE_TRIALS_LEGEND: str = "Candidate Trials"
+
+INFEASIBLE_OUTLINE_COLOR: str = "red"
+INFEASIBLE_OUTLINE_WIDTH: float = 2.0
+INFEASIBLE_LEGEND_NAME: str = "Likely Infeasible"
 
 
 def get_scatter_point_color(
@@ -153,7 +155,7 @@ def get_arm_tooltip(
         ]
     )
 
-    if row["p_feasible_mean"] < MINIMUM_CONTRAINT_VIOLATION_THRESHOLD:
+    if row["p_feasible_mean"] < MINIMUM_P_FEASIBLE:
         constraints_warning_str = "[Warning] This arm is likely infeasible"
     else:
         constraints_warning_str = ""

--- a/ax/analysis/utils.py
+++ b/ax/analysis/utils.py
@@ -174,6 +174,7 @@ def prepare_arm_data(
     target_trial_index = get_target_trial_index(
         experiment=experiment,
     )
+
     if use_model_predictions:
         if adapter is None:
             raise UserInputError(
@@ -302,6 +303,27 @@ def prepare_arm_data(
         ):
             df = df[df["trial_index"] != target_trial_index]
 
+    # Drop extra metric columns that were included for p_feasible computation
+    # but are not part of the requested metric_names.
+    requested_metric_cols = {
+        f"{m}_{suffix}" for m in metric_names for suffix in ("mean", "sem")
+    }
+    non_metric_cols = {
+        "trial_index",
+        "arm_name",
+        "trial_status",
+        "status_reason",
+        "generation_node",
+        "p_feasible_mean",
+        "p_feasible_sem",
+    }
+    # Also keep any per-constraint p_feasible columns
+    keep_cols = non_metric_cols | requested_metric_cols
+    cols_to_keep = [
+        c for c in df.columns if c in keep_cols or c.startswith("p_feasible_")
+    ]
+    df = df[cols_to_keep]
+
     return df
 
 
@@ -394,6 +416,11 @@ def _prepare_modeled_arm_data(
             for _, arm in predictable_pairs
         ]
     )
+
+    # Extract all predicted metrics (not just requested ones) so that constraint
+    # metrics are available for _prepare_p_feasible even when they differ from
+    # the plotted metrics.
+    all_predicted_metrics = list(predictions[0].keys()) if predictions[0] else []
     records = [
         *[
             {
@@ -403,12 +430,12 @@ def _prepare_modeled_arm_data(
                 else f"{Keys.UNNAMED_ARM.value}_{i}",
                 **{
                     f"{metric_name}_mean": predictions[0][metric_name][i]
-                    for metric_name in metric_names
+                    for metric_name in all_predicted_metrics
                 },
                 **{
                     f"{metric_name}_sem": predictions[1][metric_name][metric_name][i]
                     ** 0.5
-                    for metric_name in metric_names
+                    for metric_name in all_predicted_metrics
                 },
             }
             for i in range(len(predictable_pairs))
@@ -419,8 +446,10 @@ def _prepare_modeled_arm_data(
                 "arm_name": unpredictable_pairs[i][1].name
                 if unpredictable_pairs[i][1].has_name
                 else f"{Keys.UNNAMED_ARM.value}_{i}",
-                **{f"{metric_name}_mean": None for metric_name in metric_names},
-                **{f"{metric_name}_sem": None for metric_name in metric_names},
+                **{
+                    f"{metric_name}_mean": None for metric_name in all_predicted_metrics
+                },
+                **{f"{metric_name}_sem": None for metric_name in all_predicted_metrics},
             }
             for i in range(len(unpredictable_pairs))
         ],
@@ -483,13 +512,17 @@ def _prepare_raw_arm_data(
         ).df
 
     records = []
+    # Extract all available metrics (not just requested ones) so that constraint
+    # metrics are available for _prepare_p_feasible even when they differ from
+    # the plotted metrics.
+    all_data_metrics = sorted(data_df["metric_name"].unique().tolist())
     for trial in trials:
         for arm in trial.arms:
             # Extract (mean, sem) pairs for each metric when available, otherwise set to
             # None.
             means = {}
             sems = {}
-            for metric_name in metric_names:
+            for metric_name in all_data_metrics:
                 mask = (
                     (data_df["trial_index"] == trial.index)
                     & (data_df["arm_name"] == arm.name)
@@ -509,11 +542,11 @@ def _prepare_raw_arm_data(
                     "arm_name": arm.name,
                     **{
                         f"{metric_name}_mean": means[metric_name]
-                        for metric_name in metric_names
+                        for metric_name in all_data_metrics
                     },
                     **{
                         f"{metric_name}_sem": sems[metric_name]
-                        for metric_name in metric_names
+                        for metric_name in all_data_metrics
                     },
                 }
             )
@@ -912,7 +945,12 @@ def _get_status_quo_df(
 
         # Use the raw status quo effects if no model predictions are available
         # (ex. if the status quo had None in its parameters).
-        if not mask.any() or df[mask].isna().any().any():
+        # Only check the requested metric columns for NaN, not all columns,
+        # since extra columns (e.g. constraint metrics) may legitimately be NaN.
+        requested_cols = [
+            f"{m}_{suffix}" for m in metric_names for suffix in ("mean", "sem")
+        ]
+        if not mask.any() or df.loc[mask, requested_cols].isna().any().any():
             raw_df = _prepare_raw_arm_data(
                 metric_names=metric_names,
                 experiment=experiment,
@@ -963,13 +1001,12 @@ def _get_status_quo_df(
             row["trial_index"] = trial_idx
             status_quo_rows.append(row)
 
-        status_quo_df = pd.DataFrame(status_quo_rows)[
-            [
-                "trial_index",
-                *[f"{name}_mean" for name in metric_names],
-                *[f"{name}_sem" for name in metric_names],
-            ]
+        # Include all _mean and _sem columns so constraint metrics are
+        # available for _prepare_p_feasible relativization.
+        all_metric_cols = [
+            col for col in df.columns if col.endswith("_mean") or col.endswith("_sem")
         ]
+        status_quo_df = pd.DataFrame(status_quo_rows)[["trial_index", *all_metric_cols]]
     return status_quo_df
 
 


### PR DESCRIPTION
Summary:
The ScatterPlot and ArmEffectsPlot analyses compute `p_feasible_mean` for each arm but only displayed it in the hover tooltip. Users had to hover over each point to discover constraint violations.

This change adds a red outline around scatter points for arms that are likely infeasible (`p_feasible_mean < 0.1`), making constraint violations immediately visible. A "Likely Infeasible" legend entry is also added when any infeasible arms are present.

In addition, `prepare_arm_data()` previously only included columns for the requested (plotted) metrics in its DataFrame. When a constraint metric differed from the plotted metrics, `_prepare_p_feasible()` couldn't find the constraint column, filled it with NaN, and all arms incorrectly appeared feasible. This fix ensures `_prepare_modeled_arm_data()` extracts all predicted metrics and `_prepare_raw_arm_data()` extracts all available data metrics, so constraint feasibility is computed correctly regardless of which metrics are plotted.

Changes:
- `plotly/utils.py`: Add `MINIMUM_P_FEASIBLE` threshold (renamed from `MINIMUM_CONTRAINT_VIOLATION_THRESHOLD`), `get_infeasibility_marker_line()` helper, and infeasibility constants.
- `plotly/scatter.py`, `plotly/arm_effects.py`: Apply marker line to each trial's scatter points and add a "Likely Infeasible" legend entry.
- `analysis/utils.py`: Fix `_prepare_modeled_arm_data` to extract all predicted metrics (not just plotted ones), `_prepare_raw_arm_data` to extract all available data metrics, `_get_status_quo_df` to handle extra columns in NaN checks and status quo column selection. Extra columns are stripped before returning from `prepare_arm_data()` to preserve the API contract.
- Tests: Add `TestScatterPlotInfeasibility` and `TestArmEffectsPlotInfeasibility` classes covering red outlines on infeasible arms, legend presence/absence, and the case where the constraint metric differs from the plotted metrics.

Reviewed By: mpolson64

Differential Revision: D94783502


