### PR TITLE
Wrap pd.DataFrame index list literals with pd.Index() in core_stats+ax+data_ai

### DIFF
--- a/ax/analysis/plotly/marginal_effects.py
+++ b/ax/analysis/plotly/marginal_effects.py
@@ -219,7 +219,7 @@ def _prepare_data(
 
     arm_dfs = []
     for arm in plot_data.in_sample.values():
-        arm_df = pd.DataFrame(arm.parameters, index=[arm.name])
+        arm_df = pd.DataFrame(arm.parameters, index=pd.Index([arm.name]))
         arm_df["mean"] = arm.y_hat[metric]
         arm_df["sem"] = arm.se_hat[metric]
         arm_dfs.append(arm_df)


### PR DESCRIPTION
Summary:
Python 3.14 pandas type stubs require explicit `pd.Index()` for the `index`
parameter of `pd.DataFrame.__init__`. Wrap list literals with `pd.Index()`.

Applied via: `buck run fbcode//python/upgrade/codemods:cli -- pandas-dataframe-index`

Backwards compatible — `pd.Index` has been available since early pandas versions.

Differential Revision: D96619276


