### PR TITLE
Add NotApplicableStateAnalysisCard class (#5035)

### DIFF
--- a/ax/core/analysis_card.py
+++ b/ax/core/analysis_card.py
@@ -431,3 +431,17 @@ class ErrorAnalysisCard(AnalysisCard):
         """
 
         return f"<div class='content'>{self.blob}</div>"
+
+
+class NotApplicableStateAnalysisCard(AnalysisCard):
+    """Card for analyses that are not applicable to the current experiment state.
+
+    This card represents a transient state where an analysis cannot be computed
+    due to the current experiment state (e.g., when the experiment doesn't have enough
+    data, when no model has been fit yet, or when required trials have not completed),
+    but may become available as the experiment progresses.
+    """
+
+    def _body_html(self, depth: int) -> str:
+        """Return the HTML body containing the not-applicable explanation text."""
+        return f"<div class='content'>{self.blob}</div>"

--- a/ax/core/tests/test_analysis_card.py
+++ b/ax/core/tests/test_analysis_card.py
@@ -9,7 +9,7 @@ import pandas as pd
 from ax.analysis.analysis import AnalysisCard
 from ax.analysis.markdown.markdown_analysis import MarkdownAnalysisCard
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysisCard
-from ax.core.analysis_card import AnalysisCardGroup
+from ax.core.analysis_card import AnalysisCardGroup, NotApplicableStateAnalysisCard
 from ax.utils.common.testutils import TestCase
 from plotly import graph_objects as go, io as pio
 
@@ -67,3 +67,14 @@ class TestAnalysisCard(TestCase):
         test_markdown_analysis_card_title"""
 
         self.assertEqual(big_group.hierarchy_str(), expected)
+
+    def test_not_applicable_card(self) -> None:
+        """Test NotApplicableStateAnalysisCard._body_html renders blob content."""
+        card = NotApplicableStateAnalysisCard(
+            name="Test",
+            title="Test",
+            subtitle="",
+            df=pd.DataFrame(),
+            blob="Explanation text.",
+        )
+        self.assertIn("Explanation text.", card._body_html(depth=0))


### PR DESCRIPTION
Summary:

Add a new NotApplicableStateAnalysisCard class to distinguish
transient 'not applicable ' states from true errors. This card is used for
analyses that cannot be computed due to the current experiment state (e.g.,
'Experiment has no data yet') but will become available as the experiment
progresses.

Reviewed By: bernardbeckerman

Differential Revision: D96248249


