### PR TITLE
Expand is_compatible_with to support different types of parameters. (#5040)

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -156,7 +156,13 @@ class Parameter(SortableBase, metaclass=ABCMeta):
         """Check whether parameters are compatible.
 
         Two parameters are compatible if they have the same parameter type and
-        domain type. Additional checks are performed based on the domain type.
+        compatible domain types. Any pair of parameters that can be merged is also
+        considered compatible. In particular:
+
+        - Two RangeParameters are always compatible (bounds may differ).
+        - A RangeParameter and a FixedParameter are compatible.
+        - Two ChoiceParameters are always compatible (values may differ).
+        - Two FixedParameters are always compatible (values may differ).
 
         Args:
             other: Another Ax parameter object to compare against.
@@ -669,10 +675,11 @@ class RangeParameter(Parameter):
     def _is_domain_compatible(self, other: Parameter) -> bool:
         """Check domain-specific compatibility for RangeParameter.
 
-        Two RangeParameters are compatible if they are both RangeParameters.
-        The bounds do not need to overlap.
+        A RangeParameter is compatible with another RangeParameter (bounds may
+        differ) or with a FixedParameter (to support merging a fixed value
+        into a range).
         """
-        return isinstance(other, RangeParameter)
+        return isinstance(other, (RangeParameter, FixedParameter))
 
     @property
     def domain_repr(self) -> str:
@@ -1076,11 +1083,10 @@ class ChoiceParameter(Parameter):
     def _is_domain_compatible(self, other: Parameter) -> bool:
         """Check domain-specific compatibility for ChoiceParameter.
 
-        Two ChoiceParameters are compatible if they have the same set of values.
+        Two ChoiceParameters are always compatible (values may differ, since
+        they can be merged via union).
         """
-        if not isinstance(other, ChoiceParameter):
-            return False
-        return set(self.values) == set(other.values)
+        return isinstance(other, ChoiceParameter)
 
     @property
     def domain_repr(self) -> str:
@@ -1232,11 +1238,11 @@ class FixedParameter(Parameter):
     def _is_domain_compatible(self, other: Parameter) -> bool:
         """Check domain-specific compatibility for FixedParameter.
 
-        Two FixedParameters are compatible if they have the same value.
+        A FixedParameter is compatible with another FixedParameter (values may
+        differ) or with a RangeParameter (to support merging a fixed value
+        into a range).
         """
-        if not isinstance(other, FixedParameter):
-            return False
-        return self.value == other.value
+        return isinstance(other, (FixedParameter, RangeParameter))
 
     @property
     def domain_repr(self) -> str:

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -579,25 +579,30 @@ class SearchSpace(Base):
         return True
 
     def get_overlapping_parameters(
-        self, other: SearchSpace, raise_error: bool = False
+        self,
+        other: SearchSpace,
+        raise_error: bool = False,
     ) -> list[str]:
         """Get the list of compatible overlapping parameters between this search
         space and another.
 
         Two parameters are considered overlapping if they have the same name and
-        are compatible (same parameter type and domain type, and for fixed and
-        choice parameters, the same values).
+        are compatible (same parameter type and compatible domain types --
+        see ``Parameter.is_compatible_with`` for the full definition).
+
+        RangeParameters and DerivedParameters are always exempt from the
+        incompatibility check (they never block overlap). Incompatible
+        exempt parameters are simply excluded from the result.
 
         Args:
             other: Another SearchSpace object to compare against.
             raise_error: Whether to raise an error if there are incompatible
-                non-range parameters with the same name.
+                parameters with the same name.
 
         Returns:
             A list of parameter names that are present and compatible in both
-            search spaces. Returns an empty list if there are incompatible
-            fixed or choice parameters (since such search spaces cannot be
-            meaningfully compared).
+            search spaces. Returns an empty list if there are any
+            incompatible non-exempt parameters.
         """
         common_param_names = set(self.parameters.keys()) & set(other.parameters.keys())
 
@@ -607,12 +612,13 @@ class SearchSpace(Base):
             )
             for param_name in common_param_names
         }
-
         incompatible_params = {
             param_name
             for param_name in common_param_names
             if not common_param_compatibility[param_name]
-            and not isinstance(other.parameters[param_name], RangeParameter)
+            and not isinstance(
+                other.parameters[param_name], (RangeParameter, DerivedParameter)
+            )
         }
 
         if len(incompatible_params) > 0:

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -267,6 +267,34 @@ class RangeParameterTest(TestCase):
             )
             self.assertFalse(range_param_1.is_compatible_with(range_param_2))
 
+        with self.subTest("compatible_with_fixed_same_type"):
+            range_param = RangeParameter(
+                name="x",
+                parameter_type=ParameterType.FLOAT,
+                lower=0.0,
+                upper=1.0,
+            )
+            fixed_param = FixedParameter(
+                name="x",
+                parameter_type=ParameterType.FLOAT,
+                value=0.5,
+            )
+            self.assertTrue(range_param.is_compatible_with(fixed_param))
+
+        with self.subTest("incompatible_with_fixed_different_type"):
+            range_param = RangeParameter(
+                name="x",
+                parameter_type=ParameterType.FLOAT,
+                lower=0.0,
+                upper=1.0,
+            )
+            fixed_param = FixedParameter(
+                name="x",
+                parameter_type=ParameterType.INT,
+                value=1,
+            )
+            self.assertFalse(range_param.is_compatible_with(fixed_param))
+
 
 class ChoiceParameterTest(TestCase):
     def setUp(self) -> None:
@@ -784,17 +812,31 @@ class ChoiceParameterTest(TestCase):
             )
 
     def test_is_compatible_with(self) -> None:
-        choice_param_1 = ChoiceParameter(
-            name="x",
-            parameter_type=ParameterType.STRING,
-            values=["foo", "bar"],
-        )
-        choice_param_2 = ChoiceParameter(
-            name="x",
-            parameter_type=ParameterType.STRING,
-            values=["foo", "bar"],
-        )
-        self.assertTrue(choice_param_1.is_compatible_with(choice_param_2))
+        with self.subTest("compatible_same_values"):
+            choice_param_1 = ChoiceParameter(
+                name="x",
+                parameter_type=ParameterType.STRING,
+                values=["foo", "bar"],
+            )
+            choice_param_2 = ChoiceParameter(
+                name="x",
+                parameter_type=ParameterType.STRING,
+                values=["foo", "bar"],
+            )
+            self.assertTrue(choice_param_1.is_compatible_with(choice_param_2))
+
+        with self.subTest("compatible_different_values"):
+            choice_param_1 = ChoiceParameter(
+                name="x",
+                parameter_type=ParameterType.STRING,
+                values=["foo", "bar"],
+            )
+            choice_param_2 = ChoiceParameter(
+                name="x",
+                parameter_type=ParameterType.STRING,
+                values=["bar", "baz"],
+            )
+            self.assertTrue(choice_param_1.is_compatible_with(choice_param_2))
 
 
 class FixedParameterTest(TestCase):
@@ -962,7 +1004,7 @@ class FixedParameterTest(TestCase):
             )
             self.assertTrue(fixed_param_1.is_compatible_with(fixed_param_2))
 
-        with self.subTest("incompatible_different_value"):
+        with self.subTest("compatible_different_value"):
             fixed_param_1 = FixedParameter(
                 name="x",
                 parameter_type=ParameterType.STRING,
@@ -973,7 +1015,35 @@ class FixedParameterTest(TestCase):
                 parameter_type=ParameterType.STRING,
                 value="bar",
             )
-            self.assertFalse(fixed_param_1.is_compatible_with(fixed_param_2))
+            self.assertTrue(fixed_param_1.is_compatible_with(fixed_param_2))
+
+        with self.subTest("compatible_with_range_same_type"):
+            fixed_param = FixedParameter(
+                name="x",
+                parameter_type=ParameterType.FLOAT,
+                value=0.5,
+            )
+            range_param = RangeParameter(
+                name="x",
+                parameter_type=ParameterType.FLOAT,
+                lower=0.0,
+                upper=1.0,
+            )
+            self.assertTrue(fixed_param.is_compatible_with(range_param))
+
+        with self.subTest("incompatible_with_range_different_type"):
+            fixed_param = FixedParameter(
+                name="x",
+                parameter_type=ParameterType.INT,
+                value=1,
+            )
+            range_param = RangeParameter(
+                name="x",
+                parameter_type=ParameterType.FLOAT,
+                lower=0.0,
+                upper=1.0,
+            )
+            self.assertFalse(fixed_param.is_compatible_with(range_param))
 
 
 class DerivedParameterTest(TestCase):

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -815,7 +815,9 @@ class SearchSpaceTest(TestCase):
             result = search_space_1.get_overlapping_parameters(search_space_2)
             self.assertEqual(result, [])
 
-        with self.subTest("no_overlap_incompatible_fixed_params"):
+        with self.subTest("overlap_fixed_params_different_values"):
+            # Fixed params with different values are now compatible
+            # (consistent with merge_parameters).
             fixed_param_1 = FixedParameter(
                 name="x",
                 parameter_type=ParameterType.STRING,
@@ -831,7 +833,93 @@ class SearchSpaceTest(TestCase):
             search_space_2 = SearchSpace(parameters=[fixed_param_2])
 
             result = search_space_1.get_overlapping_parameters(search_space_2)
-            self.assertEqual(result, [])
+            self.assertEqual(result, ["x"])
+
+        with self.subTest("compatible_fixed_different_values_with_range"):
+            # Fixed params with different values are compatible
+            # (consistent with merge_parameters), so both x and y overlap.
+            range_param_1 = RangeParameter(
+                name="x",
+                parameter_type=ParameterType.FLOAT,
+                lower=0.0,
+                upper=1.0,
+            )
+            fixed_param_1 = FixedParameter(
+                name="y",
+                parameter_type=ParameterType.STRING,
+                value="foo",
+            )
+            search_space_1 = SearchSpace(parameters=[range_param_1, fixed_param_1])
+
+            range_param_2 = RangeParameter(
+                name="x",
+                parameter_type=ParameterType.FLOAT,
+                lower=0.5,
+                upper=2.0,
+            )
+            fixed_param_2 = FixedParameter(
+                name="y",
+                parameter_type=ParameterType.STRING,
+                value="bar",
+            )
+            search_space_2 = SearchSpace(parameters=[range_param_2, fixed_param_2])
+
+            result = search_space_1.get_overlapping_parameters(search_space_2)
+            self.assertCountEqual(result, ["x", "y"])
+
+        with self.subTest("derived_params_always_exempt"):
+            # Incompatible derived params never block overlap and are
+            # excluded from the result.
+            range_param = RangeParameter(
+                name="x",
+                parameter_type=ParameterType.FLOAT,
+                lower=0.0,
+                upper=1.0,
+            )
+            derived_param_1 = DerivedParameter(
+                name="d",
+                parameter_type=ParameterType.FLOAT,
+                expression_str="x * 2",
+            )
+            search_space_1 = SearchSpace(parameters=[range_param, derived_param_1])
+
+            range_param_2 = RangeParameter(
+                name="x",
+                parameter_type=ParameterType.FLOAT,
+                lower=0.5,
+                upper=2.0,
+            )
+            derived_param_2 = DerivedParameter(
+                name="d",
+                parameter_type=ParameterType.FLOAT,
+                expression_str="x * 3",
+            )
+            search_space_2 = SearchSpace(parameters=[range_param_2, derived_param_2])
+
+            # Derived params are always exempt -- only compatible
+            # non-derived params (x) are returned.
+            result = search_space_1.get_overlapping_parameters(search_space_2)
+            self.assertEqual(result, ["x"])
+
+        with self.subTest("overlap_choice_params_different_values"):
+            # Choice params with different values are compatible
+            # (consistent with merge_parameters).
+            choice_param_1 = ChoiceParameter(
+                name="c",
+                parameter_type=ParameterType.STRING,
+                values=["a", "b"],
+            )
+            search_space_1 = SearchSpace(parameters=[choice_param_1])
+
+            choice_param_2 = ChoiceParameter(
+                name="c",
+                parameter_type=ParameterType.STRING,
+                values=["x", "y"],
+            )
+            search_space_2 = SearchSpace(parameters=[choice_param_2])
+
+            result = search_space_1.get_overlapping_parameters(search_space_2)
+            self.assertEqual(result, ["c"])
 
 
 class SearchSpaceDigestTest(TestCase):

--- a/ax/storage/sqa_store/load.py
+++ b/ax/storage/sqa_store/load.py
@@ -843,8 +843,11 @@ def identify_transferable_experiments(
             continue
         if not exp_search_space:
             continue
+        num_tunable_params = len(exp_search_space.tunable_parameters.values())
+        if num_tunable_params == 0:
+            continue
         overlap_params = exp_search_space.get_overlapping_parameters(search_space)
-        prop_overlap = len(overlap_params) / len(search_space.parameters)
+        prop_overlap = len(overlap_params) / num_tunable_params
         if prop_overlap >= overlap_threshold:
             results.append(
                 {

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -43,7 +43,13 @@ from ax.core.optimization_config import (
     PreferenceOptimizationConfig,
 )
 from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
-from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
+from ax.core.parameter import (
+    ChoiceParameter,
+    DerivedParameter,
+    FixedParameter,
+    ParameterType,
+    RangeParameter,
+)
 from ax.core.runner import Runner
 from ax.core.search_space import SearchSpace
 from ax.core.trial import Trial
@@ -3236,12 +3242,7 @@ class SQAStoreTest(TestCase):
             source_experiment.attach_data(get_data(trial_index=trial.index))
             save_experiment(source_experiment, config=config)
 
-            # Execute: Find transferable experiments for a target search space
-            # that only has RangeParameters w and x (overlapping with source)
-            # Note: We use only RangeParameters to avoid incompatibility issues
-            # with Choice/Fixed parameters that have different values
-            from ax.core.search_space import SearchSpace
-
+            # Target has w and x (overlapping with source).
             target_search_space = SearchSpace(
                 parameters=[
                     get_range_parameter(),  # w
@@ -3267,7 +3268,8 @@ class SQAStoreTest(TestCase):
         with self.subTest("filters_by_overlap_threshold"):
             config = SQAConfig(experiment_type_enum=MockExperimentTypeEnum)
 
-            # Create and save a source experiment with parameters w, x, y, z
+            # Source experiment has params w, x, y, z, d (from get_search_space).
+            # w is RangeParameter(FLOAT), x is RangeParameter(INT).
             source_experiment = get_experiment_with_batch_trial()
             source_experiment.name = "exp_with_partial_overlap"
             source_experiment.experiment_type = "TEST"
@@ -3276,70 +3278,145 @@ class SQAStoreTest(TestCase):
             source_experiment.attach_data(get_data(trial_index=trial.index))
             save_experiment(source_experiment, config=config)
 
-            # Target has 6 range parameters: w, x overlap with source (33% overlap)
-            from ax.core.search_space import SearchSpace
-
+            # Target has w (FLOAT, compatible) and x (FLOAT, incompatible
+            # with source x which is INT). Overlap = [w], prop = 1/2 = 0.5.
             target_search_space = SearchSpace(
                 parameters=[
-                    get_range_parameter(),  # w - overlaps
-                    get_range_parameter2(),  # x - overlaps
+                    get_range_parameter(),  # w (FLOAT) - compatible with source
                     RangeParameter(
-                        name="extra1",
+                        name="x",
                         parameter_type=ParameterType.FLOAT,
                         lower=0,
                         upper=10,
+                    ),  # x (FLOAT) - incompatible with source x (INT)
+                ]
+            )
+
+            # Threshold 0.4 < 0.5 -- should include
+            result_above = identify_transferable_experiments(
+                search_space=target_search_space,
+                experiment_types=["TEST"],
+                overlap_threshold=0.4,
+                max_num_exps=10,
+                config=config,
+            )
+
+            self.assertIn("exp_with_partial_overlap", result_above)
+            metadata = result_above["exp_with_partial_overlap"]
+            self.assertIsNotNone(metadata.overlap_parameters)
+            # Only w overlaps (x is incompatible due to type mismatch)
+            self.assertEqual(len(none_throws(metadata.overlap_parameters)), 1)
+
+            # Threshold 0.6 > 0.5 -- should exclude
+            result_below = identify_transferable_experiments(
+                search_space=target_search_space,
+                experiment_types=["TEST"],
+                overlap_threshold=0.6,
+                max_num_exps=10,
+                config=config,
+            )
+
+            self.assertNotIn("exp_with_partial_overlap", result_below)
+
+        with self.subTest("prop_overlap_uses_source_tunable_params_as_denominator"):
+            config = SQAConfig(experiment_type_enum=MockExperimentTypeEnum)
+
+            # Source experiment has w (Range FLOAT), x (Range INT), y (Choice),
+            # z (Fixed), d (Derived).
+            source_experiment = get_experiment_with_batch_trial()
+            source_experiment.name = "exp_prop_overlap_denom"
+            source_experiment.experiment_type = "TEST"
+            source_experiment.is_test = False
+            trial = source_experiment.trials[0]
+            source_experiment.attach_data(get_data(trial_index=trial.index))
+            save_experiment(source_experiment, config=config)
+
+            # Target has w (compatible) and x (FLOAT, incompatible with
+            # source x which is INT). DB returns source {w, x} (filtered
+            # to target names). Tunable = {w, x} = 2. Overlap = [w].
+            # prop_overlap = 1/2 = 0.5.
+            target_search_space = SearchSpace(
+                parameters=[
+                    get_range_parameter(),  # w (FLOAT) - compatible
+                    RangeParameter(
+                        name="x",
+                        parameter_type=ParameterType.FLOAT,
+                        lower=0,
+                        upper=10,
+                    ),  # x (FLOAT) - incompatible with source x (INT)
+                ]
+            )
+
+            # prop_overlap = 0.5, so threshold 0.4 should include
+            result_above = identify_transferable_experiments(
+                search_space=target_search_space,
+                experiment_types=["TEST"],
+                overlap_threshold=0.4,
+                max_num_exps=10,
+                config=config,
+            )
+            self.assertIn("exp_with_partial_overlap", result_above)
+            metadata = result_above["exp_with_partial_overlap"]
+            self.assertEqual(len(none_throws(metadata.overlap_parameters)), 1)
+
+            # prop_overlap = 0.5, so threshold 0.6 should exclude
+            result_below = identify_transferable_experiments(
+                search_space=target_search_space,
+                experiment_types=["TEST"],
+                overlap_threshold=0.6,
+                max_num_exps=10,
+                config=config,
+            )
+            self.assertNotIn("exp_with_partial_overlap", result_below)
+
+        with self.subTest("derived_params_exempt_fixed_params_compatible"):
+            config = SQAConfig(experiment_type_enum=MockExperimentTypeEnum)
+
+            # Source has w, x, y (tunable) + z (Fixed BOOL) + d (Derived).
+            source_experiment = get_experiment_with_batch_trial()
+            source_experiment.name = "exp_ignore_fixed_derived"
+            source_experiment.experiment_type = "TEST"
+            source_experiment.is_test = False
+            trial = source_experiment.trials[0]
+            source_experiment.attach_data(get_data(trial_index=trial.index))
+            save_experiment(source_experiment, config=config)
+
+            # Target has w, x (compatible range), z (compatible fixed,
+            # different value), d (incompatible derived, exempt).
+            # Overlap = [w, x, z]. Source tunable = {w, x, y} (3).
+            # prop_overlap = 3/3 = 1.0.
+            target_search_space = SearchSpace(
+                parameters=[
+                    get_range_parameter(),  # w
+                    get_range_parameter2(),  # x
+                    FixedParameter(
+                        name="z",
+                        parameter_type=ParameterType.BOOL,
+                        value=False,
                     ),
-                    RangeParameter(
-                        name="extra2",
+                    DerivedParameter(
+                        name="d",
                         parameter_type=ParameterType.FLOAT,
-                        lower=0,
-                        upper=10,
-                    ),
-                    RangeParameter(
-                        name="extra3",
-                        parameter_type=ParameterType.FLOAT,
-                        lower=0,
-                        upper=10,
-                    ),
-                    RangeParameter(
-                        name="extra4",
-                        parameter_type=ParameterType.FLOAT,
-                        lower=0,
-                        upper=10,
+                        expression_str="99.0 * w",
                     ),
                 ]
             )
 
-            # Execute with threshold of 0.2 (20%) - should include experiment
-            # since overlap is ~33% which exceeds 20%
-            result_above = identify_transferable_experiments(
+            result = identify_transferable_experiments(
                 search_space=target_search_space,
                 experiment_types=["TEST"],
-                overlap_threshold=0.2,  # Threshold below the ~33% overlap
+                overlap_threshold=0.5,
                 max_num_exps=10,
                 config=config,
             )
-
-            # Assert: Should find experiment
-            self.assertIn("exp_with_partial_overlap", result_above)
-            # Verify overlap metadata is correct
-            metadata = result_above["exp_with_partial_overlap"]
-            self.assertIsNotNone(metadata.overlap_parameters)
-            # Should have 2 overlapping parameters (w and x)
-            self.assertEqual(len(none_throws(metadata.overlap_parameters)), 2)
-
-            # Execute with threshold of 0.5 (50%) - should exclude experiment
-            # since overlap is only ~33%
-            result_below = identify_transferable_experiments(
-                search_space=target_search_space,
-                experiment_types=["TEST"],
-                overlap_threshold=0.5,  # Threshold above the ~33% overlap
-                max_num_exps=10,
-                config=config,
-            )
-
-            # Assert: Should NOT find experiment due to threshold
-            self.assertNotIn("exp_with_partial_overlap", result_below)
+            self.assertIn("exp_ignore_fixed_derived", result)
+            metadata = result["exp_ignore_fixed_derived"]
+            overlap = none_throws(metadata.overlap_parameters)
+            # w, x, z overlap; d is derived (exempt, excluded from result)
+            self.assertEqual(len(overlap), 3)
+            self.assertIn("w", overlap)
+            self.assertIn("x", overlap)
+            self.assertIn("z", overlap)
 
         with self.subTest("respects_max_num_exps"):
             config = SQAConfig(experiment_type_enum=MockExperimentTypeEnum)
@@ -3353,9 +3430,6 @@ class SQAStoreTest(TestCase):
                 trial = exp.trials[0]
                 exp.attach_data(get_data(trial_index=trial.index))
                 save_experiment(exp, config=config)
-
-            # Use a target search space with only RangeParameters
-            from ax.core.search_space import SearchSpace
 
             target_search_space = SearchSpace(
                 parameters=[
@@ -3419,10 +3493,7 @@ class SQAStoreTest(TestCase):
                 source_exp.attach_data(get_data(trial_index=trial.index))
                 save_experiment(source_exp, config=config)
 
-            # Create target experiment with same experiment type
-            # Use only RangeParameters to ensure overlap with source experiments
-            from ax.core.search_space import SearchSpace
-
+            # Create target experiment with same type and overlapping params.
             target_search_space = SearchSpace(
                 parameters=[
                     get_range_parameter(),  # w


### PR DESCRIPTION
Summary:

This relaxes `is_compatible_with` (and the underlying `_is_domain_compatible`
methods) so that any pair of parameters that `merge_parameters` can merge
is also reported as compatible:

- FixedParameter + FixedParameter: now compatible regardless of value
  (previously required same value).
- ChoiceParameter + ChoiceParameter: now compatible regardless of values
  (previously required identical value sets).
- FixedParameter + RangeParameter (either direction): now compatible
  (previously incompatible due to different domain types).

In `SearchSpace.get_overlapping_parameters`, DerivedParameters are now always exempt
from the incompatibility check.

Reviewed By: hvarfner

Differential Revision: D96149086
