### PR TITLE
Fix transitive ObjectiveThreshold import in ax/service/utils/instantiation.py (#5041)

### DIFF
--- a/ax/analysis/plotly/tests/test_bandit_rollout.py
+++ b/ax/analysis/plotly/tests/test_bandit_rollout.py
@@ -10,7 +10,8 @@ from ax.analysis.plotly.utils import STALE_FAIL_REASON
 from ax.core.arm import Arm
 from ax.core.experiment import Experiment
 from ax.core.metric import Metric
-from ax.core.optimization_config import Objective, OptimizationConfig
+from ax.core.objective import Objective
+from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.core.search_space import SearchSpace
 from ax.utils.common.testutils import TestCase

--- a/ax/analysis/tests/test_diagnostics.py
+++ b/ax/analysis/tests/test_diagnostics.py
@@ -23,7 +23,8 @@ from ax.core.arm import Arm
 from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.metric import Metric
-from ax.core.optimization_config import Objective, OptimizationConfig
+from ax.core.objective import Objective
+from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.core.search_space import SearchSpace
 from ax.generation_strategy.generation_strategy import (

--- a/ax/analysis/tests/test_overview.py
+++ b/ax/analysis/tests/test_overview.py
@@ -24,7 +24,8 @@ from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
-from ax.core.optimization_config import Objective, OptimizationConfig
+from ax.core.objective import Objective
+from ax.core.optimization_config import OptimizationConfig
 from ax.core.outcome_constraint import ScalarizedOutcomeConstraint
 from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.core.search_space import SearchSpace

--- a/ax/analysis/tests/test_results.py
+++ b/ax/analysis/tests/test_results.py
@@ -16,7 +16,8 @@ from ax.core.data import Data
 from ax.core.experiment import Experiment
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
-from ax.core.optimization_config import Objective, OptimizationConfig
+from ax.core.objective import Objective
+from ax.core.optimization_config import OptimizationConfig
 from ax.core.parameter import ChoiceParameter, ParameterType
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import UserInputError

--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -70,7 +70,6 @@ from ax.benchmark.testing.benchmark_stubs import (
     get_soo_surrogate,
 )
 from ax.core.experiment import Experiment
-from ax.core.objective import MultiObjective
 from ax.core.trial_status import TrialStatus
 from ax.early_stopping.strategies.threshold import ThresholdEarlyStoppingStrategy
 from ax.generation_strategy.external_generation_node import ExternalGenerationNode

--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -13,11 +13,7 @@ from typing import Self
 
 from ax.core.arm import Arm
 from ax.core.objective import Objective
-from ax.core.outcome_constraint import (
-    ComparisonOp,
-    ObjectiveThreshold,
-    OutcomeConstraint,
-)
+from ax.core.outcome_constraint import ComparisonOp, OutcomeConstraint
 from ax.exceptions.core import UserInputError
 from ax.utils.common.base import Base
 

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -25,11 +25,10 @@ from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
-    ObjectiveThreshold,
     OptimizationConfig,
     PreferenceOptimizationConfig,
 )
-from ax.core.outcome_constraint import OutcomeConstraint
+from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
 from ax.core.parameter import (
     ChoiceParameter,
     DerivedParameter,

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -22,10 +22,9 @@ from ax.core.objective import MultiObjective, Objective
 from ax.core.observation import ObservationFeatures
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
-    ObjectiveThreshold,
     OptimizationConfig,
 )
-from ax.core.outcome_constraint import OutcomeConstraint
+from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
 from ax.core.parameter import (
     ChoiceParameter,
     DerivedParameter,


### PR DESCRIPTION
Summary:

Import ObjectiveThreshold from its canonical location (ax.core.outcome_constraint) instead of transitively through ax.core.optimization_config

Reviewed By: mgarrard

Differential Revision: D96780988


