### PR TITLE
Add __version__ attribute for programmatic version checking

### DIFF
--- a/ax/__init__.py
+++ b/ax/__init__.py
@@ -10,6 +10,11 @@ from ax.api.client import Client
 from ax.api.configs import ChoiceParameterConfig, RangeParameterConfig, StorageConfig
 from ax.api.types import TOutcome, TParameterization
 
+try:
+    from ax.version import version as __version__  # @manual
+except Exception:  # pragma: no cover
+    __version__: str = "Unknown"
+
 __all__ = [
     "Client",
     "ChoiceParameterConfig",


### PR DESCRIPTION
Summary:
Adds `__version__` to `ax/__init__.py` by importing from `ax.version`, which is generated by `setuptools_scm` at build time. Uses a try/except fallback to `"Unknown"` for environments where the version file hasn't been generated yet, matching the same pattern used in BoTorch. This enables programmatic version checking via `ax.__version__`.

---
AI generated Summary & Test Plan from DEV111709377

Reviewed By: saitcakmak

Differential Revision: D96685150


