### PR TITLE
Fix DerivedMetric._collect_arm_data to skip abandoned arms

### DIFF
--- a/ax/core/derived_metric.py
+++ b/ax/core/derived_metric.py
@@ -53,6 +53,7 @@ from typing import Any, Callable, cast
 
 import pandas as pd
 from ax.core.base_trial import BaseTrial
+from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data
 from ax.core.metric import Metric, MetricFetchE, MetricFetchResult
 from ax.exceptions.core import UserInputError
@@ -272,7 +273,18 @@ class DerivedMetric(Metric):
         """
         arm_data: dict[str, pd.DataFrame] = {}
 
+        # Skip abandoned arms -- they have no base metric data (the metric
+        # system correctly does not fetch data for abandoned arms), so
+        # requiring their data would cause a spurious MetricFetchE.
+        abandoned_names: set[str] = (
+            {a.name for a in trial.abandoned_arms}
+            if isinstance(trial, BatchTrial)
+            else set()
+        )
+
         for arm in trial.arms:
+            if arm.name in abandoned_names:
+                continue
             if source_trial_indices is not None and arm.name in source_trial_indices:
                 src_trial_idx, src_arm_name = source_trial_indices[arm.name]
                 arm_df = df[

--- a/ax/core/tests/test_derived_metric.py
+++ b/ax/core/tests/test_derived_metric.py
@@ -521,6 +521,34 @@ class DerivedMetricTest(TestCase):
             self.assertIsInstance(result, Err)
             self.assertIn("b", none_throws(result.err).message)
 
+    def test_fetch_trial_data_skips_abandoned_arms(self) -> None:
+        """Abandoned arms are skipped in _collect_arm_data.
+
+        When a BatchTrial has an abandoned arm, that arm has no base metric
+        data (the metric system correctly does not fetch data for abandoned
+        arms).  _collect_arm_data must skip abandoned arms rather than
+        returning a MetricFetchE for missing input data.
+        """
+        metric = _SumDerivedMetric(name="total", input_metric_names=["a", "b"])
+        exp = Experiment(name="test", search_space=get_branin_search_space())
+        trial = exp.new_batch_trial()
+        arm_ok = Arm(name="arm_ok", parameters={"x1": 1.0, "x2": 1.0})
+        arm_abandoned = Arm(name="arm_abandoned", parameters={"x1": 2.0, "x2": 2.0})
+        trial.add_arm(arm_ok)
+        trial.add_arm(arm_abandoned)
+        trial.mark_running(no_runner_required=True)
+        trial.mark_arm_abandoned(arm_name="arm_abandoned")
+        trial.mark_completed()
+
+        # Only attach data for the non-abandoned arm.
+        exp.attach_data(_make_trial_data(0, {"arm_ok": {"a": 3.0, "b": 4.0}}))
+
+        result = metric.fetch_trial_data(trial)
+        self.assertIsInstance(result, Ok)
+        df = none_throws(result.ok).df
+        self.assertEqual(list(df["arm_name"]), ["arm_ok"])
+        self.assertAlmostEqual(df["mean"].iloc[0], 7.0)
+
 
 class ExpressionDerivedMetricTest(TestCase):
     """Tests for ExpressionDerivedMetric."""


### PR DESCRIPTION
Summary:
`DerivedMetric._collect_arm_data` iterates `trial.arms`, which includes
abandoned arms in a `BatchTrial`.  Abandoned arms correctly have no base
metric data (the metric system does not fetch data for them), but
`_collect_arm_data` returns a hard `MetricFetchE` when any arm is missing
input metric data.  This causes derived metrics to silently produce no
data for trials with abandoned arms (the error is caught as a warning
upstream in `_run_parallel_trial_queries`).

The fix filters out abandoned arms at the top of `_collect_arm_data`
before the per-arm loop.  Uses a local `BatchTrial` import to avoid
circular imports, with an `isinstance` guard so single-arm `Trial`
(which has no `abandoned_arms` attribute) is handled correctly.

`_relativize_arm_data` is NOT affected -- it iterates `arm_data.items()`,
not `trial.arms`, so it naturally only sees non-abandoned arms.

Meta: Discovered via production PTS experiment `ifu_rbvm_session_proxy_pts`
where trial 7 had an abandoned arm (2_8) causing its
`ExpressionDerivedMetric` to fail while trial 0 (no abandoned arms)
succeeded.

Differential Revision: D96950664


