### PR TITLE
Sanitize parentheses in metric names to fix SympifyError

### DIFF
--- a/ax/utils/common/string_utils.py
+++ b/ax/utils/common/string_utils.py
@@ -17,6 +17,8 @@ PIPE_PLACEHOLDER = "__pipe__"
 TILDE_PLACEHOLDER = "__tilde__"
 SPACE_PLACEHOLDER = "__space__"
 HYPHEN_PLACEHOLDER = "__hyphen__"
+LPAREN_PLACEHOLDER = "__lparen__"
+RPAREN_PLACEHOLDER = "__rparen__"
 _forbidden_re: re.Pattern[str] = re.compile(r"[\;\[\'\\]")
 
 SYMPY_GLOBALS: set[str] = set(dir(sympy))
@@ -48,7 +50,7 @@ def _check_sympy_conflicts(expression: str) -> None:
         )
 
 
-def sanitize_name(s: str) -> str:
+def sanitize_name(s: str, sanitize_parens: bool = False) -> str:
     """
     Converts a string with normal dots and slashes to a string with sanitized dots and
     slashes. This is temporarily necessary because SymPy symbol names must be valid
@@ -62,6 +64,21 @@ def sanitize_name(s: str) -> str:
 
     This does not allow obvious attack vectors  `;`, `[`, backslashes, and quotations.
     Colons, dots, slashes, and tildes are sanitized.
+
+    Args:
+        s: The string to sanitize.
+        sanitize_parens: If True, also sanitize parentheses that appear to be
+            part of metric/parameter names (e.g. ``"metric_(p50)"`` becomes
+            ``"metric___lparen__p50__rparen__"``). The regex matches
+            ``identifier(alphanumeric_content)`` — any ``(...)`` preceded by
+            an identifier whose content is purely ``[a-zA-Z0-9_]``. This
+            means single-argument SymPy calls like ``log(x)`` are also
+            sanitized, which is fine because this flag is only enabled in
+            objective/constraint parsing where SymPy function calls are
+            not valid expressions. Mathematical grouping like ``"(a + b)"``
+            (no preceding identifier) is never affected.
+            Defaults to False so that ``ExpressionDerivedMetric``, which
+            relies on genuine SymPy function calls, is unaffected.
     """
     if _forbidden_re.search(s) is not None:
         raise ValueError(f"Expression {s} has forbidden control characters.")
@@ -110,10 +127,24 @@ def sanitize_name(s: str) -> str:
         rf"\1{HYPHEN_PLACEHOLDER}",
         sans_tilde,
     )
-    # Check for conflicts with sympy's global dictionary
-    _check_sympy_conflicts(sans_hyphen)
+    result = sans_hyphen
 
-    return sans_hyphen
+    # Optionally sanitize parentheses that are part of metric/parameter names.
+    # Matches ``identifier(content)`` where content is purely [a-zA-Z0-9_].
+    # This intentionally also matches single-argument SymPy calls like
+    # ``log(x)``; callers that need SymPy function calls (e.g.
+    # ExpressionDerivedMetric) should leave sanitize_parens=False.
+    if sanitize_parens:
+        result = re.sub(
+            r"([a-zA-Z_][a-zA-Z0-9_]*)\(([a-zA-Z0-9_]+)\)",
+            rf"\1{LPAREN_PLACEHOLDER}\2{RPAREN_PLACEHOLDER}",
+            result,
+        )
+
+    # Check for conflicts with sympy's global dictionary
+    _check_sympy_conflicts(result)
+
+    return result
 
 
 def unsanitize_name(s: str) -> str:
@@ -125,7 +156,9 @@ def unsanitize_name(s: str) -> str:
     """
 
     # Unsanitize in the reverse order of sanitization
-    with_hyphen = re.sub(rf"{HYPHEN_PLACEHOLDER}", "-", s)
+    with_rparen = re.sub(rf"{RPAREN_PLACEHOLDER}", ")", s)
+    with_lparen = re.sub(rf"{LPAREN_PLACEHOLDER}", "(", with_rparen)
+    with_hyphen = re.sub(rf"{HYPHEN_PLACEHOLDER}", "-", with_lparen)
     with_tilde = re.sub(rf"{TILDE_PLACEHOLDER}", "~", with_hyphen)
     with_pipe = re.sub(rf"{PIPE_PLACEHOLDER}", "|", with_tilde)
     with_colon = re.sub(rf"{COLON_PLACEHOLDER}", ":", with_pipe)

--- a/ax/utils/common/sympy.py
+++ b/ax/utils/common/sympy.py
@@ -25,7 +25,7 @@ def extract_coefficient_dict_from_inequality(
     """
     # Parse the constraint string into a SymPy inequality
     try:
-        inequality = sympify(sanitize_name(inequality_str))
+        inequality = sympify(sanitize_name(inequality_str, sanitize_parens=True))
     except SympifyError:
         raise UserInputError(f"Expected an inequality, found {inequality_str}")
 
@@ -64,7 +64,7 @@ def parse_objective_expression(expression_str: str) -> Expr | tuple[Expr, ...]:
     if len(expression_str) == 0:
         raise UserInputError("Objective expression string must not be empty.")
 
-    sanitized = sanitize_name(expression_str)
+    sanitized = sanitize_name(expression_str, sanitize_parens=True)
     parsed = sympify(sanitized)
 
     if isinstance(parsed, tuple):

--- a/ax/utils/common/tests/test_string_utils.py
+++ b/ax/utils/common/tests/test_string_utils.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from ax.utils.common.string_utils import sanitize_name
+from ax.utils.common.string_utils import sanitize_name, unsanitize_name
 from ax.utils.common.testutils import TestCase
 
 
@@ -63,8 +63,68 @@ class StringUtilsTest(TestCase):
         # Test that E in scientific notation is not flagged (it's not an identifier)
         self.assertEqual(sanitize_name("1E5 + 2.3E-4"), "1E5 + 2.3E-4")
 
-        # Test that parens and equals are preserved (not sanitized).
+        # Test that parens and equals are preserved (not sanitized) by default.
         self.assertEqual(
             sanitize_name("sin(1) + cos(2)"),
             "sin(1) + cos(2)",
         )
+
+    def test_sanitize_parens(self) -> None:
+        """Test that sanitize_parens=True sanitizes parens in metric names."""
+        # Parenthesized suffix with purely identifier content is sanitized.
+        self.assertEqual(
+            sanitize_name("metric_(p50)", sanitize_parens=True),
+            "metric___lparen__p50__rparen__",
+        )
+        self.assertEqual(
+            sanitize_name("score(0_2_5)", sanitize_parens=True),
+            "score__lparen__0_2_5__rparen__",
+        )
+        # Metric name with colons AND parentheses.
+        self.assertEqual(
+            sanitize_name(
+                "scope:sub:metric_(p99)",
+                sanitize_parens=True,
+            ),
+            "scope__colon__sub__colon__metric___lparen__p99__rparen__",
+        )
+        # Mathematical grouping is NOT sanitized (no preceding identifier).
+        self.assertEqual(
+            sanitize_name("(a + b) * c", sanitize_parens=True),
+            "(a + b) * c",
+        )
+        # Parens with operator content inside are NOT sanitized.
+        self.assertEqual(
+            sanitize_name("sin(x + y)", sanitize_parens=True),
+            "sin(x + y)",
+        )
+        # sanitize_parens=False (default) does NOT sanitize parens.
+        self.assertEqual(
+            sanitize_name("metric_(p50)"),
+            "metric_(p50)",
+        )
+
+    def test_unsanitize_name_roundtrip(self) -> None:
+        """Test that unsanitize_name reverses sanitize_name including parens."""
+        names = [
+            "foo.bar.baz",
+            "foo.bar/11:Baz|qux",
+            "~treatment_percent_",
+            "metric-name",
+        ]
+        for name in names:
+            with self.subTest(name=name):
+                self.assertEqual(unsanitize_name(sanitize_name(name)), name)
+
+        # Round-trip with sanitize_parens=True
+        paren_names = [
+            "score(0_2_5)",
+            "metric_(p50)",
+            "scope:sub:metric_(p99)",
+        ]
+        for name in paren_names:
+            with self.subTest(name=name):
+                self.assertEqual(
+                    unsanitize_name(sanitize_name(name, sanitize_parens=True)),
+                    name,
+                )


### PR DESCRIPTION
Summary:
Add `LPAREN_PLACEHOLDER` / `RPAREN_PLACEHOLDER` to `sanitize_name()`,
gated behind a `sanitize_parens` flag (default `False`). When enabled,
the regex replaces `identifier(alphanumeric_content)` patterns while
leaving mathematical grouping `(a + b)` and SymPy function calls
`log(x)` untouched. Enable the flag in `parse_objective_expression()`
and `extract_coefficient_dict_from_inequality()`.
`ExpressionDerivedMetric` keeps the default `False`, preserving its use
of SymPy function calls like `log(a)`.

Meta: Reported in: https://fb.workplace.com/groups/ae.feedback/permalink/26712439635030699/. Metric names containing parentheses (e.g. `instagram:search_serp:ndcg:nDCG8_(0_2_5)`) cause a `SympifyError` when Ax constructs `Objective` or `OutcomeConstraint` objects, because SymPy interprets `nDCG8_(0_2_5)` as a function call with an invalid integer literal argument. This blocks candidate generation in the UI.

Differential Revision: D97007509


