### PR TITLE
Fix Winsorize transform for scalarized objectives

### DIFF
--- a/ax/adapter/transforms/tests/test_winsorize_transform.py
+++ b/ax/adapter/transforms/tests/test_winsorize_transform.py
@@ -347,7 +347,7 @@ class WinsorizeTransformTest(TestCase):
             experiment=experiment,
             data_loader_config=DataLoaderConfig(),
         )
-        # Scalarized objective
+        # Scalarized objective (deprecated class)
         for minimize in [True, False]:
             experiment.optimization_config = OptimizationConfig(
                 objective=ScalarizedObjective(
@@ -368,6 +368,28 @@ class WinsorizeTransformTest(TestCase):
                     transform.cutoffs,
                     {"m1": (-6.5, INF), "m2": (-INF, 10.0), "m3": (-INF, INF)},
                 )
+        # Scalarized objective (expression-based). "m1 - m2" is equivalent to
+        # ScalarizedObjective(metrics=[m1, m2], weights=[1, -1], minimize=False)
+        # since expressions are always maximized.
+        experiment.optimization_config = OptimizationConfig(
+            objective=Objective(expression="m1 - m2")
+        )
+        adapter = Adapter(experiment=experiment, generator=Generator())
+        transform = Winsorize(experiment_data=experiment_data, adapter=adapter)
+        self.assertEqual(
+            transform.cutoffs,
+            {"m1": (-6.5, INF), "m2": (-INF, 10.0), "m3": (-INF, INF)},
+        )
+        # Negated expression "-m1 + m2" is equivalent to minimize=True above.
+        experiment.optimization_config = OptimizationConfig(
+            objective=Objective(expression="-m1 + m2")
+        )
+        adapter = Adapter(experiment=experiment, generator=Generator())
+        transform = Winsorize(experiment_data=experiment_data, adapter=adapter)
+        self.assertEqual(
+            transform.cutoffs,
+            {"m1": (-INF, 13.5), "m2": (-6.0, INF), "m3": (-INF, INF)},
+        )
         # Simple single-objective problem
         m1 = Metric(name="m1", lower_is_better=False)
         m2 = Metric(name="m2", lower_is_better=True)

--- a/ax/adapter/transforms/winsorize.py
+++ b/ax/adapter/transforms/winsorize.py
@@ -18,7 +18,7 @@ from ax.adapter.transforms.base import Transform
 from ax.adapter.transforms.utils import (
     derelativize_optimization_config_with_raw_status_quo,
 )
-from ax.core.objective import ScalarizedObjective
+from ax.core.objective import ScalarizedObjective  # noqa: F401
 from ax.core.observation import ObservationData
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
@@ -243,23 +243,20 @@ def _get_cutoffs(
             metric_values=metric_values,
         )
 
-    # Make sure we winsorize from the correct direction if a `ScalarizedObjective`.
-    if isinstance(optimization_config.objective, ScalarizedObjective):
-        objective = assert_is_instance(
-            optimization_config.objective, ScalarizedObjective
-        )
-        weight = [w for m, w in objective.metric_weights if m == metric_signature][0]
-        # metric_weights are sign-encoded: a negative weight means minimize.
-        return _get_auto_winsorization_cutoffs_single_objective(
-            metric_values=metric_values,
-            minimize=weight < 0,
-        )
-
-    # Single-objective
+    # Single-objective (including scalarized).
     if not optimization_config.is_moo_problem:
+        objective = optimization_config.objective
+        if objective.is_scalarized_objective:
+            # metric_weights are sign-encoded: a negative weight means minimize.
+            weight = [w for m, w in objective.metric_weights if m == metric_signature][
+                0
+            ]
+            minimize = weight < 0
+        else:
+            minimize = objective.minimize
         return _get_auto_winsorization_cutoffs_single_objective(
             metric_values=metric_values,
-            minimize=optimization_config.objective.minimize,
+            minimize=minimize,
         )
 
     # Multi-objective

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -1896,6 +1896,48 @@ class TestClient(TestCase):
         self.assertIn("param_sum", summary_df.columns)
         self.assertEqual(len(summary_df), 3)
 
+    @mock_botorch_optimize
+    def test_scalarized_single_objective_optimization(self) -> None:
+        """Test that a scalarized single objective (e.g., "0.5*m1 + 0.5*m2")
+        works end-to-end including BoTorch generation."""
+        client = Client()
+        client.configure_experiment(
+            parameters=[
+                RangeParameterConfig(name="x", parameter_type="float", bounds=(-1, 1)),
+            ],
+        )
+        client.configure_optimization(objective="0.5*m1 + 0.5*m2")
+        client.configure_generation_strategy(initialization_budget=3)
+
+        # Verify the objective is set up correctly.
+        opt_config = none_throws(client._experiment.optimization_config)
+        objective = opt_config.objective
+        self.assertTrue(objective.is_scalarized_objective)
+        self.assertFalse(objective.is_multi_objective)
+        self.assertEqual(objective.metric_names, ["m1", "m2"])
+
+        # Run Sobol initialization trials.
+        for _ in range(3):
+            for index, parameters in client.get_next_trials(max_trials=1).items():
+                x = assert_is_instance(parameters["x"], float)
+                client.complete_trial(
+                    trial_index=index,
+                    raw_data={"m1": x**2, "m2": 1 - x**2},
+                )
+
+        # Generate a BoTorch trial (post-initialization).
+        for index, parameters in client.get_next_trials(max_trials=1).items():
+            x = assert_is_instance(parameters["x"], float)
+            client.complete_trial(
+                trial_index=index,
+                raw_data={"m1": x**2, "m2": 1 - x**2},
+            )
+
+        # Verify we can get the best parameterization.
+        best_params, prediction, _index, _name = client.get_best_parameterization()
+        self.assertIn("x", best_params)
+        self.assertEqual(set(prediction.keys()), {"m1", "m2"})
+
 
 class DummyRunner(IRunner):
     @override


### PR DESCRIPTION
Summary:
The Winsorize transform (`ax/adapter/transforms/winsorize.py`) called
`optimization_config.objective.minimize` for single-objective cases.
With the expression-based `Objective` refactor, `.minimize` raises
`UserInputError` for scalarized objectives (multi-metric expressions
like `"0.5*m1 + 0.5*m2"`).

The fix replaces the old `isinstance(obj, ScalarizedObjective)` check
(which only matched the deprecated subclass) with the expression-based
`objective.is_scalarized_objective` property, and derives minimize from
`metric_weights` sign for scalarized objectives.

Also adds an e2e Client API test that runs a scalarized single objective
through Sobol initialization and BoTorch generation, and unit tests for
the Winsorize transform with expression-based scalarized objectives.

Differential Revision: D97112353


