### PR TITLE
Fix metric_config_summary_df for scalarized objectives

### DIFF
--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -2215,13 +2215,23 @@ class Experiment(Base):
             if objective.is_multi_objective:
                 parts = [p.strip() for p in objective.expression.split(",")]
                 sub_objectives = [Objective(expression=part) for part in parts]
+                for sub_obj in sub_objectives:
+                    obj_name = sub_obj.metric_names[0]
+                    if obj_name in records:
+                        records[obj_name][METRIC_DF_COLNAMES["goal"]] = (
+                            "minimize" if sub_obj.minimize else "maximize"
+                        )
+            elif objective.is_scalarized_objective:
+                for metric_name, weight in objective.metric_weights:
+                    if metric_name in records:
+                        records[metric_name][METRIC_DF_COLNAMES["goal"]] = (
+                            "minimize" if weight < 0 else "maximize"
+                        )
             else:
-                sub_objectives = [objective]
-            for sub_obj in sub_objectives:
-                obj_name = sub_obj.metric_names[0]
+                obj_name = objective.metric_names[0]
                 if obj_name in records:
                     records[obj_name][METRIC_DF_COLNAMES["goal"]] = (
-                        "minimize" if sub_obj.minimize else "maximize"
+                        "minimize" if objective.minimize else "maximize"
                     )
 
             objective_threshold_names: set[str] = set()

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -1625,6 +1625,25 @@ class ExperimentTest(TestCase):
         )
         pd.testing.assert_frame_equal(df, expected_df)
 
+    def test_metric_summary_df_scalarized_objective(self) -> None:
+        experiment = Experiment(
+            name="test_experiment",
+            search_space=SearchSpace(parameters=[]),
+            optimization_config=OptimizationConfig(
+                objective=Objective(expression="2*metric_a + -3*metric_b"),
+            ),
+            tracking_metrics=[
+                Metric(name="metric_a", lower_is_better=False),
+                Metric(name="metric_b", lower_is_better=True),
+            ],
+        )
+        df = experiment.metric_config_summary_df
+        # metric_a has positive weight -> maximize
+        # metric_b has negative weight -> minimize
+        goal_by_name = dict(zip(df["Name"], df["Goal"]))
+        self.assertEqual(goal_by_name["metric_a"], "maximize")
+        self.assertEqual(goal_by_name["metric_b"], "minimize")
+
     def test_arms_by_signature_for_deduplication(self) -> None:
         experiment = self.experiment
         trial = experiment.new_trial()


### PR DESCRIPTION
Summary:
The `metric_config_summary_df` method in `Experiment` crashes when using
scalarized objectives because the `else` branch calls `sub_obj.minimize`,
which raises `UserInputError` for scalarized objectives.

Add an `elif objective.is_scalarized_objective:` branch that iterates
`objective.metric_weights` and sets per-metric goal using `weight < 0`.

Differential Revision: D97122953


