### PR TITLE
Fix SQAEncodeError when experiment_type_enum is None in transfer learning query

### DIFF
--- a/ax/storage/sqa_store/load.py
+++ b/ax/storage/sqa_store/load.py
@@ -766,6 +766,8 @@ def _query_historical_experiments_given_parameters(
                         encoder.get_enum_value(t, config.experiment_type_enum)
                         for t in experiment_types
                     ]
+                    if config.experiment_type_enum is not None
+                    else experiment_types
                 )
             )
             .filter(SQAExperiment.is_test == False)  # noqa E712 `is` won't work for SQA


### PR DESCRIPTION
Summary:
When `experiment_type_enum` is `None`, use raw string values directly 
for the SQL filter instead of encoding through a non-existent enum in the `_query_historical_experiments_given_parameters`  function.

Reviewed By: ItsMrLin

Differential Revision: D97020149


