### PR TITLE
Fix Pyre type errors from PSS 3 numpy stub changes (#5066)

### DIFF
--- a/ax/adapter/tests/test_cross_validation.py
+++ b/ax/adapter/tests/test_cross_validation.py
@@ -136,7 +136,7 @@ class CrossValidationTest(TestCase):
             self.assertEqual(len(set(train[i]).intersection(test[i])), 0)
             self.assertEqual(len(train[i]) + len(test[i]), 4)
         # Test all points used as test points
-        all_test = np.hstack(test)
+        all_test = np.hstack([np.asarray(t) for t in test])
         self.assertTrue(
             np.array_equal(sorted(all_test), np.array([2.0, 2.0, 3.0, 4.0]))
         )
@@ -162,7 +162,7 @@ class CrossValidationTest(TestCase):
             self.assertEqual(len(set(train[i]).intersection(test[i])), 0)
             self.assertEqual(len(train[i]) + len(test[i]), 4)
         # Test all points used as test points
-        all_test = np.hstack(test)
+        all_test = np.hstack([np.asarray(t) for t in test])
         self.assertTrue(
             np.array_equal(sorted(all_test), np.array([2.0, 2.0, 3.0, 4.0]))
         )
@@ -200,7 +200,7 @@ class CrossValidationTest(TestCase):
             self.assertEqual(len(set(train[i]).intersection(test[i])), 0)
             self.assertEqual(len(train[i]) + len(test[i]), 4)
         # Test all points used as test points -- these are transformed after call.
-        all_test = np.hstack(test)
+        all_test = np.hstack([np.asarray(t) for t in test])
         self.assertTrue(
             np.array_equal(sorted(all_test), np.array([0.2, 0.2, 0.3, 0.4]))
         )
@@ -248,7 +248,10 @@ class CrossValidationTest(TestCase):
         z = mock_cv.mock_calls
         self.assertEqual(len(z), 2)
         all_test = np.hstack(
-            [[obsf.parameters["x"] for obsf in r[2]["cv_test_points"]] for r in z]
+            [
+                np.asarray([obsf.parameters["x"] for obsf in r[2]["cv_test_points"]])
+                for r in z
+            ]
         )
         self.assertTrue(np.array_equal(sorted(all_test), np.array([2.0, 2.0, 3.0])))
 

--- a/ax/benchmark/benchmark.py
+++ b/ax/benchmark/benchmark.py
@@ -120,7 +120,7 @@ def compute_score_trace(
         optimal_value: The best possible value of the objective; when the
             optimization_trace equals the optimal_value, the score is 100.
     """
-    return (
+    return np.asarray(
         100 * (optimization_trace - baseline_value) / (optimal_value - baseline_value)
     )
 
@@ -481,7 +481,7 @@ def get_benchmark_result_from_experiment_and_gs(
         )
     else:
         trial_completion_order = [{i} for i in range(len(experiment.trials))]
-        cost_trace = 1.0 + np.arange(len(experiment.trials), dtype=float)
+        cost_trace = np.arange(len(experiment.trials), dtype=float) + 1.0
 
     num_trials = list(accumulate(len(trials) for trials in trial_completion_order))
 

--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -457,7 +457,7 @@ class BatchTrial(BaseTrial):
         weights = np.array(self.weights)
         if trunc_digits is not None:
             atomic_weight = 10**-trunc_digits
-            int_weights = (
+            int_weights = np.asarray(
                 (total / atomic_weight) * (weights / np.sum(weights))
             ).astype(int)
             n_leftover = int(total / atomic_weight) - np.sum(int_weights)

--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -768,7 +768,7 @@ def relativize_dataframe(
 def _ceil_divide(
     a: int | np.int_ | npt.NDArray[np.int_], b: int | np.int_ | npt.NDArray[np.int_]
 ) -> np.int_ | npt.NDArray[np.int_]:
-    return -np.floor_divide(-a, b)
+    return -np.floor_divide(np.negative(a), b)
 
 
 def _subsample_rate(

--- a/ax/core/evaluations_to_data.py
+++ b/ax/core/evaluations_to_data.py
@@ -38,10 +38,10 @@ def _validate_and_extract_single_metric_data(
             sem is None or isinstance(sem, FloatLike)
         ):
             raise UserInputError(error_message)
-        return mean, sem
+        return float(mean), float(sem) if sem is not None else None
     if not isinstance(dat, FloatLike):
         raise UserInputError(error_message)
-    return dat, None
+    return float(dat), None
 
 
 def raw_evaluations_to_data(

--- a/ax/core/types.py
+++ b/ax/core/types.py
@@ -12,6 +12,7 @@ from collections.abc import Callable, Mapping, Sequence
 from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 
 
 TNumeric = float | int
@@ -21,7 +22,7 @@ TParameterization = dict[str, TParamValue]
 TParamValueList = list[TParamValue]  # a parameterization without the keys
 TContextStratum = dict[str, str | float | int] | None
 
-TBounds = tuple[np.ndarray[Any, Any], np.ndarray[Any, Any]] | None
+TBounds = tuple[npt.NDArray, npt.NDArray] | None
 TModelMean = dict[str, list[float]]
 TModelCov = dict[str, dict[str, list[float]]]
 TModelPredict = tuple[TModelMean, TModelCov]

--- a/ax/generators/utils.py
+++ b/ax/generators/utils.py
@@ -24,7 +24,7 @@ from pyre_extensions import assert_is_instance
 from torch import Tensor
 
 
-Tensoray = Union[torch.Tensor, npt.NDArray]
+Tensoray = Union[torch.Tensor, np.ndarray]
 TTensoray = TypeVar("TTensoray", bound=Tensoray)
 
 

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -399,9 +399,9 @@ def compute_posterior_pareto_frontier(
     # Construct weightings with linear angular spacing.
     # TODO: Verify whether 0, 1 weights cause problems because of subset_model.
     alpha = np.linspace(0 + 0.01, np.pi / 2 - 0.01, num_points)
-    primary_weight = (-1 if primary_objective.lower_is_better else 1) * np.cos(alpha)
-    secondary_weight = (-1 if secondary_objective.lower_is_better else 1) * np.sin(
-        alpha
+    primary_weight = np.cos(alpha) * (-1 if primary_objective.lower_is_better else 1)
+    secondary_weight = np.sin(alpha) * (
+        -1 if secondary_objective.lower_is_better else 1
     )
     weights_list = np.stack([primary_weight, secondary_weight]).transpose()
     for weights in weights_list:


### PR DESCRIPTION
Summary:

D97086630 upgraded ax to Python Scientific Stack 3, which ships updated numpy
type stubs. This broke `ax/core:core-type-checking` with 5 Pyre errors:

- `types.py`: `np.ndarray` is no longer generic in the new stubs; use `npt.NDArray`.
- `batch_trial.py`: Pyre resolves `float * ndarray` as `float`, which lacks `.astype()`; wrap in `np.array()`.
- `data.py`: Unary `-` on a union type is not supported; use `np.negative()`.
- `evaluations_to_data.py`: numpy scalar types (`np.floating`, `np.integer`) don't narrow to `float`; add explicit `float()` casts.

Reviewed By: bernardbeckerman, Cesar-Cardoso

Differential Revision: D97164515


