### PR TITLE
Fix pandas FutureWarning in Data.deduplicate for groupby operations (#5069)

### DIFF
--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -357,7 +357,7 @@ class Data(Base, SerializationMixin):
             # In the case where all MAP_KEY values are NaN for a group we return an
             # arbitrary row from that group.
             .fillna(
-                self.full_df.groupby(self.DEDUPLICATE_BY_COLUMNS).apply(
+                self.full_df.groupby(self.DEDUPLICATE_BY_COLUMNS)[MAP_KEY].apply(
                     lambda group: group.index[0]
                 )
             )


### PR DESCRIPTION
Summary:

Fixes a pandas FutureWarning that appears when using `DataFrameGroupBy.apply` on grouping columns by changing to `SeriesGroupBy.apply`. The fix adds `[MAP_KEY]` selector before `.apply()` at line 360 in `ax/core/data.py`, which operates on the series rather than the entire grouped DataFrame. This eliminates the deprecation warning on pandas >= 2.1 while maintaining backward compatibility with older pandas versions.

--
Reviewed + modified AI generated Summary & Test Plan from DEV115723120

Reviewed By: saitcakmak

Differential Revision: D97020436
