### PR TITLE
Add @ sanitization to string_utils for sympy compatibility

### DIFF
--- a/ax/utils/common/string_utils.py
+++ b/ax/utils/common/string_utils.py
@@ -17,6 +17,7 @@ PIPE_PLACEHOLDER = "__pipe__"
 TILDE_PLACEHOLDER = "__tilde__"
 SPACE_PLACEHOLDER = "__space__"
 HYPHEN_PLACEHOLDER = "__hyphen__"
+AT_PLACEHOLDER = "__at__"
 LPAREN_PLACEHOLDER = "__lparen__"
 RPAREN_PLACEHOLDER = "__rparen__"
 _forbidden_re: re.Pattern[str] = re.compile(r"[\;\[\'\\]")
@@ -127,7 +128,16 @@ def sanitize_name(s: str, sanitize_parens: bool = False) -> str:
         rf"\1{HYPHEN_PLACEHOLDER}",
         sans_tilde,
     )
-    result = sans_hyphen
+    # Replace "@" when it appears between identifier characters
+    # (e.g. "metric@region" in metric names). In Python, @ is the matrix
+    # multiplication operator (PEP 465), so SymPy's sympify() will
+    # misinterpret it and raise a TypeError.
+    sans_at = re.sub(
+        r"([a-zA-Z_][a-zA-Z0-9_]*)@(?=[a-zA-Z0-9_])",
+        rf"\1{AT_PLACEHOLDER}",
+        sans_hyphen,
+    )
+    result = sans_at
 
     # Optionally sanitize parentheses that are part of metric/parameter names.
     # Matches ``identifier(content)`` where content is purely [a-zA-Z0-9_].
@@ -158,7 +168,8 @@ def unsanitize_name(s: str) -> str:
     # Unsanitize in the reverse order of sanitization
     with_rparen = re.sub(rf"{RPAREN_PLACEHOLDER}", ")", s)
     with_lparen = re.sub(rf"{LPAREN_PLACEHOLDER}", "(", with_rparen)
-    with_hyphen = re.sub(rf"{HYPHEN_PLACEHOLDER}", "-", with_lparen)
+    with_at = re.sub(rf"{AT_PLACEHOLDER}", "@", with_lparen)
+    with_hyphen = re.sub(rf"{HYPHEN_PLACEHOLDER}", "-", with_at)
     with_tilde = re.sub(rf"{TILDE_PLACEHOLDER}", "~", with_hyphen)
     with_pipe = re.sub(rf"{PIPE_PLACEHOLDER}", "|", with_tilde)
     with_colon = re.sub(rf"{COLON_PLACEHOLDER}", ":", with_pipe)

--- a/ax/utils/common/tests/test_string_utils.py
+++ b/ax/utils/common/tests/test_string_utils.py
@@ -104,6 +104,17 @@ class StringUtilsTest(TestCase):
             "metric_(p50)",
         )
 
+    def test_sanitize_at_sign(self) -> None:
+        """Test that @ in metric names is sanitized to avoid sympy misparse."""
+        self.assertEqual(
+            sanitize_name("metric@region"),
+            "metric__at__region",
+        )
+        self.assertEqual(
+            sanitize_name("scope:sub:metric@region"),
+            "scope__colon__sub__colon__metric__at__region",
+        )
+
     def test_unsanitize_name_roundtrip(self) -> None:
         """Test that unsanitize_name reverses sanitize_name including parens."""
         names = [
@@ -111,6 +122,8 @@ class StringUtilsTest(TestCase):
             "foo.bar/11:Baz|qux",
             "~treatment_percent_",
             "metric-name",
+            "metric@region",
+            "scope:sub:metric@region",
         ]
         for name in names:
             with self.subTest(name=name):


### PR DESCRIPTION
Summary:
The recent migration of ScalarizedObjective to expression-based
Objective.__init__() introduced sympy parsing of metric names. Metric
names containing @ (e.g. metric@USCA) cause sympify() to interpret @
as Python's matrix multiplication operator (PEP 465), raising:

  TypeError: unsupported operand type(s) for @: 'Mul' and 'Symbol'

Add @ -> __at__ sanitization to sanitize_name() and the corresponding
reverse in unsanitize_name(), following the same pattern already used
for `:, ., /, |, ~, -, ()`.

Reviewed By: saitcakmak, Balandat

Differential Revision: D97242521


