### PR TITLE
Fix Orchestrator.__repr__ crash on partially-initialized instances

### DIFF
--- a/ax/orchestration/orchestrator.py
+++ b/ax/orchestration/orchestrator.py
@@ -501,7 +501,7 @@ class Orchestrator(WithDBSettingsBase, BestPointMixin):
 
     def __repr__(self) -> str:
         """Short user-friendly string representation."""
-        if not hasattr(self, "experiment"):
+        if not hasattr(self, "experiment") or not hasattr(self, "generation_strategy"):
             # Experiment, generation strategy, etc. attributes have not
             # yet been set.
             return f"{self.__class__.__name__}"


### PR DESCRIPTION
Summary:
Fix `AttributeError` in `Orchestrator.__repr__()` when the object is only
partially initialized. The method checked `hasattr(self, "experiment")` but
did not check `hasattr(self, "generation_strategy")`, causing a crash when
`__repr__` was called between the two attribute assignments.

**Bug details:**

`Orchestrator.__init__` sets attributes in this order:
```
self.experiment = experiment           # line 228
self._set_logger(options=options)      # line 231
self.options = options                 # line 232
self.generation_strategy = generation_strategy  # line 235
```

If any error occurs between lines 228-235 (e.g. in `_set_logger`), then
`self.experiment` exists but `self.generation_strategy` does not.

The `log_usage()` decorator on `OrcOpticsScheduler.__init__` catches such
errors and calls `repr(args)` to log them. Since `args[0]` is the partially-
initialized scheduler instance, this triggers `Orchestrator.__repr__()`:

```python
def __repr__(self) -> str:
    if not hasattr(self, "experiment"):       # True -- experiment IS set
        return f"{self.__class__.__name__}"
    return (
        f"...generation_strategy={self.generation_strategy}..."  # BOOM
    )
```

The secondary `AttributeError` replaces the original error, making the real
failure impossible to diagnose.

**Example:** FBLearner run f1051747930 failed with:
```
AttributeError: 'OrcOpticsScheduler' object has no attribute 'generation_strategy'
```
Stack trace: `OrcOpticsScheduler.__init__` -> `Orchestrator.__init__` ->
(error between lines 228-235) -> `log_usage` error handler ->
`repr(args)` -> `Orchestrator.__repr__` -> `self.generation_strategy` crash.

The actual root cause was completely masked by this `__repr__` bug.

**Fix:** Add `hasattr(self, "generation_strategy")` guard alongside the
existing `hasattr(self, "experiment")` check.

Differential Revision: D97166104


