### PR TITLE
Raise UnsupportedError in get_optimization_trace for scalarized objectives/constraints

### DIFF
--- a/ax/service/ax_client.py
+++ b/ax/service/ax_client.py
@@ -1046,13 +1046,29 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
                 "for multi-objective experiments"
             )
 
+        if objective.is_scalarized_objective:
+            raise UnsupportedError(
+                "`get_optimization_trace` is not supported for scalarized "
+                "objectives. `trial.objective_mean` returns the value of "
+                "the first metric, not the weighted combination."
+            )
+
+        opt_config = none_throws(self.experiment.optimization_config)
+        if any(len(oc.metric_names) > 1 for oc in opt_config.outcome_constraints):
+            raise UnsupportedError(
+                "`get_optimization_trace` is not supported for scalarized "
+                "outcome constraints."
+            )
+
+        minimize: bool = objective.minimize
+
         # Setting the objective values of infeasible points to be infinitely
         # bad prevents them from increasing or decreasing the
         # optimization trace.
         def _constrained_trial_objective_mean(trial: BaseTrial) -> float:
             if constraint_satisfaction(trial):
                 return assert_is_instance(trial, Trial).objective_mean
-            return float("inf") if self.objective.minimize else float("-inf")
+            return float("inf") if minimize else float("-inf")
 
         objective_name = self.objective_name
         best_objectives = np.array(
@@ -1072,7 +1088,7 @@ class AxClient(AnalysisBase, BestPointMixin, InstantiationBase):
         return optimization_trace_single_method(
             y=(
                 np.minimum.accumulate(best_objectives, axis=1)
-                if objective.minimize
+                if minimize
                 else np.maximum.accumulate(best_objectives, axis=1)
             ),
             optimum=objective_optimum,

--- a/ax/service/tests/test_ax_client.py
+++ b/ax/service/tests/test_ax_client.py
@@ -26,8 +26,11 @@ from ax.core.data import Data, MAP_KEY
 from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
 from ax.core.multi_type_experiment import MultiTypeExperiment
-from ax.core.objective import MultiObjective
-from ax.core.optimization_config import MultiObjectiveOptimizationConfig
+from ax.core.objective import MultiObjective, Objective
+from ax.core.optimization_config import (
+    MultiObjectiveOptimizationConfig,
+    OptimizationConfig,
+)
 from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
 from ax.core.parameter import (
     ChoiceParameter,
@@ -3224,6 +3227,35 @@ class TestAxClient(TestCase):
         ) as mock_plot:
             ax_client.get_optimization_trace()
         mock_plot.assert_called_once()
+
+    def test_get_optimization_trace_scalarized(self) -> None:
+        """get_optimization_trace raises UnsupportedError for scalarized."""
+        ax_client = get_branin_optimization()
+        params, idx = ax_client.get_next_trial()
+        ax_client.complete_trial(trial_index=idx, raw_data={"branin": (1.0, 0.0)})
+        ax_client.experiment.add_tracking_metric(Metric(name="other_metric"))
+        ax_client.experiment._optimization_config = OptimizationConfig(
+            objective=Objective(expression="2*branin + -1*other_metric"),
+        )
+        with self.assertRaisesRegex(UnsupportedError, "not supported for scalarized"):
+            ax_client.get_optimization_trace()
+
+    def test_get_optimization_trace_scalarized_outcome_constraint(self) -> None:
+        """get_optimization_trace raises UnsupportedError for scalarized
+        outcome constraints."""
+        ax_client = get_branin_optimization()
+        params, idx = ax_client.get_next_trial()
+        ax_client.complete_trial(trial_index=idx, raw_data={"branin": (1.0, 0.0)})
+        ax_client.experiment.add_tracking_metric(Metric(name="m1"))
+        ax_client.experiment.add_tracking_metric(Metric(name="m2"))
+        ax_client.experiment._optimization_config = OptimizationConfig(
+            objective=Objective(metric=Metric(name="branin"), minimize=True),
+            outcome_constraints=[
+                OutcomeConstraint(expression="2*m1 + 3*m2 <= 10"),
+            ],
+        )
+        with self.assertRaisesRegex(UnsupportedError, "not supported for scalarized"):
+            ax_client.get_optimization_trace()
 
 
 # Utility functions for testing get_model_predictions without calling


### PR DESCRIPTION
Summary:
`get_optimization_trace` uses `trial.objective_mean` which calls
`metric_names[0]` — returning only the first metric's value instead of
the weighted combination for scalarized objectives. It also calls
`objective.minimize`, which raises for scalarized objectives. The
Y-axis label from `self.objective_name` would also be wrong (showing
just the first metric name instead of the expression).

Similarly, `constraint_satisfaction` uses `constraint.metric_names[0]`,
which is wrong for scalarized outcome constraints.

Raise `UnsupportedError` early for both scalarized objectives and
scalarized outcome constraints rather than silently producing incorrect
trace data. Also moved local imports to top-of-file per project
conventions.

Reviewed By: dme65

Differential Revision: D97123271


