### PR TITLE
Make TL eligibility health-check more actionable

### DIFF
--- a/ax/analysis/healthcheck/transfer_learning_analysis.py
+++ b/ax/analysis/healthcheck/transfer_learning_analysis.py
@@ -175,7 +175,9 @@ class TransferLearningAnalysis(Analysis):
             "Using data from unrelated experiments can lead to negative "
             "transfer, which may hurt "
             "optimization performance. Review the overlapping parameters "
-            "before enabling transfer learning."
+            "before enabling transfer learning. If using the UI, 'Learn from "
+            "Related Experiments' button is likely available for use; "
+            "otherwise, use `Client.add_transferable_experiment`."
         )
 
         return TransferLearningAnalysisCard(


### PR DESCRIPTION
Summary:
I was very excited to see this warning in the UI: 

{F1987030629} 

But it also seemed insufficiently actionable for either users or agents. I think a vague mention of the UI is ok even though this is going into OSS; what do folks think?

NOTE: Also a thought: should we be saying "Transfer Learning Eligibilty" or "Meta-Learning Eligibility"?

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: mgarrard

Differential Revision: D97489418


