### PR TITLE
Reorder TL eligibility message: action before caution

### DIFF
--- a/ax/analysis/healthcheck/transfer_learning_analysis.py
+++ b/ax/analysis/healthcheck/transfer_learning_analysis.py
@@ -170,14 +170,14 @@ class TransferLearningAnalysis(Analysis):
             f"**{n} eligible source experiment(s)** "
             "for transfer learning:\n\n"
             f"{exp_lines}\n\n"
-            "Caution: Only use source experiments that are closely related "
-            "to your current experiment. "
-            "Using data from unrelated experiments can lead to negative "
-            "transfer, which may hurt "
-            "optimization performance. Review the overlapping parameters "
-            "before enabling transfer learning. If using the UI, 'Learn from "
+            "If using the UI, 'Learn from "
             "Related Experiments' button is likely available for use; "
-            "otherwise, use `Client.add_transferable_experiment`."
+            "otherwise, use `Client.add_transferable_experiment`.\n\n"
+            "Caution: Only use source experiments that are closely related "
+            "to your current experiment. Using data from unrelated experiments "
+            "can lead to negative transfer, which may hurt optimization "
+            "performance. Review the overlapping parameters before enabling "
+            "transfer learning."
         )
 
         return TransferLearningAnalysisCard(

--- a/ax/generation_strategy/generation_node.py
+++ b/ax/generation_strategy/generation_node.py
@@ -496,16 +496,6 @@ class GenerationNode(SerializationMixin, SortableBase):
             logger.debug(f"Skipping generation for node {self.name}.")
             return None
 
-        # TODO[drfreund]: Move this to `Adapter` or another more suitable place.
-        # Keeping here for now to limit the scope of the current changeset.
-        generator_gen_kwargs["fixed_features"] = (
-            experiment.search_space.get_disabled_parameter_fixed_features(
-                fixed_features_to_overlay_on=generator_gen_kwargs.get(
-                    "fixed_features", None
-                )
-            )
-        )
-
         # Step 2: Fit this node's underlying adapter and generator.
         if not skip_fit:
             self._fit(experiment=experiment, data=data)

--- a/ax/generation_strategy/tests/test_generation_node.py
+++ b/ax/generation_strategy/tests/test_generation_node.py
@@ -423,56 +423,6 @@ class TestGenerationNode(TestCase):
             ObservationFeatures(parameters={"x": 0}),
         )
 
-    def test_disabled_parameters(self) -> None:
-        """Test that disabled parameters are correctly passed as fixed_features
-        to _gen.
-        """
-        # First, test with no disabled parameters - fixed_features should be None
-        with patch.object(GenerationNode, "_gen", autospec=True) as mock_gen:
-            mock_gen.return_value = MagicMock()
-            mock_gen.return_value._generation_node_name = None
-            mock_gs = MagicMock()
-            mock_gs.experiment = self.branin_experiment
-            self.sobol_generation_node._generation_strategy = mock_gs
-            self.sobol_generation_node.gen(
-                experiment=self.branin_experiment,
-                pending_observations={},
-            )
-            # With no disabled parameters, fixed_features should not be in kwargs
-            # or should be None
-            call_kwargs = mock_gen.call_args.kwargs
-            self.assertIsNone(call_kwargs.get("fixed_features"))
-
-        # Disable parameter and test again
-        self.branin_experiment.disable_parameters_in_search_space({"x1": 1.2345})
-        with patch.object(GenerationNode, "_gen", autospec=True) as mock_gen:
-            mock_gen.return_value = MagicMock()
-            mock_gen.return_value._generation_node_name = None
-            self.sobol_generation_node.gen(
-                experiment=self.branin_experiment,
-                pending_observations={},
-            )
-            call_kwargs = mock_gen.call_args.kwargs
-            expected_fixed_features = ObservationFeatures(parameters={"x1": 1.2345})
-            self.assertEqual(call_kwargs.get("fixed_features"), expected_fixed_features)
-
-        # Test fixed features override - passed fixed_features should take precedence
-        with patch.object(GenerationNode, "_gen", autospec=True) as mock_gen:
-            mock_gen.return_value = MagicMock()
-            mock_gen.return_value._generation_node_name = None
-            self.sobol_generation_node.gen(
-                experiment=self.branin_experiment,
-                pending_observations={},
-                fixed_features=ObservationFeatures(parameters={"x1": 0.0, "x2": 0.0}),
-            )
-            call_kwargs = mock_gen.call_args.kwargs
-            # The passed fixed feature overrides the disabled parameter default value
-            expected_fixed_features = ObservationFeatures(
-                parameters={"x1": 0.0, "x2": 0.0}
-            )
-            self.assertEqual(call_kwargs.get("fixed_features"), expected_fixed_features)
-
-
 class TestGenerationStep(TestCase):
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
Summary:
Apply self-review suggestion from D97489418: move the actionable
instructions (UI button / `Client.add_transferable_experiment`) before
the caution text so users see what to do first, then the warning.

Differential Revision: D97553476


