### PR TITLE
Update MetricFetchingErrors healthcheck: FAIL/WARNING by metric type + remediation (#5088)

### DIFF
--- a/ax/analysis/healthcheck/metric_fetching_errors.py
+++ b/ax/analysis/healthcheck/metric_fetching_errors.py
@@ -121,12 +121,37 @@ class MetricFetchingErrorsAnalysis(Analysis):
         }
         subtitle = df.rename(columns=subtitle_df_columns)
 
+        # Determine status: WARNING at least, if any metric has errors.
+        # Escalate to FAIL if any metric on the optimization config has errors.
+        status = HealthcheckStatus.WARNING
+        if (opt_config := experiment.optimization_config) is not None:
+            errored_metric_names: set[str] = {
+                e["metric_name"] for e in metric_fetch_errors_for_card
+            }
+            critical_metric_names = set(opt_config.metric_names)
+            has_critical_errors = bool(errored_metric_names & critical_metric_names)
+            if has_critical_errors:
+                status = HealthcheckStatus.FAIL
+
+        remediation = (
+            "\n\n**What to do:**\n"
+            "1. **Check if errors are transient:** Metric fetch errors are "
+            "automatically retried on subsequent data-fetching calls and "
+            "cleared on success. If errors persist, they may require "
+            "investigation.\n"
+            "2. **Review the error messages:** The error messages and "
+            "tracebacks above can help identify the root cause.\n"
+            "3. **Contact the metric owner:** If errors persist, reach out "
+            "to the owner of the affected metric(s) to investigate the "
+            "underlying issue."
+        )
+
         return create_healthcheck_analysis_card(
             name=self.__class__.__name__,
             title="Metric Fetch Errors",
-            subtitle=subtitle.to_markdown(index=False),
+            subtitle=subtitle.to_markdown(index=False) + remediation,
             df=df,
-            status=HealthcheckStatus.WARNING,
+            status=status,
         )
 
     @staticmethod

--- a/ax/analysis/healthcheck/tests/test_metric_fetching_errors.py
+++ b/ax/analysis/healthcheck/tests/test_metric_fetching_errors.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import pandas as pd
+from ax.analysis.healthcheck.healthcheck_analysis import HealthcheckStatus
 from ax.analysis.healthcheck.metric_fetching_errors import MetricFetchingErrorsAnalysis
 from ax.core.base_trial import BaseTrial
 from ax.core.data import Data
@@ -168,6 +169,8 @@ class TestMetricFetchingErrors(TestCase):
             card.df["timestamp"].iloc[0],
             (datetime.now() - timedelta(minutes=1)).isoformat(),
         )
+        # Tracking metric errors should produce WARNING, not FAIL
+        self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
 
     def test_metric_fetching_errors_without_traceback(self) -> None:
         # GIVEN an experiment with a test metric and running trial
@@ -221,6 +224,8 @@ class TestMetricFetchingErrors(TestCase):
             card.df["timestamp"].iloc[0],
             (datetime.now() - timedelta(minutes=1)).isoformat(),
         )
+        # Tracking metric errors should produce WARNING, not FAIL
+        self.assertEqual(card.get_status(), HealthcheckStatus.WARNING)
 
     def test_error_order(self) -> None:
         # GIVEN an experiment with a test metric and running trial
@@ -294,3 +299,45 @@ class TestMetricFetchingErrors(TestCase):
         orchestrator.poll_and_process_results()
 
         self.assertEqual(len(exp._metric_fetching_errors), 0)
+
+    def _make_metric_fetching_error(
+        self, trial_index: int, metric_name: str
+    ) -> dict[str, Any]:
+        return {
+            "trial_index": trial_index,
+            "metric_name": metric_name,
+            "reason": f"Simulated {metric_name} fetch failure",
+            "timestamp": datetime.now().isoformat(),
+            "traceback": "",
+        }
+
+    def test_critical_metric_errors_returns_fail(self) -> None:
+        cases: list[dict[str, Any]] = [
+            {
+                "label": "objective_metric",
+                "exp_kwargs": {"with_batch": True},
+                "error_metrics": ["branin"],
+            },
+            {
+                "label": "constraint_metric",
+                "exp_kwargs": {
+                    "with_batch": True,
+                    "with_absolute_constraint": True,
+                },
+                "error_metrics": ["branin_e"],
+            },
+            {
+                "label": "mixed_objective_and_tracking",
+                "exp_kwargs": {"with_batch": True},
+                "error_metrics": ["branin", "tracking_metric"],
+            },
+        ]
+        for case in cases:
+            with self.subTest(case=case["label"]):
+                exp = get_branin_experiment(**case["exp_kwargs"])
+                for metric_name in case["error_metrics"]:
+                    exp._metric_fetching_errors[(0, metric_name)] = (
+                        self._make_metric_fetching_error(0, metric_name)
+                    )
+                card = MetricFetchingErrorsAnalysis().compute(experiment=exp)
+                self.assertEqual(card.get_status(), HealthcheckStatus.FAIL)

--- a/ax/analysis/plotly/tests/test_marginal_effects.py
+++ b/ax/analysis/plotly/tests/test_marginal_effects.py
@@ -11,13 +11,15 @@ from ax.analysis.plotly.marginal_effects import (
     compute_marginal_effects_adhoc,
     MarginalEffectsPlot,
 )
+from ax.core.arm import Arm
 from ax.core.data import Data
 from ax.core.experiment import Experiment
+from ax.core.generator_run import GeneratorRun
 from ax.core.metric import Metric
 from ax.core.objective import Objective
 from ax.core.optimization_config import OptimizationConfig
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_discrete_search_space, get_sobol
+from ax.utils.testing.core_stubs import get_discrete_search_space
 from pyre_extensions import none_throws
 
 
@@ -35,8 +37,18 @@ class TestMarginalEffectsPlot(TestCase):
         )
         num_arms = 3
         num_trials = 3
-        sobol = get_sobol(search_space=self.experiment.search_space)
-        gr = sobol.gen(n=num_arms)
+        # Use explicit arms instead of a Sobol generator to guarantee each
+        # level of the ChoiceParameter "z" is represented. Sobol can map
+        # quasi-random points to the same discrete level depending on the
+        # environment (observed on Python 3.14 CI), which causes
+        # marginal_effects to skip covariates with <= 1 unique value.
+        gr = GeneratorRun(
+            arms=[
+                Arm(parameters={"x": 0, "y": 5, "z": "red"}, name="0_0"),
+                Arm(parameters={"x": 1, "y": 6, "z": "panda"}, name="0_1"),
+                Arm(parameters={"x": 2, "y": 7, "z": "bear"}, name="0_2"),
+            ]
+        )
 
         for i in range(num_trials):
             self.experiment.new_batch_trial(generator_run=gr)

--- a/ax/utils/stats/statstools.py
+++ b/ax/utils/stats/statstools.py
@@ -216,4 +216,4 @@ def marginal_effects(
             formatted_vals.append(
                 {"Name": cov, "Level": name, "Beta": effect, "SE": effect_sem}
             )
-    return pd.DataFrame(formatted_vals)[["Name", "Level", "Beta", "SE"]]
+    return pd.DataFrame(formatted_vals, columns=["Name", "Level", "Beta", "SE"])


### PR DESCRIPTION
Summary:

Two improvements to MetricFetchingErrors:

1. Status now depends on which metrics have errors:
   - FAIL if any objective or constraint metric has fetch errors (serious).
   - WARNING if only tracking metrics are affected (non-blocking).

2. Add remediation guidance after the error table.

Reviewed By: bernardbeckerman

Differential Revision: D97337646


