### PR TITLE
incorporate backfill into search space parameter check

### DIFF
--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -316,7 +316,7 @@ class SearchSpace(Base):
         self, parameterization: Mapping[str, TParamValue], raise_error: bool = False
     ) -> bool:
         """Whether a given parameterization contains all the parameters in the
-        search space.
+        search space. Parameters with a backfill value are considered present.
 
         Args:
             parameterization: Dict from parameter name to value to validate.
@@ -329,12 +329,19 @@ class SearchSpace(Base):
         parameterization_params = set(parameterization.keys())
         ss_params = set(self.parameters.keys())
         if parameterization_params != ss_params:
-            if raise_error:
-                raise ValueError(
-                    f"Parameterization has parameters: {parameterization_params}, "
-                    f"but search space has parameters: {ss_params}."
-                )
-            return False
+            # Allow missing parameters if they have backfill values set.
+            missing_params = ss_params - parameterization_params
+            extra_params = parameterization_params - ss_params
+            missing_without_backfill = {
+                p for p in missing_params if self.parameters[p].backfill_value is None
+            }
+            if missing_without_backfill or extra_params:
+                if raise_error:
+                    raise ValueError(
+                        f"Parameterization has parameters: {parameterization_params}, "
+                        f"but search space has parameters: {ss_params}."
+                    )
+                return False
         return True
 
     def check_membership(
@@ -355,7 +362,8 @@ class SearchSpace(Base):
             raise_error: If true parameterization does not belong, raises an error
                 with detailed explanation of why.
             check_all_parameters_present: Ensure that parameterization specifies
-                values for all parameters as expected by the search space.
+                values for all parameters as expected by the search space. Parameters
+                with a backfill value set are considered always present.
             check_range_bounds: If False, only check that values for
                 RangeParameters have the correct type, without enforcing
                 the parameter bounds. Other parameter types (ChoiceParameter,
@@ -464,7 +472,12 @@ class SearchSpace(Base):
         # Check all parameters present (for non-hierarchical search spaces)
         # This must happen BEFORE filtering to detect extra columns
         if check_all_parameters_present and not self.is_hierarchical:
-            if df_cols != ss_params:
+            missing_params = ss_params - df_cols
+            extra_params = df_cols - ss_params
+            missing_without_backfill = {
+                p for p in missing_params if self.parameters[p].backfill_value is None
+            }
+            if missing_without_backfill or extra_params:
                 # All rows are out of design if parameters don't match
                 return [False] * len(arm_data)
 

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -303,6 +303,40 @@ class SearchSpaceTest(TestCase):
         with self.assertRaises(ValueError):
             self.ss2.check_membership(p_dict, raise_error=True)
 
+    def test_CheckMembershipMissingParamWithBackfill(self) -> None:
+        """Missing parameters with backfill values should pass membership check."""
+        ss = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+                RangeParameter(
+                    name="y",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                    backfill_value=0.5,
+                ),
+            ]
+        )
+
+        # Both present: valid
+        self.assertTrue(ss.check_membership({"x": 0.5, "y": 0.5}))
+
+        # Missing param with backfill value: valid
+        self.assertTrue(ss.check_membership({"x": 0.5}))
+
+        # Missing param without backfill value: invalid
+        self.assertFalse(ss.check_membership({"y": 0.5}))
+        with self.assertRaises(ValueError):
+            ss.check_membership({"y": 0.5}, raise_error=True)
+
+        # Extra param: still invalid
+        self.assertFalse(ss.check_membership({"x": 0.5, "y": 0.5, "z": 1.0}))
+
     def test_CheckMembershipSkipRangeBounds(self) -> None:
         ss = SearchSpace(
             parameters=[
@@ -426,6 +460,48 @@ class SearchSpaceTest(TestCase):
         test_data_with_metadata["metadata"] = [{"key": "value"}] * len(test_data)
         result_with_metadata = self.ss1.check_membership_df(test_data_with_metadata)
         self.assertEqual(result, result_with_metadata)
+
+    def test_check_membership_df_missing_param_with_backfill(self) -> None:
+        """Missing columns with backfill values should not cause all-False."""
+        ss = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+                RangeParameter(
+                    name="y",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                    backfill_value=0.5,
+                ),
+            ]
+        )
+
+        # DataFrame missing column "y" which has backfill: should pass
+        df = pd.DataFrame(
+            {"x": [0.5, 0.3]},
+            index=pd.MultiIndex.from_tuples(
+                [(0, "arm0"), (1, "arm1")],
+                names=["trial_index", "arm_name"],
+            ),
+        )
+        result = ss.check_membership_df(df)
+        self.assertEqual(result, [True, True])
+
+        # DataFrame missing column "x" which has no backfill: should fail
+        df_missing_x = pd.DataFrame(
+            {"y": [0.5, 0.3]},
+            index=pd.MultiIndex.from_tuples(
+                [(0, "arm0"), (1, "arm1")],
+                names=["trial_index", "arm_name"],
+            ),
+        )
+        result_missing_x = ss.check_membership_df(df_missing_x)
+        self.assertEqual(result_missing_x, [False, False])
 
     def test_CheckTypes(self) -> None:
         p_dict = {"a": 1.0, "b": 5, "c": "foo", "d": True, "e": 0.2, "f": 5}


### PR DESCRIPTION
Summary:
In SearchSpace.check_membership we verify that all parameters are present on an Arm.

This does not make any consideration for parameters that are missing but have a backfill value. Since the backfill is a fundamental property of the Parameter, I think the correct logic here is for a parameter to be considered "present" if it has a backfill value set.

From a practical perspective, if I add a parameter to an experiment and set a backfill, then all of my existing arms are in-design thanks to the backfill value. But they will all fail SearchSpace.check_membership on the updated search space. This is especially problematic because the Analysis for plotting arms uses SearchSpace.check_membership to decide what to plot, and so all existing arms get left out of the plot despite having a backfill.

Reviewed By: saitcakmak

Differential Revision: D96523999


