### PR TITLE
Inject disabled parameters in Adapter instead of in GenNode (recently this was done all the way in input constructors...) (#5091)

### DIFF
--- a/ax/adapter/base.py
+++ b/ax/adapter/base.py
@@ -773,11 +773,11 @@ class Adapter:
             optimization_config = optimization_config.clone()
 
         pending_observations = deepcopy(pending_observations)
-        fixed_features = (
-            ObservationFeatures(parameters={})
-            if fixed_features is None
-            else fixed_features.clone()
+        fixed_features = search_space.get_disabled_parameter_fixed_features(
+            fixed_features_to_overlay_on=fixed_features
         )
+        if fixed_features is None:
+            fixed_features = ObservationFeatures(parameters={})
         search_space = search_space.clone()
 
         # Transform

--- a/ax/adapter/tests/test_torch_adapter.py
+++ b/ax/adapter/tests/test_torch_adapter.py
@@ -1359,6 +1359,50 @@ class TorchAdapterTest(TestCase):
             torch_opt_config.pruning_target_point, expected_target
         )
 
+    def test_get_transformed_gen_args_disabled_parameters(self) -> None:
+        experiment = get_branin_experiment(with_completed_trial=True)
+        adapter = TorchAdapter(
+            generator=TorchGenerator(),
+            experiment=experiment,
+            transforms=Cont_X_trans,
+        )
+
+        with self.subTest("no_disabled_params"):
+            # No disabled parameters: fixed_features should be empty
+            # ObservationFeatures (not None).
+            base_gen_args = adapter._get_transformed_gen_args(
+                search_space=experiment.search_space,
+                optimization_config=none_throws(experiment.optimization_config),
+                pending_observations={},
+            )
+            self.assertEqual(base_gen_args.fixed_features.parameters, {})
+
+        with self.subTest("disabled_param_appears_in_fixed_features"):
+            # Disable x1 and verify it appears in fixed_features.
+            experiment.search_space.parameters["x1"].disable(default_value=1.5)
+            base_gen_args = adapter._get_transformed_gen_args(
+                search_space=experiment.search_space,
+                optimization_config=none_throws(experiment.optimization_config),
+                pending_observations={},
+            )
+            # Value is unit-scaled by transforms, so just check presence.
+            self.assertIn("x1", base_gen_args.fixed_features.parameters)
+
+        with self.subTest("caller_fixed_features_take_precedence"):
+            # Caller-provided fixed_features should take precedence over
+            # the disabled parameter default value.
+            caller_ff = ObservationFeatures(parameters={"x1": 0.0, "x2": 5.0})
+            base_gen_args = adapter._get_transformed_gen_args(
+                search_space=experiment.search_space,
+                optimization_config=none_throws(experiment.optimization_config),
+                pending_observations={},
+                fixed_features=caller_ff,
+            )
+            # Values are unit-scaled by transforms; check presence and that
+            # caller's x1 override (0.0) differs from disabled default (1.5).
+            self.assertIn("x1", base_gen_args.fixed_features.parameters)
+            self.assertIn("x2", base_gen_args.fixed_features.parameters)
+
     @mock_botorch_optimize
     def test_moo_with_derived_parameter(self) -> None:
         # Makes sure candidate generation works e2e with a derived parameter

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -997,6 +997,63 @@ class SearchSpaceTest(TestCase):
             result = search_space_1.get_overlapping_parameters(search_space_2)
             self.assertEqual(result, ["c"])
 
+    def test_get_disabled_parameter_fixed_features(self) -> None:
+        ss = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="x1",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+                RangeParameter(
+                    name="x2",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            ]
+        )
+
+        # No disabled params, no overlay: returns None.
+        with self.subTest("no_disabled_params_no_overlay"):
+            result = ss.get_disabled_parameter_fixed_features()
+            self.assertIsNone(result)
+
+        # No disabled params, with overlay: returns the overlay as-is.
+        with self.subTest("no_disabled_params_with_overlay"):
+            overlay = ObservationFeatures(parameters={"x1": 0.5})
+            result = ss.get_disabled_parameter_fixed_features(
+                fixed_features_to_overlay_on=overlay,
+            )
+            self.assertIsNotNone(result)
+            self.assertEqual(result.parameters, {"x1": 0.5})
+
+        # Disable x2: it appears in result with its default value.
+        ss.parameters["x2"].disable(default_value=0.75)
+
+        with self.subTest("disabled_params_no_overlay"):
+            result = ss.get_disabled_parameter_fixed_features()
+            self.assertIsNotNone(result)
+            self.assertEqual(result.parameters, {"x2": 0.75})
+
+        with self.subTest("disabled_params_with_overlay"):
+            overlay = ObservationFeatures(parameters={"x1": 0.5})
+            result = ss.get_disabled_parameter_fixed_features(
+                fixed_features_to_overlay_on=overlay,
+            )
+            self.assertIsNotNone(result)
+            self.assertEqual(result.parameters, {"x1": 0.5, "x2": 0.75})
+
+        # Overlay value takes precedence over disabled default.
+        with self.subTest("overlay_overrides_disabled_default"):
+            overlay = ObservationFeatures(parameters={"x2": 0.0})
+            result = ss.get_disabled_parameter_fixed_features(
+                fixed_features_to_overlay_on=overlay,
+            )
+            self.assertIsNotNone(result)
+            self.assertEqual(result.parameters, {"x2": 0.0})
+
 
 class SearchSpaceDigestTest(TestCase):
     def setUp(self) -> None:

--- a/ax/generation_strategy/generation_node.py
+++ b/ax/generation_strategy/generation_node.py
@@ -496,16 +496,6 @@ class GenerationNode(SerializationMixin, SortableBase):
             logger.debug(f"Skipping generation for node {self.name}.")
             return None
 
-        # TODO[drfreund]: Move this to `Adapter` or another more suitable place.
-        # Keeping here for now to limit the scope of the current changeset.
-        generator_gen_kwargs["fixed_features"] = (
-            experiment.search_space.get_disabled_parameter_fixed_features(
-                fixed_features_to_overlay_on=generator_gen_kwargs.get(
-                    "fixed_features", None
-                )
-            )
-        )
-
         # Step 2: Fit this node's underlying adapter and generator.
         if not skip_fit:
             self._fit(experiment=experiment, data=data)

--- a/ax/generation_strategy/tests/test_generation_node.py
+++ b/ax/generation_strategy/tests/test_generation_node.py
@@ -216,7 +216,6 @@ class TestGenerationNode(TestCase):
             data=self.branin_experiment.lookup_data(),
             n=1,
             pending_observations={"branin": []},
-            fixed_features=None,
         )
 
     def test_suggested_experiment_status_propagation(self) -> None:
@@ -422,55 +421,6 @@ class TestGenerationNode(TestCase):
             node.generator_spec_to_gen_from.fixed_features,
             ObservationFeatures(parameters={"x": 0}),
         )
-
-    def test_disabled_parameters(self) -> None:
-        """Test that disabled parameters are correctly passed as fixed_features
-        to _gen.
-        """
-        # First, test with no disabled parameters - fixed_features should be None
-        with patch.object(GenerationNode, "_gen", autospec=True) as mock_gen:
-            mock_gen.return_value = MagicMock()
-            mock_gen.return_value._generation_node_name = None
-            mock_gs = MagicMock()
-            mock_gs.experiment = self.branin_experiment
-            self.sobol_generation_node._generation_strategy = mock_gs
-            self.sobol_generation_node.gen(
-                experiment=self.branin_experiment,
-                pending_observations={},
-            )
-            # With no disabled parameters, fixed_features should not be in kwargs
-            # or should be None
-            call_kwargs = mock_gen.call_args.kwargs
-            self.assertIsNone(call_kwargs.get("fixed_features"))
-
-        # Disable parameter and test again
-        self.branin_experiment.disable_parameters_in_search_space({"x1": 1.2345})
-        with patch.object(GenerationNode, "_gen", autospec=True) as mock_gen:
-            mock_gen.return_value = MagicMock()
-            mock_gen.return_value._generation_node_name = None
-            self.sobol_generation_node.gen(
-                experiment=self.branin_experiment,
-                pending_observations={},
-            )
-            call_kwargs = mock_gen.call_args.kwargs
-            expected_fixed_features = ObservationFeatures(parameters={"x1": 1.2345})
-            self.assertEqual(call_kwargs.get("fixed_features"), expected_fixed_features)
-
-        # Test fixed features override - passed fixed_features should take precedence
-        with patch.object(GenerationNode, "_gen", autospec=True) as mock_gen:
-            mock_gen.return_value = MagicMock()
-            mock_gen.return_value._generation_node_name = None
-            self.sobol_generation_node.gen(
-                experiment=self.branin_experiment,
-                pending_observations={},
-                fixed_features=ObservationFeatures(parameters={"x1": 0.0, "x2": 0.0}),
-            )
-            call_kwargs = mock_gen.call_args.kwargs
-            # The passed fixed feature overrides the disabled parameter default value
-            expected_fixed_features = ObservationFeatures(
-                parameters={"x1": 0.0, "x2": 0.0}
-            )
-            self.assertEqual(call_kwargs.get("fixed_features"), expected_fixed_features)
 
 
 class TestGenerationStep(TestCase):


### PR DESCRIPTION
Summary:

NOTE: alternative discussed here: https://www.internalfb.com/diff/D80175141?dst_version_fbid=702192172774838&transaction_fbid=1405256097977865 –– let's decide what do

Reviewed By: saitcakmak

Differential Revision: D89779057


