### PR TITLE
Support PairwiseGP in ModelList pipelines (#5092)

### DIFF
--- a/ax/adapter/base.py
+++ b/ax/adapter/base.py
@@ -39,6 +39,7 @@ from ax.exceptions.core import UnsupportedError, UserInputError
 from ax.exceptions.model import AdapterMethodNotImplementedError, ModelError
 from ax.generators.base import Generator
 from ax.generators.types import TConfig
+from ax.utils.common.constants import Keys
 from ax.utils.common.logger import get_logger
 from botorch.settings import validate_input_scaling
 from pandas import DataFrame
@@ -314,7 +315,28 @@ class Adapter:
         transform_configs: Mapping[str, TConfig],
         assign_transforms: bool = True,
     ) -> tuple[ExperimentData, SearchSpace]:
-        """Initialize transforms and apply them to provided data."""
+        """Initialize transforms and apply them to provided data.
+
+        Pairwise preference labels (binary 0/1) are popped before
+        transforms and reattached afterward to prevent corruption by
+        Y-transforms like StandardizeY or Winsorize.
+        """
+        pairwise_key = Keys.PAIRWISE_PREFERENCE_QUERY.value
+        obs_data = experiment_data.observation_data
+        saved_pairwise = None
+        if ("mean", pairwise_key) in obs_data.columns:
+            saved_pairwise = {
+                "mean": obs_data[("mean", pairwise_key)].copy(),
+                "sem": obs_data[("sem", pairwise_key)].copy(),
+            }
+            obs_data = obs_data.drop(
+                columns=[("mean", pairwise_key), ("sem", pairwise_key)]
+            )
+            experiment_data = ExperimentData(
+                arm_data=experiment_data.arm_data,
+                observation_data=obs_data,
+            )
+
         search_space = search_space.clone()
         if transforms is not None:
             for t in transforms:
@@ -332,6 +354,19 @@ class Adapter:
                 )
                 if assign_transforms:
                     self.transforms[t.__name__] = t_instance
+
+        if saved_pairwise is not None:
+            # Reattach by index alignment. Safe because pairwise labeling
+            # trials are in _non_relativizable_trial_indices and are never
+            # dropped by transforms like TransformToNewSQ.
+            obs_data = experiment_data.observation_data
+            obs_data[("mean", pairwise_key)] = saved_pairwise["mean"]
+            obs_data[("sem", pairwise_key)] = saved_pairwise["sem"]
+            experiment_data = ExperimentData(
+                arm_data=experiment_data.arm_data,
+                observation_data=obs_data,
+            )
+
         return experiment_data, search_space
 
     def _set_search_space(

--- a/ax/adapter/tests/test_torch_adapter.py
+++ b/ax/adapter/tests/test_torch_adapter.py
@@ -14,10 +14,12 @@ from unittest import mock
 from unittest.mock import patch
 
 import numpy as np
+import pandas as pd
 import torch
 from ax.adapter.adapter_utils import _binary_pref_to_comp_pair, _consolidate_comparisons
 from ax.adapter.base import Adapter
 from ax.adapter.cross_validation import cross_validate
+from ax.adapter.data_utils import ExperimentData
 from ax.adapter.registry import Cont_X_trans, MBM_X_trans, Y_trans
 from ax.adapter.torch import TorchAdapter
 from ax.adapter.transforms.one_hot import OneHot
@@ -1771,3 +1773,104 @@ class AdapterWithPLBOTest(TestCase):
             "Preference optimization requires a BoTorchGenerator",
         ):
             adapter.gen(n=2, optimization_config=self.pref_opt_config)
+
+
+class TestTransformDataPairwiseProtection(TestCase):
+    """Test that _transform_data preserves raw pairwise preference labels."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.experiment = get_branin_experiment(with_status_quo=True)
+        # Build ExperimentData with both regular metric and pairwise columns.
+        index = pd.MultiIndex.from_tuples(
+            [(0, "0_0"), (0, "0_1"), (1, "1_0"), (1, "1_1")],
+            names=["trial_index", "arm_name"],
+        )
+        pairwise_key = Keys.PAIRWISE_PREFERENCE_QUERY.value
+        columns = pd.MultiIndex.from_tuples(
+            [
+                ("mean", "branin"),
+                ("sem", "branin"),
+                ("mean", pairwise_key),
+                ("sem", pairwise_key),
+            ]
+        )
+        obs_data = pd.DataFrame(
+            [
+                [10.0, 1.0, float("nan"), float("nan")],
+                [12.0, 1.0, 0.0, 0.0],
+                [8.0, 1.0, float("nan"), float("nan")],
+                [6.0, 1.0, 1.0, 0.0],
+            ],
+            index=index,
+            columns=columns,
+        )
+        arm_data = pd.DataFrame(
+            {"x1": [0.0, 1.0, 2.0, 3.0], "x2": [0.0, 1.0, 2.0, 3.0]},
+            index=index,
+        )
+        self.experiment_data = ExperimentData(
+            arm_data=arm_data, observation_data=obs_data
+        )
+
+    def test_pairwise_labels_preserved_through_standardize_y(self) -> None:
+        """Pairwise preference labels (0/1) must not be modified by
+        Y-transforms like StandardizeY."""
+        adapter = TorchAdapter(
+            experiment=self.experiment,
+            generator=TorchGenerator(),
+            fit_on_init=False,
+        )
+        transformed_data, _ = adapter._transform_data(
+            experiment_data=self.experiment_data,
+            search_space=self.experiment.search_space,
+            transforms=[StandardizeY],
+            transform_configs={},
+            assign_transforms=False,
+        )
+        pairwise_key = Keys.PAIRWISE_PREFERENCE_QUERY.value
+        obs = transformed_data.observation_data
+
+        # Pairwise columns should exist and be unchanged.
+        self.assertIn(("mean", pairwise_key), obs.columns)
+        original = self.experiment_data.observation_data[("mean", pairwise_key)]
+        result = obs[("mean", pairwise_key)]
+        # Compare values including NaN positions.
+        pd.testing.assert_series_equal(
+            original.fillna(-999), result.fillna(-999), check_names=False
+        )
+
+        # Regular metric should be transformed (standardized).
+        branin_mean = obs[("mean", "branin")]
+        self.assertAlmostEqual(branin_mean.mean(), 0.0, places=5)
+        # Verify branin values actually changed (not all equal to original).
+        original_branin = self.experiment_data.observation_data[("mean", "branin")]
+        self.assertFalse(branin_mean.equals(original_branin))
+
+    def test_no_pairwise_data_passes_through(self) -> None:
+        """When no pairwise data is present, _transform_data works normally."""
+        pairwise_key = Keys.PAIRWISE_PREFERENCE_QUERY.value
+        obs_no_pairwise = self.experiment_data.observation_data.drop(
+            columns=[("mean", pairwise_key), ("sem", pairwise_key)]
+        )
+        experiment_data = ExperimentData(
+            arm_data=self.experiment_data.arm_data,
+            observation_data=obs_no_pairwise,
+        )
+        adapter = TorchAdapter(
+            experiment=self.experiment,
+            generator=TorchGenerator(),
+            fit_on_init=False,
+        )
+        transformed_data, _ = adapter._transform_data(
+            experiment_data=experiment_data,
+            search_space=self.experiment.search_space,
+            transforms=[StandardizeY],
+            transform_configs={},
+            assign_transforms=False,
+        )
+        # Should still have branin, no pairwise.
+        self.assertIn(("mean", "branin"), transformed_data.observation_data.columns)
+        self.assertNotIn(
+            ("mean", pairwise_key), transformed_data.observation_data.columns
+        )

--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -463,8 +463,9 @@ def choose_botorch_acqf_class(
                     )
 
             if not is_feasible.any().item():
-                # NOTE: Adding a new acqf class here requires a corresponding
-                # update in get_botorch_objective_and_transform.
+                # NOTE: Adding a new acqf class here requires a
+                # corresponding update in
+                # get_botorch_objective_and_transform.
                 acqf_class = qLogProbabilityOfFeasibility
                 logger.debug(f"Chose BoTorch acquisition function class: {acqf_class}.")
                 return acqf_class

--- a/ax/generators/torch/tests/test_utils.py
+++ b/ax/generators/torch/tests/test_utils.py
@@ -38,6 +38,7 @@ from ax.generators.torch.utils import (
     extract_objectives,
     get_feature_importances_from_botorch_model,
     get_rounding_func,
+    pick_best_out_of_sample_point_acqf_class,
     predict_from_model,
 )
 from ax.generators.torch_base import TorchOptConfig
@@ -50,6 +51,7 @@ from botorch.acquisition.logei import (
     qLogNoisyExpectedImprovement,
     qLogProbabilityOfFeasibility,
 )
+from botorch.acquisition.monte_carlo import qSimpleRegret
 from botorch.acquisition.multi_objective.logei import (
     qLogNoisyExpectedHypervolumeImprovement,
 )
@@ -1378,3 +1380,19 @@ class BoTorchGeneratorUtilsTest(TestCase):
         # points exist (after fixing MAP_KEY, the data can be merged properly)
         # We expect qLogNoisyExpectedImprovement for single-objective
         self.assertEqual(acqf_class, qLogNoisyExpectedImprovement)
+
+    def test_pick_best_out_of_sample_point_acqf_class(self) -> None:
+        # Unconstrained: PosteriorMean with no options.
+        acqf_class, acqf_options = pick_best_out_of_sample_point_acqf_class(
+            outcome_constraints=None,
+        )
+        self.assertEqual(acqf_class, PosteriorMean)
+        self.assertEqual(acqf_options, {})
+
+        # Constrained: qSimpleRegret with no explicit sampler (get_sampler
+        # auto-dispatches, which handles PosteriorList correctly).
+        acqf_class, acqf_options = pick_best_out_of_sample_point_acqf_class(
+            outcome_constraints=(torch.tensor([[1.0, 0.0]]), torch.tensor([[0.5]])),
+        )
+        self.assertEqual(acqf_class, qSimpleRegret)
+        self.assertEqual(acqf_options, {})

--- a/ax/generators/torch/utils.py
+++ b/ax/generators/torch/utils.py
@@ -15,7 +15,6 @@ import numpy.typing as npt
 import torch
 from ax.exceptions.core import UnsupportedError
 from ax.generators.utils import filter_constraints_and_fixed_features, get_observed
-from ax.utils.common.constants import Keys
 from botorch.acquisition.acquisition import AcquisitionFunction
 from botorch.acquisition.analytic import PosteriorMean
 from botorch.acquisition.logei import qLogProbabilityOfFeasibility
@@ -41,7 +40,6 @@ from botorch.acquisition.utils import get_infeasible_cost
 from botorch.models.model import Model, ModelList
 from botorch.posteriors.ensemble import EnsemblePosterior
 from botorch.posteriors.fully_bayesian import GaussianMixturePosterior
-from botorch.sampling.normal import IIDNormalSampler, SobolQMCNormalSampler
 from botorch.utils.constraints import get_outcome_constraint_transforms
 from botorch.utils.datasets import SupervisedDataset
 from botorch.utils.objective import get_objective_weights_transform
@@ -423,12 +421,7 @@ def pick_best_out_of_sample_point_acqf_class(
         acqf_options = {}
     else:
         acqf_class = qSimpleRegret
-        sampler_class = SobolQMCNormalSampler if qmc else IIDNormalSampler
-        acqf_options = {
-            Keys.SAMPLER.value: sampler_class(
-                sample_shape=torch.Size([mc_samples]), seed=seed_inner
-            )
-        }
+        acqf_options = {}
 
     return cast(type[AcquisitionFunction], acqf_class), acqf_options
 


### PR DESCRIPTION
Summary:

When a PairwiseGP is used alongside regular GPs in a ModelList
(e.g., for LILO preference-based optimization), two pipeline points
need adaptation:

1. **Adapter `_transform_data` pairwise label protection**: Pop
   pairwise preference labels before Y-transforms (StandardizeY,
   Winsorize) and reattach afterward, preventing corruption of
   binary 0/1 values. Uses pandas column assignment for reattach,
   which aligns by index without adding or removing rows.
2. **`pick_best_out_of_sample_point_acqf_class` sampler fix**: Remove
   the explicit `SobolQMCNormalSampler` from `acqf_options` in the
   constrained branch. `get_sampler` already auto-dispatches correctly
   for `PosteriorList` -> `ListSampler`. The explicit sampler was
   broken for `PosteriorList` (crashes on `rsample_from_base_samples`).

Reviewed By: saitcakmak

Differential Revision: D96574732
