### PR TITLE
Dispatch qEUBO for preferential BO (PBO) (#5093)

### DIFF
--- a/ax/generation_strategy/generation_strategy.py
+++ b/ax/generation_strategy/generation_strategy.py
@@ -388,6 +388,12 @@ class GenerationStrategy(Base):
             n._step_index = None
             if len(n.generator_specs) > 1:
                 n._generator_spec_to_gen_from = None
+            elif len(n.generator_specs) == 1:
+                # Reset to the sole spec, matching what __init__ sets on
+                # deserialized nodes. This is needed because
+                # _try_gen_with_fallback can override this field with a
+                # non-persisted fallback spec (e.g. Fallback_Sobol).
+                n._generator_spec_to_gen_from = n.generator_specs[0]
             # Reset cache fields that are used for performance optimization only
             # and should not affect equality comparisons.
             n._trials_from_node_cache = set()

--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -53,6 +53,10 @@ from botorch.acquisition.multioutput_acquisition import (
     MultiOutputAcquisitionFunctionWrapper,
 )
 from botorch.acquisition.objective import MCAcquisitionObjective, PosteriorTransform
+from botorch.acquisition.preference import (
+    AnalyticExpectedUtilityOfBestOption,
+    qExpectedUtilityOfBestOption,
+)
 from botorch.exceptions.errors import BotorchError, InputDataError
 from botorch.generation.sampling import SamplingStrategy
 from botorch.models.model import Model
@@ -369,6 +373,20 @@ class Acquisition(Base):
         botorch_acqf_options: dict[str, Any],
         model: Model,
     ) -> AcquisitionFunction:
+        # EUBO (PBO / BOPE): bypass the generic path because EUBO input
+        # constructors don't accept training_data, bounds, X_baseline, etc.
+        # TODO: Update EUBO input constructors to accept and validate these
+        # kwargs so we can use the generic path.
+        # Guard: skip when pref_model was popped by PreferenceModelAcquisition
+        # (legacy BOPE) -- detected by multi-output model without pref_model.
+        if issubclass(
+            botorch_acqf_class,
+            (AnalyticExpectedUtilityOfBestOption, qExpectedUtilityOfBestOption),
+        ) and ("pref_model" in botorch_acqf_options or model.num_outputs == 1):
+            input_constructor = get_acqf_input_constructor(botorch_acqf_class)
+            acqf_inputs = input_constructor(model=model, **botorch_acqf_options)
+            return botorch_acqf_class(**acqf_inputs)  # pyre-ignore [45]
+
         objective, posterior_transform = self.get_botorch_objective_and_transform(
             botorch_acqf_class=botorch_acqf_class,
             model=model,

--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -34,6 +34,7 @@ from botorch.acquisition.multi_objective.logei import (
     qLogNoisyExpectedHypervolumeImprovement,
 )
 from botorch.acquisition.multi_objective.parego import qLogNParEGO
+from botorch.acquisition.preference import qExpectedUtilityOfBestOption
 from botorch.exceptions.errors import BotorchError, CandidateGenerationError
 from botorch.fit import fit_fully_bayesian_model_nuts, fit_gpytorch_mll
 from botorch.models import PairwiseLaplaceMarginalLogLikelihood
@@ -406,12 +407,30 @@ def choose_botorch_acqf_class(
             - `qLogProbabilityOfFeasibility` if no observed point simultaneously
                 satisfies all outcome constraints (if any) and dominates all
                 objective thresholds (if any, for MOO).
+            - `qExpectedUtilityOfBestOption` for single-objective
+                preference-only optimization (PBO / LILO) where the sole
+                objective is ``pairwise_pref_query`` with no constraints.
             - `qLogNoisyExpectedImprovement` for single-objective optimization.
             - `qLogNoisyExpectedHypervolumeImprovement` for multi-objective
                 optimization with <= 4 objectives.
             - `qLogNParEGO` for multi-objective optimization with > 4 objectives
                 to prevent slow optimization.
     """
+
+    # Preferential BO (PBO): single-objective preference-only optimization
+    # (e.g. LILO).  The sole objective is pairwise_pref_query with no
+    # constraints, so we optimize the preference model directly via qEUBO.
+    # This must come before the PFeasibility block to prevent PBO experiments
+    # from reaching convert_to_block_design (which is incompatible with
+    # RankingDatasets).
+    if (
+        not torch_opt_config.is_moo
+        and torch_opt_config.outcome_constraints is None
+        and Keys.PAIRWISE_PREFERENCE_QUERY.value in torch_opt_config.opt_config_metrics
+    ):
+        acqf_class = qExpectedUtilityOfBestOption
+        logger.debug(f"Chose BoTorch acquisition function class: {acqf_class}.")
+        return acqf_class
 
     if use_p_feasible and datasets is not None:
         has_outcome_constraints = torch_opt_config.outcome_constraints is not None

--- a/ax/generators/torch/tests/test_utils.py
+++ b/ax/generators/torch/tests/test_utils.py
@@ -15,6 +15,7 @@ from unittest.mock import Mock
 import numpy as np
 import torch
 from ax.core.data import MAP_KEY
+from ax.core.metric import Metric
 from ax.core.search_space import SearchSpaceDigest
 from ax.exceptions.core import AxWarning, UnsupportedError, UserInputError
 from ax.generators.torch.botorch_modular.kernels import ScaleMaternKernel
@@ -47,6 +48,7 @@ from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.torch_stubs import get_torch_test_data
 from botorch.acquisition.analytic import PosteriorMean
+from botorch.acquisition.input_constructors import get_acqf_input_constructor
 from botorch.acquisition.logei import (
     qLogNoisyExpectedImprovement,
     qLogProbabilityOfFeasibility,
@@ -56,6 +58,10 @@ from botorch.acquisition.multi_objective.logei import (
     qLogNoisyExpectedHypervolumeImprovement,
 )
 from botorch.acquisition.multi_objective.parego import qLogNParEGO
+from botorch.acquisition.preference import (
+    AnalyticExpectedUtilityOfBestOption,
+    qExpectedUtilityOfBestOption,
+)
 from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
 from botorch.models.gp_regression import SingleTaskGP
 from botorch.models.gp_regression_fidelity import SingleTaskMultiFidelityGP
@@ -63,6 +69,7 @@ from botorch.models.gp_regression_mixed import MixedSingleTaskGP
 from botorch.models.heterogeneous_mtgp import HeterogeneousMTGP
 from botorch.models.model_list_gp_regression import ModelListGP
 from botorch.models.multitask import MultiTaskGP
+from botorch.models.pairwise_gp import PairwiseGP
 from botorch.models.transforms.input import Normalize, Warp
 from botorch.posteriors.ensemble import EnsemblePosterior
 from botorch.utils.datasets import MultiTaskDataset, SupervisedDataset
@@ -601,6 +608,84 @@ class BoTorchGeneratorUtilsTest(TestCase):
                 datasets=[dataset],
             ),
         )
+
+    def test_choose_botorch_acqf_class_pbo_dispatches_qeubo(self) -> None:
+        pref_metric = Keys.PAIRWISE_PREFERENCE_QUERY.value
+        pbo_opt_config = TorchOptConfig(
+            objective_weights=torch.tensor([[1.0]]),
+            opt_config_metrics={pref_metric: Metric(name=pref_metric)},
+        )
+        # Single-objective PBO with pairwise_pref_query → qEUBO.
+        self.assertEqual(
+            qExpectedUtilityOfBestOption,
+            choose_botorch_acqf_class(
+                search_space_digest=self.search_space_digest,
+                torch_opt_config=pbo_opt_config,
+                datasets=None,
+            ),
+        )
+        # Adding outcome constraints → should NOT dispatch qEUBO.
+        self.assertEqual(
+            qLogNoisyExpectedImprovement,
+            choose_botorch_acqf_class(
+                search_space_digest=self.search_space_digest,
+                torch_opt_config=TorchOptConfig(
+                    objective_weights=torch.tensor([[1.0, 0.0]]),
+                    outcome_constraints=(
+                        torch.tensor([[0.0, 1.0]]),
+                        torch.tensor([[5.0]]),
+                    ),
+                    opt_config_metrics={
+                        pref_metric: Metric(name=pref_metric),
+                        "other": Metric(name="other"),
+                    },
+                ),
+                datasets=[self.supervised_dataset],
+            ),
+        )
+        # Without pairwise_pref_query in opt_config_metrics → standard SOO.
+        self.assertEqual(
+            qLogNoisyExpectedImprovement,
+            choose_botorch_acqf_class(
+                search_space_digest=self.search_space_digest,
+                torch_opt_config=TorchOptConfig(
+                    objective_weights=torch.tensor([[1.0, 0.0]]),
+                ),
+                datasets=[self.supervised_dataset],
+            ),
+        )
+
+    def test_eubo_construction_pbo_and_bope_modes(self) -> None:
+        """Verify the EUBO construction path used by the early return in
+        _construct_botorch_acquisition: PBO mode (pref_model absent) and
+        BOPE mode (pref_model provided via botorch_acqf_options)."""
+        pref_model = PairwiseGP(
+            datapoints=torch.rand(3, 2),
+            comparisons=torch.tensor([[0, 1], [1, 2]], dtype=torch.long),
+        )
+        outcome_model = SingleTaskGP(train_X=torch.rand(5, 2), train_Y=torch.rand(5, 2))
+
+        for acqf_class in (
+            AnalyticExpectedUtilityOfBestOption,
+            qExpectedUtilityOfBestOption,
+        ):
+            with self.subTest(acqf_class=acqf_class.__name__):
+                # PBO mode: model IS the preference model, no pref_model kwarg.
+                input_constructor = get_acqf_input_constructor(acqf_class)
+                acqf_inputs = input_constructor(model=pref_model)
+                acqf = acqf_class(**acqf_inputs)
+                self.assertIsInstance(acqf, acqf_class)
+                self.assertIs(acqf.model, pref_model)
+                self.assertIsNone(acqf.outcome_model)
+
+                # BOPE mode: model is the outcome model, pref_model provided.
+                acqf_inputs = input_constructor(
+                    model=outcome_model, pref_model=pref_model
+                )
+                acqf = acqf_class(**acqf_inputs)
+                self.assertIsInstance(acqf, acqf_class)
+                self.assertIs(acqf.model, pref_model)
+                self.assertIsNotNone(acqf.outcome_model)
 
     def test_construct_acquisition_and_optimizer_options(self) -> None:
         # Two dicts for `Acquisition` should be concatenated


### PR DESCRIPTION
Summary:

When the sole objective is `pairwise_pref_query` with no outcome
constraints (the PBO pattern, e.g. LILO), `choose_botorch_acqf_class`
now returns `qExpectedUtilityOfBestOption` instead of the default
`qLogNoisyExpectedImprovement`.

Adds generic EUBO handling in `_construct_botorch_acquisition`: EUBO
input constructors don't accept the standard kwargs (`training_data`,
`bounds`, `X_baseline`, etc.), so the method delegates directly to the
registered EUBO input constructor with `model` and
`botorch_acqf_options`.  The input constructor dispatches between:
- **PBO mode** (`pref_model` absent in options): `model` IS the
  preference model, `outcome_model=None`.
- **BOPE mode** (`pref_model` in `botorch_acqf_options`): `model` is
  the outcome model, wrapped in `FixedSingleSampleModel`.

Reviewed By: saitcakmak

Differential Revision: D97219483


