### PR TITLE
Refactor Runner base class: rename run_multiple→run_trials, add stage_trials/stop_trial/stop_arms/poll_run_metadata/apply_status_change_side_effects, deprecate run/poll_exception/stop

### DIFF
--- a/ax/core/base_trial.py
+++ b/ax/core/base_trial.py
@@ -341,7 +341,8 @@ class BaseTrial(ABC, SortableBase):
         if self.runner is None:
             raise ValueError("No runner set on experiment.")
 
-        self.update_run_metadata(none_throws(self.runner).run(self))
+        run_metadata = none_throws(self.runner).run_trials(trials=[self])
+        self.update_run_metadata(run_metadata[self.index])
 
         if none_throws(self.runner).staging_required:
             self.mark_staged()
@@ -380,7 +381,7 @@ class BaseTrial(ABC, SortableBase):
             raise ValueError("No runner set on experiment.")
         runner = none_throws(self.runner)
 
-        self._stop_metadata = runner.stop(self, reason=reason)
+        self._stop_metadata = runner.stop_trial(trial=self, reason=reason)
         self.mark_as(new_status)
         return self
 

--- a/ax/core/runner.py
+++ b/ax/core/runner.py
@@ -8,7 +8,8 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
+import warnings
+from abc import ABC
 from collections.abc import Iterable
 from typing import Any, Self, TYPE_CHECKING
 
@@ -31,14 +32,17 @@ class Runner(Base, SerializationMixin, ABC):
 
     @property
     def run_metadata_report_keys(self) -> list[str]:
-        """A list of keys of the metadata dict returned by `run()` that are
-        relevant outside the runner-internal impolementation. These can e.g.
-        be reported in `orchestrator.report_results()`."""
+        """A list of keys of the metadata dict returned by ``run_trials()`` that
+        are relevant outside the runner-internal implementation. These can e.g.
+        be reported in ``orchestrator.report_results()``."""
         return []
 
-    @abstractmethod
     def run(self, trial: core.base_trial.BaseTrial) -> dict[str, Any]:
         """Deploys a trial based on custom runner subclass implementation.
+
+        .. deprecated::
+            Override ``run_trials`` instead. This method exists only for
+            backward compatibility and will be removed in a future release.
 
         Args:
             trial: The trial to deploy.
@@ -46,47 +50,80 @@ class Runner(Base, SerializationMixin, ABC):
         Returns:
             Dict of run metadata from the deployment process.
         """
-        pass
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement `run`. "
+            "Override `run_trials` instead."
+        )
+
+    def run_trials(
+        self, trials: Iterable[core.base_trial.BaseTrial]
+    ) -> dict[int, dict[str, Any]]:
+        """Deploys one or more trials based on custom runner subclass
+        implementation.
+
+        Subclasses should override this method. The default implementation
+        falls back to calling the deprecated ``run()`` method for each trial,
+        which allows existing runners to continue working until they are
+        migrated.
+
+        Args:
+            trials: Iterable of trials to be deployed, each containing arms
+                with parameterizations to be evaluated. Can be a ``Trial``
+                if contains only one arm or a ``BatchTrial`` if contains
+                multiple arms.
+
+        Returns:
+            Dict of trial index to the run metadata of that trial from the
+            deployment process.
+        """
+        return {trial.index: self.run(trial=trial) for trial in trials}
 
     def run_multiple(
         self, trials: Iterable[core.base_trial.BaseTrial]
     ) -> dict[int, dict[str, Any]]:
-        """Runs a single evaluation for each of the given trials. Useful when deploying
-        multiple trials at once is more efficient than deploying them one-by-one.
-        Used in Ax ``Orchestrator``.
+        """Runs a single evaluation for each of the given trials.
 
-        NOTE: By default simply loops over `run_trial`. Should be overwritten
-        if deploying multiple trials in batch is preferable.
+        .. deprecated::
+            Use ``run_trials`` instead. This method exists only for backward
+            compatibility and will be removed in a future release.
+        """
+        warnings.warn(
+            "`run_multiple` is deprecated. Use `run_trials` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.run_trials(trials=trials)
+
+    def stage_trials(self, trials: Iterable[core.base_trial.BaseTrial]) -> None:
+        """Stage trials for later execution.
+
+        Does nothing by default. Override for runners that support a staging
+        step before running (e.g. creating a paused job).
 
         Args:
-            trials: Iterable of trials to be deployed, each containing arms with
-                parameterizations to be evaluated. Can be a `Trial`
-                if contains only one arm or a `BatchTrial` if contains
-                multiple arms.
-
-        Returns:
-            Dict of trial index to the run metadata of that trial from the deployment
-            process.
+            trials: Trials to stage.
         """
-        return {trial.index: self.run(trial=trial) for trial in trials}
+        pass
 
     def poll_available_capacity(self) -> int:
-        """Checks how much available capacity there is to schedule trial evaluations.
-        Required for runners used with Ax ``Orchestrator``.
+        """Checks how much available capacity there is to schedule trial
+        evaluations. Required for runners used with Ax ``Orchestrator``.
 
-        NOTE: This method might be difficult to implement in some systems. Returns -1
-        if capacity of the system is "unlimited" or "unknown"
-        (meaning that the ``Orchestrator`` should be trying to schedule as many trials
-        as is possible without violating Orchestrator settings). There is no need to
-        artificially force this method to limit capacity; ``Orchestrator`` has other
-        limitations in place to limit number of trials running at once,
-        like the ``OrchestratorOptions.max_pending_trials`` setting, or
-        more granular control in the form of the `max_parallelism`
-        setting in each of the `GenerationStep`s of a `GenerationStrategy`).
+        NOTE: This method might be difficult to implement in some systems.
+        Returns -1 if capacity of the system is "unlimited" or "unknown"
+        (meaning that the ``Orchestrator`` should be trying to schedule as many
+        trials as is possible without violating Orchestrator settings). There is
+        no need to artificially force this method to limit capacity;
+        ``Orchestrator`` has other limitations in place to limit number of
+        trials running at once, like the
+        ``OrchestratorOptions.max_pending_trials`` setting, or more granular
+        control in the form of the `max_parallelism` setting in each of the
+        `GenerationStep`s of a `GenerationStrategy`).
 
         Returns:
-            An integer, representing how many trials there is available capacity for;
-            -1 if capacity is "unlimited" or not possible to know in advance.
+            An integer, representing how many trials there is available
+            capacity for; -1 if capacity is "unlimited" or not possible to
+            know in advance.
         """
         return -1
 
@@ -104,18 +141,42 @@ class Runner(Base, SerializationMixin, ABC):
             trials: Trials to poll.
 
         Returns:
-            A dictionary mapping TrialStatus to a list of trial indices that have
-            the respective status at the time of the polling. This does not need to
-            include trials that at the time of polling already have a terminal
-            (ABANDONED, FAILED, COMPLETED) status (but it may).
+            A dictionary mapping TrialStatus to a list of trial indices that
+            have the respective status at the time of the polling. This does
+            not need to include trials that at the time of polling already have
+            a terminal (ABANDONED, FAILED, COMPLETED) status (but it may).
         """
         raise NotImplementedError(
-            f"{self.__class__.__name__} does not implement a `poll_trial_status` "
-            "method."
+            f"{self.__class__.__name__} does not implement a "
+            "`poll_trial_status` method."
         )
+
+    def poll_run_metadata(
+        self, trials: Iterable[core.base_trial.BaseTrial]
+    ) -> dict[int, dict[str, Any]]:
+        """Update run metadata based on actual deployment results.
+
+        For example, a trial might not actually start when ``run_trials`` is
+        called (it may be queued/"staged" for a while). This method allows
+        runners to update start/end dates and other run metadata to reflect
+        reality.
+
+        Args:
+            trials: Trials whose run metadata should be refreshed.
+
+        Returns:
+            Dict of trial index to updated run metadata. Only trials whose
+            metadata changed need to be included.
+        """
+        return {}
 
     def poll_exception(self, trial: core.base_trial.BaseTrial) -> str:
         """Returns the exception from a trial.
+
+        .. deprecated::
+            Fold exception reporting into ``poll_trial_status`` by including
+            a ``status_reason`` in the trial's run metadata. This method will
+            be removed in a future release.
 
         Args:
             trial: Trial to get exception for.
@@ -123,11 +184,17 @@ class Runner(Base, SerializationMixin, ABC):
         Returns:
             Exception string.
         """
+        warnings.warn(
+            "`poll_exception` is deprecated. Fold exception reporting into "
+            "`poll_trial_status` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         raise NotImplementedError(
             f"{self.__class__.__name__} does not implement a `poll_exception` method."
         )
 
-    def stop(
+    def stop_trial(
         self, trial: core.base_trial.BaseTrial, reason: str | None = None
     ) -> dict[str, Any]:
         """Stop a trial based on custom runner subclass implementation.
@@ -136,7 +203,28 @@ class Runner(Base, SerializationMixin, ABC):
 
         Args:
             trial: The trial to stop.
-            reason: A message containing information why the trial is to be stopped.
+            reason: A message containing information why the trial is to
+                be stopped.
+
+        Returns:
+            A dictionary of run metadata from the stopping process.
+        """
+        # Fall back to the deprecated `stop` method for backward compatibility.
+        return self.stop(trial=trial, reason=reason)
+
+    def stop(
+        self, trial: core.base_trial.BaseTrial, reason: str | None = None
+    ) -> dict[str, Any]:
+        """Stop a trial based on custom runner subclass implementation.
+
+        .. deprecated::
+            Override ``stop_trial`` instead. This method exists only for
+            backward compatibility and will be removed in a future release.
+
+        Args:
+            trial: The trial to stop.
+            reason: A message containing information why the trial is to
+                be stopped.
 
         Returns:
             A dictionary of run metadata from the stopping process.
@@ -144,6 +232,48 @@ class Runner(Base, SerializationMixin, ABC):
         raise NotImplementedError(
             f"{self.__class__.__name__} does not implement a `stop` method."
         )
+
+    def stop_arms(
+        self,
+        trial: core.base_trial.BaseTrial,
+        arm_names: list[str],
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        """Stop specific arms within a running trial.
+
+        Optional method. Override for runners that support stopping individual
+        arms without stopping the entire trial.
+
+        Args:
+            trial: The trial containing the arms to stop.
+            arm_names: Names of the arms to stop.
+            reason: A message containing information why the arms are to
+                be stopped.
+
+        Returns:
+            A dictionary of run metadata from the stopping process.
+        """
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not implement a `stop_arms` method."
+        )
+
+    def apply_status_change_side_effects(
+        self, trials: Iterable[core.base_trial.BaseTrial]
+    ) -> set[int]:
+        """Apply side effects triggered by trial status changes.
+
+        Called after ``poll_trial_status`` to handle actions that should occur
+        when a trial's status transitions (e.g. treating trials that ran for
+        "too short" as failed). Gives these side effects a dedicated place
+        rather than chaining them onto ``poll_trial_status``.
+
+        Args:
+            trials: Trials whose status may have changed.
+
+        Returns:
+            Set of trial indices that were updated by side effects.
+        """
+        return set()
 
     def clone(self) -> Self:
         """Create a copy of this Runner."""

--- a/ax/core/tests/test_runner.py
+++ b/ax/core/tests/test_runner.py
@@ -28,7 +28,11 @@ class RunnerTest(TestCase):
     def test_base_runner_staging_required(self) -> None:
         self.assertFalse(self.dummy_runner.staging_required)
 
-    def test_base_runner_stop(self) -> None:
+    def test_base_runner_stop_trial(self) -> None:
+        with self.assertRaises(NotImplementedError):
+            self.dummy_runner.stop_trial(trial=mock.Mock(), reason="")
+
+    def test_base_runner_stop_deprecated(self) -> None:
         with self.assertRaises(NotImplementedError):
             self.dummy_runner.stop(trial=mock.Mock(), reason="")
 
@@ -37,24 +41,52 @@ class RunnerTest(TestCase):
         self.assertIsInstance(runner_clone, DummyRunner)
         self.assertEqual(runner_clone, self.dummy_runner)
 
-    def test_base_runner_run_multiple(self) -> None:
-        metadata = self.dummy_runner.run_multiple(trials=self.trials)
+    def test_base_runner_run_trials(self) -> None:
+        metadata = self.dummy_runner.run_trials(trials=self.trials)
         self.assertEqual(
             metadata,
             {t.index: {"metadatum": f"value_for_trial_{t.index}"} for t in self.trials},
         )
-        self.assertEqual({}, self.dummy_runner.run_multiple(trials=[]))
+        self.assertEqual({}, self.dummy_runner.run_trials(trials=[]))
+
+    def test_base_runner_run_multiple_deprecated(self) -> None:
+        with self.assertWarns(DeprecationWarning):
+            metadata = self.dummy_runner.run_multiple(trials=self.trials)
+        self.assertEqual(
+            metadata,
+            {t.index: {"metadatum": f"value_for_trial_{t.index}"} for t in self.trials},
+        )
 
     def test_base_runner_poll_trial_status(self) -> None:
         with self.assertRaises(NotImplementedError):
             self.dummy_runner.poll_trial_status(trials=self.trials)
 
-    def test_base_runner_poll_exception(self) -> None:
-        with self.assertRaises(NotImplementedError):
-            self.dummy_runner.poll_exception(trial=self.trials[0])
+    def test_base_runner_poll_exception_deprecated(self) -> None:
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(NotImplementedError):
+                self.dummy_runner.poll_exception(trial=self.trials[0])
 
     def test_poll_available_capacity(self) -> None:
         self.assertEqual(self.dummy_runner.poll_available_capacity(), -1)
 
     def test_run_metadata_report_keys(self) -> None:
         self.assertEqual(self.dummy_runner.run_metadata_report_keys, [])
+
+    def test_stage_trials(self) -> None:
+        # Default implementation does nothing.
+        self.dummy_runner.stage_trials(trials=self.trials)
+
+    def test_poll_run_metadata(self) -> None:
+        self.assertEqual(self.dummy_runner.poll_run_metadata(trials=self.trials), {})
+
+    def test_stop_arms(self) -> None:
+        with self.assertRaises(NotImplementedError):
+            self.dummy_runner.stop_arms(
+                trial=mock.Mock(), arm_names=["arm_0"], reason=""
+            )
+
+    def test_apply_status_change_side_effects(self) -> None:
+        self.assertEqual(
+            self.dummy_runner.apply_status_change_side_effects(trials=self.trials),
+            set(),
+        )


### PR DESCRIPTION
Summary:
Refactors the core Runner base class per the E2E Automation design doc:

**Renamed/restructured methods:**
- `run_multiple` → `run_trials` (kept `run_multiple` as deprecated wrapper)
- `stop` → `stop_trial` (kept `stop` as deprecated fallback)
- `run` is no longer abstract; `run_trials` default implementation calls it for backward compat

**New methods added:**
- `stage_trials(trials)` — does nothing by default, override for staging
- `stop_arms(trial, arm_names, reason)` — stop specific arms in a trial
- `poll_run_metadata(trials)` — update run metadata from actual deployment
- `apply_status_change_side_effects(trials)` — dedicated place for status-change side effects

**Deprecated methods (to be removed after runner migration):**
- `run(trial)` — override `run_trials` instead
- `poll_exception(trial)` — fold into `poll_trial_status`
- `stop(trial, reason)` — override `stop_trial` instead
- `run_multiple(trials)` — use `run_trials` instead

Differential Revision: D97842794


