### PR TITLE
Fix sanitize_name to handle colons/parens/hyphens adjacent to spaces (#5101)

### DIFF
--- a/ax/utils/common/string_utils.py
+++ b/ax/utils/common/string_utils.py
@@ -83,11 +83,31 @@ def sanitize_name(s: str, sanitize_parens: bool = False) -> str:
     """
     if _forbidden_re.search(s) is not None:
         raise ValueError(f"Expression {s} has forbidden control characters.")
-    # Replace spaces between word characters so metric names with spaces
-    # (e.g. "CIFAR10 Test Accuracy") become valid Python identifiers.
-    # Spaces around operators (e.g. "m1 + m2") are not affected because
-    # operators like +, -, *, are not word characters.
-    sans_space = re.sub(r"(?<=\w)\s+(?=\w)", SPACE_PLACEHOLDER, s)
+    # When in objective/constraint parsing mode (sanitize_parens=True) and
+    # the string contains a colon — a character that is never a valid SymPy
+    # operator — any `` - `` (space-hyphen-space) is very likely part of a
+    # metric name rather than mathematical subtraction.  Pre-sanitize the
+    # spaces around the hyphen so the hyphen regex below can match it.
+    # Without this, metric names like ``"TTRC - Hidden Requests"`` would be
+    # misinterpreted as ``Symbol("TTRC") - Symbol("Hidden...")``.
+    # We skip this when the string contains ``*`` because that indicates a
+    # mathematical expression (e.g. ``"-0.5*m:c1 - 0.5*m:c2"``) where
+    # `` - `` is genuine subtraction.
+    if sanitize_parens and ":" in s and "*" not in s:
+        s = re.sub(
+            r"(?<=\w) - (?=\w)",
+            f"{SPACE_PLACEHOLDER}-{SPACE_PLACEHOLDER}",
+            s,
+        )
+    # Replace spaces that appear inside metric/parameter names so they
+    # become valid Python identifiers.  We match spaces between word
+    # characters (e.g. "CIFAR10 Test Accuracy"), as well as spaces that
+    # follow colons or close-parens and precede word characters or
+    # open-parens (e.g. "scope: value", "metric(p50): next", "fn (arg)").
+    # Spaces around mathematical operators (+, -, *, >=, <=) are NOT
+    # affected because those operator characters are not in the
+    # lookbehind/lookahead character classes.
+    sans_space = re.sub(r"(?<=[\w:)])\s+(?=[\w(])", SPACE_PLACEHOLDER, s)
     # Replace occurrences of "." and "/" when they appear after a valid Python variable
     # name and before any alphanumeric character.  We use a lookahead (?=...)
     # for the trailing character so it is NOT consumed by the match; this
@@ -103,10 +123,24 @@ def sanitize_name(s: str, sanitize_parens: bool = False) -> str:
         rf"\1{SLASH_PLACEHOLDER}",
         sans_dots,
     )
+    # Optionally sanitize parentheses that are part of metric/parameter
+    # names BEFORE colons so that ``__rparen__:`` is recognised as an
+    # identifier–colon boundary by the colon regex below.
+    # Matches ``identifier(content)`` where content is purely [a-zA-Z0-9_].
+    # This intentionally also matches single-argument SymPy calls like
+    # ``log(x)``; callers that need SymPy function calls (e.g.
+    # ExpressionDerivedMetric) should leave sanitize_parens=False.
+    sans_parens = sans_slash
+    if sanitize_parens:
+        sans_parens = re.sub(
+            r"([a-zA-Z_][a-zA-Z0-9_]*)\(([a-zA-Z0-9_]+)\)",
+            rf"\1{LPAREN_PLACEHOLDER}\2{RPAREN_PLACEHOLDER}",
+            sans_slash,
+        )
     sans_colon = re.sub(
         r"([a-zA-Z_][a-zA-Z0-9_]*):(?=[a-zA-Z0-9_])",
         rf"\1{COLON_PLACEHOLDER}",
-        sans_slash,
+        sans_parens,
     )
     sans_pipe = re.sub(
         r"([a-zA-Z_][a-zA-Z0-9_]*)\|(?=[a-zA-Z0-9_])",
@@ -138,18 +172,6 @@ def sanitize_name(s: str, sanitize_parens: bool = False) -> str:
         sans_hyphen,
     )
     result = sans_at
-
-    # Optionally sanitize parentheses that are part of metric/parameter names.
-    # Matches ``identifier(content)`` where content is purely [a-zA-Z0-9_].
-    # This intentionally also matches single-argument SymPy calls like
-    # ``log(x)``; callers that need SymPy function calls (e.g.
-    # ExpressionDerivedMetric) should leave sanitize_parens=False.
-    if sanitize_parens:
-        result = re.sub(
-            r"([a-zA-Z_][a-zA-Z0-9_]*)\(([a-zA-Z0-9_]+)\)",
-            rf"\1{LPAREN_PLACEHOLDER}\2{RPAREN_PLACEHOLDER}",
-            result,
-        )
 
     # Check for conflicts with sympy's global dictionary
     _check_sympy_conflicts(result)

--- a/ax/utils/common/tests/test_string_utils.py
+++ b/ax/utils/common/tests/test_string_utils.py
@@ -141,3 +141,81 @@ class StringUtilsTest(TestCase):
                     unsanitize_name(sanitize_name(name, sanitize_parens=True)),
                     name,
                 )
+
+    def test_sanitize_name_colon_space_and_paren_patterns(self) -> None:
+        """Test sanitization of colons adjacent to spaces, parens, and combos.
+
+        Covers colon-space, space-before-paren, paren-then-colon, and complex
+        production metric names. Each case also verifies the round-trip.
+        """
+        cases: list[tuple[str, str, bool]] = [
+            # (input, expected_sanitized, sanitize_parens)
+            # Colon followed by space.
+            ("scope: value", "scope__colon____space__value", False),
+            ("a: b: c", "a__colon____space__b__colon____space__c", False),
+            # Space before paren.
+            (
+                "Reliability (UserRID)",
+                "Reliability__space____lparen__UserRID__rparen__",
+                True,
+            ),
+            # Paren then colon.
+            (
+                "metric(p50): value",
+                "metric__lparen__p50__rparen____colon____space__value",
+                True,
+            ),
+            # Space after close-paren.
+            ("end) next", "end)__space__next", False),
+            (
+                "fn(x) next",
+                "fn__lparen__x__rparen____space__next",
+                True,
+            ),
+        ]
+        for name, expected, parens in cases:
+            with self.subTest(name=name):
+                sanitized = sanitize_name(name, sanitize_parens=parens)
+                self.assertEqual(sanitized, expected)
+                self.assertEqual(unsanitize_name(sanitized), name)
+
+    def test_sanitize_name_complex_metrics(self) -> None:
+        """Regression tests for production metric names (T261468156).
+
+        Complex metrics with colons, spaces, parens, and hyphens must
+        round-trip and must not contain raw special characters after
+        sanitization.
+        """
+        metrics = [
+            "Scope: Long Name (Qualifier): PROD:All: By Interface",
+            (
+                "Messaging: Threads Message Request TTRC"
+                " - Hidden Requests Inbox Reliability"
+                " (User RID): PROD:All: By Interface"
+            ),
+        ]
+        for metric in metrics:
+            with self.subTest(metric=metric):
+                sanitized = sanitize_name(metric, sanitize_parens=True)
+                for char in (":", " ", "(", ")"):
+                    self.assertNotIn(char, sanitized)
+                self.assertEqual(unsanitize_name(sanitized), metric)
+
+    def test_sanitize_name_hyphen_no_colon_is_subtraction(self) -> None:
+        """Without colons, ` - ` is left as subtraction (not sanitized)."""
+        self.assertEqual(
+            sanitize_name("m1 - m2", sanitize_parens=True),
+            "m1 - m2",
+        )
+
+    def test_sanitize_name_operators_unchanged(self) -> None:
+        """Spaces around mathematical operators must NOT be sanitized."""
+        cases = [
+            ("m1 + m2", "m1 + m2", False),
+            ("m1 * m2", "m1 * m2", False),
+            ("m1 >= 100", "m1 >= 100", False),
+            ("(a + b) * c", "(a + b) * c", True),
+        ]
+        for name, expected, parens in cases:
+            with self.subTest(name=name):
+                self.assertEqual(sanitize_name(name, sanitize_parens=parens), expected)


### PR DESCRIPTION
Summary:

User posts on failed to generate candidate & failed to deploy: https://fb.workplace.com/groups/ae.feedback/permalink/26796800489927946/

SymPy parsing for metric names (sanitize_name) did not handle metric
names containing patterns like `"Scope: Value"` (colon-space), `"Name (Qualifier)"`
(space-paren), or `"fn(x): next"` (paren-colon). This caused `SympifyError` when
loading experiments with such metric names, breaking both trial generation and
trial deployment in the Ax UI.

Root cause: The space sanitization regex `(?<=\w)\s+(?=\w)` only matched spaces
between word characters. Spaces adjacent to `:`, `)`, or `(` were left unsanitized,
which then prevented the colon and paren regexes from matching (they require
identifier characters on both sides).

Fix:
1. Expand the space regex to `(?<=[\w:)])\s+(?=[\w(])` so spaces after colons/
   close-parens and before open-parens are also sanitized.
2. Move paren sanitization before colon sanitization so that `__rparen__:` is
   recognized as an identifier-colon boundary.

These changes are safe because the expanded lookbehind/lookahead characters
(`:`, `)`, `(`) are never adjacent to spaces in valid mathematical expressions
— operators like `+`, `-`, `*`, `>=`, `<=` are not in the character classes.

Note: Metric names containing ` - ` (space-hyphen-space, e.g. "TTRC - Hidden")
remain ambiguous with subtraction and are NOT addressed here. After this fix,
such names will parse as subtraction (no SympifyError) but may extract incorrect
metric names. A follow-up is needed to handle this at the storage/serialization
level.

Reviewed By: ItsMrLin

Differential Revision: D98243121
