### PR TITLE
Remove deprecated ObjectiveThreshold assert_is_instance checks

### DIFF
--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -39,11 +39,7 @@ from ax.core.optimization_config import (
     OptimizationConfig,
     PreferenceOptimizationConfig,
 )
-from ax.core.outcome_constraint import (
-    ObjectiveThreshold,
-    OutcomeConstraint,
-    ScalarizedOutcomeConstraint,
-)
+from ax.core.outcome_constraint import OutcomeConstraint, ScalarizedOutcomeConstraint
 from ax.core.parameter import (
     ChoiceParameter,
     DerivedParameter,
@@ -772,7 +768,7 @@ class Encoder:
 
     def objective_threshold_to_sqa(
         self,
-        objective_threshold: ObjectiveThreshold,
+        objective_threshold: OutcomeConstraint,
         experiment_metrics: dict[str, Metric] | None = None,
     ) -> SQAMetric:
         """Convert Ax OutcomeConstraint to SQLAlchemy."""
@@ -847,9 +843,7 @@ class Encoder:
         ):
             for threshold in optimization_config.objective_thresholds:
                 threshold_sqa = self.objective_threshold_to_sqa(
-                    objective_threshold=assert_is_instance(
-                        threshold, ObjectiveThreshold
-                    ),
+                    objective_threshold=threshold,
                     experiment_metrics=experiment_metrics,
                 )
                 metrics_sqa.append(threshold_sqa)


### PR DESCRIPTION
Summary:
After the recent refactoring in D98172405 that deprecated `ObjectiveThreshold` in favor of plain `OutcomeConstraint`, two locations in the codebase still used `assert_is_instance(..., ObjectiveThreshold)` which would fail when objective thresholds are represented as plain `OutcomeConstraint` objects (the new recommended pattern).

This caused Axolotl to crash with:
```
TypeError: obj is not an instance of cls: obj=OutcomeConstraint(core_app:ecosystem:linked_sessions:fb_session_count_cap30 >= 58.924384179812996) cls=<class 'ax.core.outcome_constraint.ObjectiveThreshold'>
```

Changes:

- `ax/storage/sqa_store/encoder.py`: Updated `objective_threshold_to_sqa` to accept `OutcomeConstraint` instead of `ObjectiveThreshold`, and removed the `assert_is_instance` cast at the call site. Since `ObjectiveThreshold` is deprecated and `MultiObjectiveOptimizationConfig.objective_thresholds` is typed as `list[OutcomeConstraint]`, these assertions were incorrect.

Differential Revision: D98172405


