### PR TITLE
Add input_transform_argparse dispatcher for LearnedFeatureImputation (#5106)

### DIFF
--- a/ax/generators/torch/botorch_modular/input_constructors/input_transforms.py
+++ b/ax/generators/torch/botorch_modular/input_constructors/input_transforms.py
@@ -17,6 +17,7 @@ from ax.utils.common.typeutils import _argparse_type_encoder
 from botorch.models.transforms.input import (
     FilterFeatures,
     InputTransform,
+    LearnedFeatureImputation,
     Normalize,
     Warp,
 )
@@ -314,3 +315,100 @@ def _input_transform_argparse_filter_features(
         )
 
     return input_transform_options_copy
+
+
+@input_transform_argparse.register(LearnedFeatureImputation)
+def _input_transform_argparse_learned_feature_imputation(
+    input_transform_class: type[LearnedFeatureImputation],
+    dataset: SupervisedDataset,
+    search_space_digest: SearchSpaceDigest,
+    input_transform_options: dict[str, Any] | None = None,
+    torch_device: torch.device | None = None,
+    torch_dtype: torch.dtype | None = None,
+) -> dict[str, Any]:
+    """Extract LearnedFeatureImputation kwargs from a MultiTaskDataset.
+
+    Computes ``feature_indices`` and ``d`` from the heterogeneous feature sets
+    in the dataset, following the same convention as
+    ``HeterogeneousMTGP.construct_inputs``: the target task is placed first,
+    and the task feature column is excluded from the feature union.
+
+    Args:
+        input_transform_class: Input transform class.
+        dataset: A ``MultiTaskDataset`` with heterogeneous features.
+        search_space_digest: Search space digest.
+        input_transform_options: Optional overrides for transform kwargs.
+        torch_device: Device for the transform parameters.
+        torch_dtype: Dtype for the transform parameters.
+
+    Returns:
+        A dictionary with ``feature_indices``, ``d``, ``task_feature_index``,
+        ``bounds``, ``device``, and ``dtype`` keys.
+    """
+    if not isinstance(dataset, MultiTaskDataset):
+        raise ValueError(
+            "LearnedFeatureImputation requires a MultiTaskDataset, "
+            f"got {type(dataset).__name__}."
+        )
+    if not dataset.has_heterogeneous_features:
+        raise ValueError(
+            "LearnedFeatureImputation requires a MultiTaskDataset with "
+            "heterogeneous features (has_heterogeneous_features=True)."
+        )
+    input_transform_options = input_transform_options or {}
+
+    # Order datasets: target first, then remaining (same as HeterogeneousMTGP).
+    child_datasets = dataset.datasets.copy()
+    target_dataset = child_datasets.pop(dataset.target_outcome_name)
+    all_datasets = [target_dataset] + list(child_datasets.values())
+
+    # The feature_names[:task_feature_index] slice only works when the task
+    # column is the last column (index == -1). Guard against other positions
+    # the same way ImputedMultiTaskGP.construct_inputs does.
+    task_feature_index = (
+        dataset.task_feature_index if (dataset.task_feature_index is not None) else -1
+    )
+    if task_feature_index != -1:
+        raise NotImplementedError(
+            "LearnedFeatureImputation argparse only supports "
+            "task_feature_index == -1. Got "
+            f"task_feature_index={task_feature_index}."
+        )
+
+    # Use target's feature order as canonical (NO alphabetical sort).
+    # Source-only features are appended at the end.
+    all_features: list[str] = list(target_dataset.feature_names[:task_feature_index])
+    for ds in all_datasets[1:]:
+        for fn in ds.feature_names[:task_feature_index]:
+            if fn not in all_features:
+                all_features.append(fn)
+    d = len(all_features)
+
+    # Map each task's features to indices in the global feature space.
+    feature_indices = {
+        task_idx: [
+            all_features.index(fn) for fn in ds.feature_names[:task_feature_index]
+        ]
+        for task_idx, ds in enumerate(all_datasets)
+    }
+
+    dtype = torch_dtype or torch.float64
+    # Constrain imputation values to [0, 1] since the preceding Normalize
+    # maps features to this range. Without bounds, imputation values are
+    # unconstrained and can drift far from the valid input range.
+    bounds = torch.stack(
+        [
+            torch.zeros(d, dtype=dtype, device=torch_device),
+            torch.ones(d, dtype=dtype, device=torch_device),
+        ]
+    )
+    kwargs: dict[str, Any] = {
+        "feature_indices": feature_indices,
+        "d": d,
+        "task_feature_index": task_feature_index,
+        "bounds": bounds,
+        "device": torch_device,
+        "dtype": dtype,
+    }
+    kwargs.update(input_transform_options)
+    return kwargs

--- a/ax/generators/torch/tests/test_input_transform_argparse.py
+++ b/ax/generators/torch/tests/test_input_transform_argparse.py
@@ -22,6 +22,7 @@ from botorch.models.transforms.input import (
     FilterFeatures,
     InputStandardize,
     InputTransform,
+    LearnedFeatureImputation,
     Normalize,
     Warp,
 )
@@ -376,3 +377,193 @@ class InputTransformArgparseTest(TestCase):
                     "ignored_params": ["x0", "x1"],
                 },
             )
+
+    def test_argparse_learned_feature_imputation(self) -> None:
+        task_feature_name = Keys.TASK_FEATURE_NAME.value
+
+        # Task 0 (target): features x0, x1, x2, x3 + task
+        dataset_target = SupervisedDataset(
+            X=torch.cat([torch.rand(5, 4), torch.zeros(5, 1)], dim=-1),
+            Y=torch.randn(5, 1),
+            feature_names=["x0", "x1", "x2", "x3", task_feature_name],
+            outcome_names=["y0"],
+        )
+        # Task 1 (aux): features x0, x1 + task (subset of target features)
+        dataset_aux = SupervisedDataset(
+            X=torch.cat([torch.rand(5, 2), torch.ones(5, 1)], dim=-1),
+            Y=torch.randn(5, 1),
+            feature_names=["x0", "x1", task_feature_name],
+            outcome_names=["y1"],
+        )
+        mtds = MultiTaskDataset(
+            datasets=[dataset_target, dataset_aux],
+            target_outcome_name="y0",
+            task_feature_index=-1,
+        )
+        mt_ssd = dataclasses.replace(
+            self.search_space_digest,
+            feature_names=["x0", "x1", "x2", "x3", task_feature_name],
+            task_features=[-1],
+            bounds=[(0.0, 1.0)] * 5,
+        )
+
+        kwargs = input_transform_argparse(
+            LearnedFeatureImputation,
+            dataset=mtds,
+            search_space_digest=mt_ssd,
+        )
+
+        # all_features uses target-first ordering: ["x0","x1","x2","x3"]
+        self.assertEqual(kwargs["d"], 4)
+        # Target has all 4 features, aux has x0, x1 -> indices [0, 1]
+        self.assertEqual(kwargs["feature_indices"], {0: [0, 1, 2, 3], 1: [0, 1]})
+        self.assertEqual(kwargs["task_feature_index"], -1)
+        self.assertTrue(torch.equal(kwargs["bounds"][0], torch.zeros(4)))
+        self.assertTrue(torch.equal(kwargs["bounds"][1], torch.ones(4)))
+        self.assertEqual(kwargs["dtype"], torch.float64)
+
+        with self.subTest("non_multitask_dataset_raises"):
+            with self.assertRaisesRegex(ValueError, "requires a MultiTaskDataset"):
+                input_transform_argparse(
+                    LearnedFeatureImputation,
+                    dataset=self.dataset,
+                    search_space_digest=self.search_space_digest,
+                )
+
+        with self.subTest("homogeneous_features_raises"):
+            homogeneous_ds = MultiTaskDataset(
+                datasets=[
+                    SupervisedDataset(
+                        X=torch.rand(5, 3),
+                        Y=torch.randn(5, 1),
+                        feature_names=["x0", "x1", task_feature_name],
+                        outcome_names=["y0"],
+                    ),
+                    SupervisedDataset(
+                        X=torch.rand(5, 3),
+                        Y=torch.randn(5, 1),
+                        feature_names=["x0", "x1", task_feature_name],
+                        outcome_names=["y1"],
+                    ),
+                ],
+                target_outcome_name="y0",
+                task_feature_index=-1,
+            )
+            with self.assertRaisesRegex(ValueError, "heterogeneous features"):
+                input_transform_argparse(
+                    LearnedFeatureImputation,
+                    dataset=homogeneous_ds,
+                    search_space_digest=mt_ssd,
+                )
+
+        with self.subTest("non_last_task_feature_raises"):
+            bad_ds = MultiTaskDataset(
+                datasets=[
+                    SupervisedDataset(
+                        X=torch.rand(5, 5),
+                        Y=torch.randn(5, 1),
+                        feature_names=[task_feature_name, "x0", "x1", "x2", "x3"],
+                        outcome_names=["y0"],
+                    ),
+                    SupervisedDataset(
+                        X=torch.rand(5, 3),
+                        Y=torch.randn(5, 1),
+                        feature_names=[task_feature_name, "x0", "x1"],
+                        outcome_names=["y1"],
+                    ),
+                ],
+                target_outcome_name="y0",
+                task_feature_index=0,
+            )
+            with self.assertRaisesRegex(
+                NotImplementedError, "task_feature_index == -1"
+            ):
+                input_transform_argparse(
+                    LearnedFeatureImputation,
+                    dataset=bad_ds,
+                    search_space_digest=mt_ssd,
+                )
+
+        with self.subTest("options_override"):
+            kwargs = input_transform_argparse(
+                LearnedFeatureImputation,
+                dataset=mtds,
+                search_space_digest=mt_ssd,
+                torch_dtype=torch.float32,
+            )
+            self.assertEqual(kwargs["dtype"], torch.float32)
+
+    def test_argparse_learned_feature_imputation_feature_ordering(self) -> None:
+        """Test that feature ordering preserves target's order, not alphabetical."""
+        task_feature_name = Keys.TASK_FEATURE_NAME.value
+
+        with self.subTest("target_order_preserved_not_alphabetical"):
+            # Target: features C, A, B (NOT alphabetical)
+            target_ds = SupervisedDataset(
+                X=torch.cat([torch.rand(3, 3), torch.zeros(3, 1)], dim=-1),
+                Y=torch.randn(3, 1),
+                feature_names=["C", "A", "B", task_feature_name],
+                outcome_names=["target"],
+            )
+            # Source: features A, B (subset, different order)
+            source_ds = SupervisedDataset(
+                X=torch.cat([torch.rand(2, 2), torch.ones(2, 1)], dim=-1),
+                Y=torch.randn(2, 1),
+                feature_names=["A", "B", task_feature_name],
+                outcome_names=["source"],
+            )
+            mtds = MultiTaskDataset(
+                datasets=[target_ds, source_ds],
+                target_outcome_name="target",
+                task_feature_index=-1,
+            )
+            ssd = dataclasses.replace(
+                self.search_space_digest,
+                feature_names=["C", "A", "B", task_feature_name],
+                task_features=[-1],
+                bounds=[(0.0, 1.0)] * 4,
+            )
+            kwargs = input_transform_argparse(
+                LearnedFeatureImputation,
+                dataset=mtds,
+                search_space_digest=ssd,
+            )
+            # Canonical order should be C, A, B (target's order), not A, B, C
+            self.assertEqual(kwargs["d"], 3)
+            # Target: C, A, B -> [0, 1, 2]; Source: A, B -> [1, 2]
+            self.assertEqual(kwargs["feature_indices"], {0: [0, 1, 2], 1: [1, 2]})
+
+        with self.subTest("source_only_features_appended_at_end"):
+            # Target: A, B; Source: B, C, D (C, D are source-only)
+            target_ds = SupervisedDataset(
+                X=torch.cat([torch.rand(3, 2), torch.zeros(3, 1)], dim=-1),
+                Y=torch.randn(3, 1),
+                feature_names=["A", "B", task_feature_name],
+                outcome_names=["target"],
+            )
+            source_ds = SupervisedDataset(
+                X=torch.cat([torch.rand(2, 3), torch.ones(2, 1)], dim=-1),
+                Y=torch.randn(2, 1),
+                feature_names=["B", "C", "D", task_feature_name],
+                outcome_names=["source"],
+            )
+            mtds = MultiTaskDataset(
+                datasets=[target_ds, source_ds],
+                target_outcome_name="target",
+                task_feature_index=-1,
+            )
+            ssd = dataclasses.replace(
+                self.search_space_digest,
+                feature_names=["A", "B", "C", "D", task_feature_name],
+                task_features=[-1],
+                bounds=[(0.0, 1.0)] * 5,
+            )
+            kwargs = input_transform_argparse(
+                LearnedFeatureImputation,
+                dataset=mtds,
+                search_space_digest=ssd,
+            )
+            # Canonical order: A, B (target), then C, D (source-only, appended)
+            self.assertEqual(kwargs["d"], 4)
+            # Target: A, B -> [0, 1]; Source: B, C, D -> [1, 2, 3]
+            self.assertEqual(kwargs["feature_indices"], {0: [0, 1], 1: [1, 2, 3]})

--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -86,6 +86,7 @@ from botorch.models.transforms.input import (
     FilterFeatures,
     InputPerturbation,
     InputTransform,
+    LearnedFeatureImputation,
     Normalize,
     Round,
     Warp,
@@ -215,6 +216,7 @@ Mapping of BoTorch `InputTransform` classes to class name strings.
 """
 INPUT_TRANSFORM_REGISTRY: dict[type[InputTransform], str] = {
     ChainedInputTransform: "ChainedInputTransform",
+    LearnedFeatureImputation: "LearnedFeatureImputation",
     Normalize: "Normalize",
     Round: "Round",
     Warp: "Warp",


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexternal/botorch_fb/pull/34


Wire LearnedFeatureImputation and ImputedMultiTaskGP into Ax:

1. **input_transform_argparse dispatcher**: Computes `feature_indices` and `d`
   from a heterogeneous MultiTaskDataset using target-first feature ordering.
   Validates that the dataset is a MultiTaskDataset with heterogeneous features.

2. **Storage registry**: Register ImputedMultiTaskGP in MODEL_REGISTRY and
   LearnedFeatureImputation in INPUT_TRANSFORM_REGISTRY.

3. **Model selection (utils.py)**: When a heterogeneous MultiTaskDataset is
   detected and a model class is specified (e.g. ImputedMultiTaskGP), use the
   specified class instead of force-overriding to HeterogeneousMTGP. Also add
   automatic Normalize + LearnedFeatureImputation transform chaining for
   ImputedMultiTaskGP.

Reviewed By: sdaulton

Differential Revision: D97625733


