### PR TITLE
Respect specified model class for heterogeneous MultiTaskDatasets

### DIFF
--- a/ax/adapter/transfer_learning/adapter.py
+++ b/ax/adapter/transfer_learning/adapter.py
@@ -239,6 +239,31 @@ class TransferLearningAdapter(TorchAdapter):
 
         return experiment_data, search_space
 
+    def _compute_in_design(
+        self,
+        search_space: SearchSpace,
+        experiment_data: ExperimentData,
+    ) -> list[bool]:
+        """Compute in-design status for heterogeneous transfer learning.
+
+        Overrides base class to use check_all_parameters_present=False, which
+        tolerates extra columns in arm_data beyond the search space parameters.
+        This is necessary for heterogeneous TL where FillMissingParameters adds
+        columns for source-only parameters (e.g. 'z') to target arm data,
+        causing the default extra_params check to reject all rows.
+        """
+        experiment_data, _ = self._transform_data(
+            experiment_data=experiment_data,
+            search_space=search_space,
+            transforms=self._raw_transforms[:1],
+            transform_configs=self._transform_configs,
+            assign_transforms=False,
+        )
+        return search_space.check_membership_df(
+            arm_data=experiment_data.arm_data,
+            check_all_parameters_present=False,
+        )
+
     def get_training_data(self, filter_in_design: bool = False) -> ExperimentData:
         """Returns the training data for the current experiment, with its metadata
         updated to include the task value.

--- a/ax/adapter/transfer_learning/utils.py
+++ b/ax/adapter/transfer_learning/utils.py
@@ -81,6 +81,9 @@ def merge_parameters(
     If both are choice parameters, they will be merged into a choice parameter that
     includes the union of the values of the two parameters.
 
+    If one is a fixed parameter and the other a choice parameter, they will be
+    merged into a choice parameter whose values include the fixed value.
+
     If the parameters have dependents (for hierarchical search spaces), then the
     dependents will be merged together.
     """
@@ -91,9 +94,12 @@ def merge_parameters(
         )
     p1_type = type(p1)
     p2_type = type(p2)
+    allowed_mixed_pairs = (
+        {FixedParameter, RangeParameter},
+        {FixedParameter, ChoiceParameter},
+    )
     if (
-        p1_type is not p2_type
-        and ({p1_type, p2_type} != {FixedParameter, RangeParameter})
+        p1_type is not p2_type and ({p1_type, p2_type} not in allowed_mixed_pairs)
     ) or p1.parameter_type != p2.parameter_type:
         raise ValueError(f"Cannot merge parameters of different types: {p1}, {p2}.")
     if isinstance(p1, RangeParameter) and isinstance(p2, RangeParameter):
@@ -140,6 +146,33 @@ def merge_parameters(
             upper=max(range_param.upper, range_param.cast(fixed_param.value)),
         )
         return new_range_param
+    elif (
+        isinstance(fixed_param := p1, FixedParameter)
+        and isinstance(choice_param := p2, ChoiceParameter)
+    ) or (
+        isinstance(fixed_param := p2, FixedParameter)
+        and isinstance(choice_param := p1, ChoiceParameter)
+    ):
+        # Merge FixedParameter into ChoiceParameter by including the fixed
+        # value in the set of choice values.
+        values = list(set(choice_param.values) | {fixed_param.value})
+        return ChoiceParameter(
+            name=p1.name,
+            parameter_type=p1.parameter_type,
+            values=values,
+            is_ordered=choice_param.is_ordered,
+            is_task=choice_param.is_task,
+            is_fidelity=choice_param.is_fidelity,
+            target_value=choice_param.target_value,
+            sort_values=choice_param.sort_values,
+            dependents=merge_dependents(
+                # pyre-ignore[6]: p1/p2 are FixedParameter | ChoiceParameter here.
+                p1=p1,
+                # pyre-ignore[6]: p1/p2 are FixedParameter | ChoiceParameter here.
+                p2=p2,
+                reverse_param_config=reverse_param_config,
+            ),
+        )
     elif isinstance(p1, ChoiceParameter) and isinstance(p2, ChoiceParameter):
         return ChoiceParameter(
             name=p1.name,

--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -295,23 +295,16 @@ def choose_model_class(
             "Multi-task multi-fidelity optimization not yet supported."
         )
 
-    # Check for heterogeneous multi-task datasets & override model class if needed.
+    # Check for heterogeneous multi-task datasets & use specified model class.
     if (
         search_space_digest.task_features
         and isinstance(dataset, MultiTaskDataset)
         and dataset.has_heterogeneous_features
     ):
-        if (
-            specified_model_class is not None
-            and specified_model_class is not HeterogeneousMTGP
-        ):
-            logger.warning(
-                f"Detected heterogeneous features in MultiTaskDataset. "
-                f"Overriding specified model class {specified_model_class.__name__} "
-                f"with HeterogeneousMTGP for transfer learning with "
-                f"heterogeneous search spaces."
-            )
-        model_class = HeterogeneousMTGP
+        if specified_model_class is not None:
+            model_class = specified_model_class
+        else:
+            model_class = HeterogeneousMTGP
         logger.debug(f"Chose BoTorch model class: {model_class}.")
         return model_class
 

--- a/ax/generators/torch/tests/test_utils.py
+++ b/ax/generators/torch/tests/test_utils.py
@@ -198,12 +198,10 @@ class BoTorchGeneratorUtilsTest(TestCase):
         # Assert: Should select HeterogeneousMTGP for heterogeneous features
         self.assertEqual(HeterogeneousMTGP, model_class)
 
-    def test_choose_model_class_heterogeneous_overrides_specified(self) -> None:
-        # Test that HeterogeneousMTGP overrides a pre-specified model class
-        # when heterogeneous features are detected
+    def test_choose_model_class_heterogeneous_respects_specified(self) -> None:
+        # Test that specified model class is respected for heterogeneous datasets.
         mt_dataset = self._get_heterogeneous_mt_dataset()
 
-        # Execute: Try to specify MultiTaskGP explicitly
         model_class = choose_model_class(
             dataset=mt_dataset,
             search_space_digest=dataclasses.replace(
@@ -212,8 +210,7 @@ class BoTorchGeneratorUtilsTest(TestCase):
             specified_model_class=MultiTaskGP,
         )
 
-        # Assert: Should override to HeterogeneousMTGP despite specification
-        self.assertEqual(HeterogeneousMTGP, model_class)
+        self.assertEqual(MultiTaskGP, model_class)
 
     def test_choose_model_class_respects_specified_when_no_override_needed(
         self,

--- a/ax/storage/botorch_modular_registry.py
+++ b/ax/storage/botorch_modular_registry.py
@@ -338,3 +338,14 @@ def register_mll(mll_class: type[MarginalLogLikelihood]) -> None:
     class_name = mll_class.__name__
     CLASS_TO_REGISTRY[MarginalLogLikelihood].update({mll_class: class_name})
     CLASS_TO_REVERSE_REGISTRY[MarginalLogLikelihood].update({class_name: mll_class})
+
+
+def register_input_transform(
+    input_transform_class: type[InputTransform],
+) -> None:
+    """Add a custom input transform class to the SQA and JSON registries."""
+    class_name = input_transform_class.__name__
+    CLASS_TO_REGISTRY[InputTransform].update({input_transform_class: class_name})
+    CLASS_TO_REVERSE_REGISTRY[InputTransform].update(
+        {class_name: input_transform_class}
+    )


### PR DESCRIPTION
Summary:
Previously, `choose_model_class` in `utils.py` would always force-override
any user-specified model class to `HeterogeneousMTGP` when a heterogeneous
`MultiTaskDataset` was detected. This made it impossible to use alternative
models for heterogeneous transfer learning (e.g., `ImputedMultiTaskGP`).

This diff changes the behavior so that when a `specified_model_class` is
provided by the user (via `ModelConfig.botorch_model_class`), it is respected
for heterogeneous datasets. When no model class is specified, the default
behavior of selecting `HeterogeneousMTGP` is preserved.

This is a prerequisite for using `ImputedMultiTaskGP` through Ax's model
selection pipeline with heterogeneous search spaces.

Differential Revision: D98672892


