### PR TITLE
Bump MAX_VALUES_CHOICE_PARAM from 1000 to 1001 (#5116)

### DIFF
--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -40,7 +40,7 @@ logger: Logger = get_logger(__name__)
 # TODO: Do a more comprehensive audit of how floating point precision issues
 # may creep up and implement a more principled fix
 EPS = 1.5e-7
-MAX_VALUES_CHOICE_PARAM = 1000
+MAX_VALUES_CHOICE_PARAM = 1001
 FIXED_CHOICE_PARAM_ERROR = (
     "ChoiceParameters require multiple feasible values. "
     "Please use FixedParameter instead when setting a single possible value."

--- a/ax/core/tests/test_parameter.py
+++ b/ax/core/tests/test_parameter.py
@@ -490,17 +490,17 @@ class ChoiceParameterTest(TestCase):
         ChoiceParameter(
             name="x",
             parameter_type=ParameterType.INT,
-            values=list(range(999)),
+            values=list(range(1000)),
         )
         with self.assertRaisesRegex(
             UserInputError,
-            "`ChoiceParameter` with more than 1000 values is not supported! Use a "
+            "`ChoiceParameter` with more than 1001 values is not supported! Use a "
             "`RangeParameter` instead.",
         ):
             ChoiceParameter(
                 name="x",
                 parameter_type=ParameterType.INT,
-                values=list(range(1001)),
+                values=list(range(1002)),
             )
         # With bypass_cardinality_check=True, this should not raise an error.
         p = ChoiceParameter(


### PR DESCRIPTION
Summary:

 ## Summary:
Bump `MAX_VALUES_CHOICE_PARAM` from 1000 to 1001 in Ax `ChoiceParameter` to fix GitHub issue facebook/Ax #5108.

Users commonly want to split [0, 1] in 0.001 steps, yielding 1001 elements. The previous limit of 1000 blocked this natural use case. Updated the constant in `parameter.py` and adjusted 3 test values in `test_parameter.py` to match the new limit.

Internal
---
## Instructions about RACER Diffs:
**Commandeer this diff (recommended) or land with accept2ship tag.**

**This diff was generated by Racer AI agent on behalf of [Cesar Cardoso](https://www.internalfb.com/profile/view/100028184453680) for T262124460. If the diff quality is poor, consider contacting the user to provide clearer instructions on the task.**

- If you are happy with the changes, commandeer it if minor edits are needed. (**we encourage commandeer to get the diff credit**)
- If you are not happy with the changes, please comment on the diff with clear actions and send it back to the author. Racer will pick it up and re-generate.
- If you really feel the Racer is not helping with this change (alas, some complex changes are hard for AI) feel free to abandon this diff.
- **For M10N reviewers:** as you review AI-generated diffs, we ask you to give them the same priority as human-generated diffs, and take action in a timely manner by either accepting, rejecting, or resigning as a reviewer. For diffs that don't meet the quality bar (e.g. code doesn't compile, not readable or introduces functionality regressions), we ask that you use the following hashtags to provide clear signals to improve our tools - `#monlowqualitydiff` `#monwrongreviewerdiff`
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=f5214618-2c52-11f1-b857-dd63b4a9f85c&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=f5214618-2c52-11f1-b857-dd63b4a9f85c&tab=Trace)

Reviewed By: Cesar-Cardoso

Differential Revision: D98747907


