### PR TITLE
Add toggle_label field to AnalysisCardBase for custom subtitle expansion text (#5124)

### DIFF
--- a/ax/core/analysis_card.py
+++ b/ax/core/analysis_card.py
@@ -18,6 +18,8 @@ from ax.utils.tutorials.environment import is_running_in_papermill
 from IPython.display import display, HTML, Markdown
 from plotly.offline import get_plotlyjs
 
+DEFAULT_SUBTITLE_TOGGLE_LABEL: str = "See more"
+
 # Simple HTML template for rendering a card with a title, subtitle, and body with
 # scrollable overflow. Subtitles are rendered in a <div> with max-height overflow
 # so that any HTML content (tables, lists, etc.) is valid and clipped correctly
@@ -54,11 +56,11 @@ html_card_template = """
     display: none;
 }}
 </style>
-<div class="card">
+<div class="card" id="{card_id}">
     <div class="card-header">
         <b>{title_str}</b>
         <div class="card-subtitle">{subtitle_str}</div>
-        <button class="card-subtitle-toggle">See more</button>
+        <button class="card-subtitle-toggle">{toggle_text}</button>
     </div>
     <div class="card-body">
         {body_html}
@@ -66,10 +68,12 @@ html_card_template = """
 </div>
 <script>
 (function() {{
-    var card = document.currentScript.previousElementSibling;
+    var card = document.getElementById('{card_id}');
+    if (!card) return;
     var subtitle = card.querySelector('.card-subtitle');
     var toggle = card.querySelector('.card-subtitle-toggle');
     if (subtitle && toggle) {{
+        var originalText = toggle.textContent;
         requestAnimationFrame(function() {{
             if (subtitle.scrollHeight > subtitle.clientHeight
                     || subtitle.scrollWidth > subtitle.clientWidth) {{
@@ -81,7 +85,7 @@ html_card_template = """
                 subtitle.style.maxHeight = '1.4em';
                 subtitle.style.whiteSpace = 'nowrap';
                 subtitle.style.textOverflow = 'ellipsis';
-                toggle.textContent = 'See more';
+                toggle.textContent = originalText;
             }} else {{
                 subtitle.style.maxHeight = 'none';
                 subtitle.style.whiteSpace = 'normal';
@@ -154,6 +158,7 @@ class AnalysisCardBase(SortableBase, ABC):
 
     title: str
     subtitle: str
+    subtitle_toggle_label: str
 
     _timestamp: datetime
 
@@ -163,6 +168,7 @@ class AnalysisCardBase(SortableBase, ABC):
         title: str,
         subtitle: str,
         timestamp: datetime | None = None,
+        subtitle_toggle_label: str = DEFAULT_SUBTITLE_TOGGLE_LABEL,
     ) -> None:
         """
         Args:
@@ -175,10 +181,16 @@ class AnalysisCardBase(SortableBase, ABC):
             timestamp: The time at which the Analysis was computed. This can be
                 especially useful when querying the database for the most recently
                 produced artifacts.
+            subtitle_toggle_label: Custom label for the subtitle
+                expansion toggle. When non-empty, replaces the default
+                "See more" text. An empty string is converted to the
+                default. Persisted to storage and used by both notebook
+                and web UI rendering.
         """
         self.name = name
         self.title = title
         self.subtitle = subtitle
+        self.subtitle_toggle_label = subtitle_toggle_label
         self._timestamp = timestamp if timestamp is not None else datetime.now()
 
     @abstractmethod
@@ -258,10 +270,16 @@ class AnalysisCardBase(SortableBase, ABC):
         return plotlyjs_script + self._to_html(depth=0)
 
     def _to_html(self, depth: int) -> str:
+        toggle_text = self.subtitle_toggle_label or DEFAULT_SUBTITLE_TOGGLE_LABEL
+        # Use id(self) so each card gets a unique HTML element ID even when
+        # multiple cards share the same name.
+        card_id = f"ax-card-{id(self)}"
         return html_card_template.format(
+            card_id=card_id,
             title_str=self.title,
             subtitle_str=self.subtitle,
             body_html=self._body_html(depth=depth),
+            toggle_text=toggle_text,
         )
 
 
@@ -282,6 +300,7 @@ class AnalysisCardGroup(AnalysisCardBase):
         subtitle: str | None,
         children: Sequence[AnalysisCardBase],
         timestamp: datetime | None = None,
+        subtitle_toggle_label: str = DEFAULT_SUBTITLE_TOGGLE_LABEL,
     ) -> None:
         """
         Args:
@@ -294,12 +313,16 @@ class AnalysisCardGroup(AnalysisCardBase):
             timestamp: The time at which the Analysis was computed. This can be
                 especially useful when querying the database for the most recently
                 produced artifacts.
+            subtitle_toggle_label: Custom label for the subtitle expansion
+                toggle. When non-empty, replaces the default "See more" text.
+                An empty string is converted to the default.
         """
         super().__init__(
             name=name,
             title=title,
             subtitle=subtitle if subtitle is not None else "",
             timestamp=timestamp,
+            subtitle_toggle_label=subtitle_toggle_label,
         )
 
         self.children = [
@@ -404,6 +427,7 @@ class AnalysisCard(AnalysisCardBase):
         df: pd.DataFrame,
         blob: str,
         timestamp: datetime | None = None,
+        subtitle_toggle_label: str = DEFAULT_SUBTITLE_TOGGLE_LABEL,
     ) -> None:
         """
         Args:
@@ -417,12 +441,16 @@ class AnalysisCard(AnalysisCardBase):
             timestamp: The time at which the Analysis was computed. This can be
                 especially useful when querying the database for the most recently
                 produced artifacts.
+            subtitle_toggle_label: Custom label for the subtitle expansion
+                toggle. When non-empty, replaces the default "See more" text.
+                An empty string is converted to the default.
         """
         super().__init__(
             name=name,
             title=title,
             subtitle=subtitle,
             timestamp=timestamp,
+            subtitle_toggle_label=subtitle_toggle_label,
         )
 
         self.df = df

--- a/ax/core/tests/test_analysis_card.py
+++ b/ax/core/tests/test_analysis_card.py
@@ -14,35 +14,36 @@ from ax.utils.common.testutils import TestCase
 from plotly import graph_objects as go, io as pio
 
 
-class TestAnalysisCard(TestCase):
-    def test_hierarchy_str(self) -> None:
-        test_df = pd.DataFrame(
-            columns=["a", "b"],
-            data=[
-                [1, 2],
-                [3, 4],
-            ],
-        )
+DUMMY_DF: pd.DataFrame = pd.DataFrame(
+    columns=["a", "b"],
+    data=[[1, 2], [3, 4]],
+)
 
-        base_analysis_card = AnalysisCard(
+
+class TestAnalysisCard(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.base_card = AnalysisCard(
             name="test_base_analysis_card",
             title="test_base_analysis_card_title",
             subtitle="test_subtitle",
-            df=test_df,
+            df=DUMMY_DF,
             blob="test blob",
         )
+
+    def test_hierarchy_str(self) -> None:
         markdown_analysis_card = MarkdownAnalysisCard(
             name="test_markdown_analysis_card",
             title="test_markdown_analysis_card_title",
             subtitle="test_subtitle",
-            df=test_df,
+            df=DUMMY_DF,
             blob="This is some **really cool** markdown",
         )
         plotly_analysis_card = PlotlyAnalysisCard(
             name="test_plotly_analysis_card",
             title="test_plotly_analysis_card_title",
             subtitle="test_subtitle",
-            df=test_df,
+            df=DUMMY_DF,
             blob=pio.to_json(go.Figure()),
         )
 
@@ -51,7 +52,7 @@ class TestAnalysisCard(TestCase):
             name="small_group",
             title="Small Group",
             subtitle="This is a small group with just a few cards",
-            children=[base_analysis_card, markdown_analysis_card],
+            children=[self.base_card, markdown_analysis_card],
         )
         big_group = AnalysisCardGroup(
             name="big_group",
@@ -78,3 +79,47 @@ class TestAnalysisCard(TestCase):
             blob="Explanation text.",
         )
         self.assertIn("Explanation text.", card._body_html(depth=0))
+
+    def test_subtitle_toggle_label_rendering(self) -> None:
+        """Verify subtitle_toggle_label controls toggle button text in HTML."""
+        for label, expected_text in (
+            ("", "See more"),
+            (
+                "Expand to see annotated parameters.",
+                "Expand to see annotated parameters.",
+            ),
+        ):
+            with self.subTest(label=label):
+                card = AnalysisCard(
+                    name="Test",
+                    title="Title",
+                    subtitle="A long subtitle",
+                    df=pd.DataFrame(),
+                    blob="blob",
+                    subtitle_toggle_label=label,
+                )
+                self.assertEqual(card.subtitle_toggle_label, label)
+                html = card._repr_html_()
+                self.assertIn(expected_text, html)
+
+    def test_analysis_card_group_html_does_not_render_toggle(self) -> None:
+        """AnalysisCardGroup._to_html uses html_group_card_template which renders
+        the subtitle as a plain <p> tag (no collapsible toggle). Verify the group's
+        own subtitle_toggle_label is stored but not rendered in the group header."""
+
+        group = AnalysisCardGroup(
+            name="G",
+            title="GT",
+            subtitle="GS",
+            children=[self.base_card],
+            subtitle_toggle_label="Custom toggle.",
+        )
+        self.assertEqual(group.subtitle_toggle_label, "Custom toggle.")
+
+        html = group._to_html(depth=0)
+
+        # The group template uses a plain <p> for subtitles, not the
+        # collapsible card-subtitle + toggle-button pattern.
+        self.assertNotIn("Custom toggle.", html)
+        self.assertIn('<p class="group-subtitle">', html)
+        self.assertIn("GS", html)

--- a/ax/storage/json_store/encoders.py
+++ b/ax/storage/json_store/encoders.py
@@ -89,6 +89,7 @@ def analysis_card_to_dict(card: AnalysisCard) -> dict[str, Any]:
         "df": card.df,
         "blob": card.blob,
         "timestamp": card._timestamp,
+        "subtitle_toggle_label": card.subtitle_toggle_label,
     }
 
 
@@ -101,6 +102,7 @@ def analysis_card_group_to_dict(group: AnalysisCardGroup) -> dict[str, Any]:
         "subtitle": group.subtitle,
         "children": group.children,
         "timestamp": group._timestamp,
+        "subtitle_toggle_label": group.subtitle_toggle_label,
     }
 
 

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -426,6 +426,7 @@ TEST_CASES: list[tuple[str, Callable[..., Any]]] = [
             subtitle="subtitle",
             df=pd.DataFrame({"a": [1, 2]}),
             blob="blob_str",
+            subtitle_toggle_label="Expand to see details.",
         ),
     ),
     (
@@ -486,6 +487,7 @@ TEST_CASES: list[tuple[str, Callable[..., Any]]] = [
             subtitle="na subtitle",
             df=pd.DataFrame(),
             blob="Not enough data.",
+            subtitle_toggle_label="Expand to see why.",
         ),
     ),
     (
@@ -510,6 +512,7 @@ TEST_CASES: list[tuple[str, Callable[..., Any]]] = [
                     blob="# md",
                 ),
             ],
+            subtitle_toggle_label="Expand to see children.",
         ),
     ),
 ]
@@ -648,6 +651,64 @@ class JSONStoreTest(TestCase):
                     )
                 else:
                     raise e
+
+    def test_EncodeDecodeAnalysisCardSubtitleToggleLabel(self) -> None:
+        """Verify decoding old JSON missing subtitle_toggle_label falls back to
+        the constructor default (backwards compatibility).
+        """
+
+        # GIVEN old AnalysisCard JSON missing the subtitle_toggle_label key
+        with self.subTest(msg="backward compatible - AnalysisCard"):
+            restored = object_from_json(
+                {
+                    "__type": "AnalysisCard",
+                    "name": "OldCard",
+                    "title": "T",
+                    "subtitle": "S",
+                    "df": {"__type": "DataFrame", "value": "{}"},
+                    "blob": "b",
+                    "timestamp": {
+                        "__type": "datetime",
+                        "value": "2025-01-01 00:00:00.000000",
+                    },
+                },
+                decoder_registry=CORE_DECODER_REGISTRY,
+                class_decoder_registry=CORE_CLASS_DECODER_REGISTRY,
+            )
+            self.assertEqual(restored.subtitle_toggle_label, "See more")
+
+        # GIVEN old AnalysisCardGroup JSON missing subtitle_toggle_label
+        with self.subTest(msg="backward compatible - AnalysisCardGroup"):
+            restored_group = object_from_json(
+                {
+                    "__type": "AnalysisCardGroup",
+                    "name": "OldGroup",
+                    "title": "GT",
+                    "subtitle": "GS",
+                    "children": [
+                        {
+                            "__type": "AnalysisCard",
+                            "name": "C",
+                            "title": "CT",
+                            "subtitle": "CS",
+                            "df": {"__type": "DataFrame", "value": "{}"},
+                            "blob": "b",
+                            "timestamp": {
+                                "__type": "datetime",
+                                "value": "2025-01-01 00:00:00.000000",
+                            },
+                        }
+                    ],
+                    "timestamp": {
+                        "__type": "datetime",
+                        "value": "2025-01-01 00:00:00.000000",
+                    },
+                },
+                decoder_registry=CORE_DECODER_REGISTRY,
+                class_decoder_registry=CORE_CLASS_DECODER_REGISTRY,
+            )
+            self.assertEqual(restored_group.subtitle_toggle_label, "")
+            self.assertEqual(restored_group.children[0].subtitle_toggle_label, "")
 
     def test_EncodeDecode_dataclass_with_initvar(self) -> None:
         @dataclasses.dataclass

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -23,6 +23,7 @@ from ax.core.analysis_card import (
     AnalysisCard,
     AnalysisCardBase,
     AnalysisCardGroup,
+    DEFAULT_SUBTITLE_TOGGLE_LABEL,
     ErrorAnalysisCard,
     NotApplicableStateAnalysisCard,
 )
@@ -1163,6 +1164,7 @@ class Decoder:
                 analysis_card_sqa.title if analysis_card_sqa.title is not None else ""
             )
             subtitle = analysis_card_sqa.subtitle
+            subtitle_toggle_label = analysis_card_sqa.subtitle_toggle_label or DEFAULT_SUBTITLE_TOGGLE_LABEL
 
             return AnalysisCardGroup(
                 name=analysis_card_sqa.name,
@@ -1170,12 +1172,14 @@ class Decoder:
                 subtitle=subtitle,
                 children=children,
                 timestamp=analysis_card_sqa.timestamp,
+                subtitle_toggle_label=subtitle_toggle_label,
             )
 
         title = none_throws(analysis_card_sqa.title)
         subtitle = none_throws(analysis_card_sqa.subtitle)
         blob = none_throws(analysis_card_sqa.blob)
         blob_annotation = analysis_card_sqa.blob_annotation
+        subtitle_toggle_label = analysis_card_sqa.subtitle_toggle_label or ""
 
         if blob_annotation == "not_applicable_state":
             return NotApplicableStateAnalysisCard(
@@ -1185,6 +1189,7 @@ class Decoder:
                 df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
                 blob=blob,
                 timestamp=analysis_card_sqa.timestamp,
+                subtitle_toggle_label=subtitle_toggle_label,
             )
         if blob_annotation == "error":
             return ErrorAnalysisCard(
@@ -1194,6 +1199,7 @@ class Decoder:
                 df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
                 blob=blob,
                 timestamp=analysis_card_sqa.timestamp,
+                subtitle_toggle_label=subtitle_toggle_label,
             )
         if blob_annotation == "plotly":
             return PlotlyAnalysisCard(
@@ -1203,6 +1209,7 @@ class Decoder:
                 df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
                 blob=blob,
                 timestamp=analysis_card_sqa.timestamp,
+                subtitle_toggle_label=subtitle_toggle_label,
             )
         if blob_annotation == "markdown":
             return MarkdownAnalysisCard(
@@ -1212,6 +1219,7 @@ class Decoder:
                 df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
                 blob=blob,
                 timestamp=analysis_card_sqa.timestamp,
+                subtitle_toggle_label=subtitle_toggle_label,
             )
         if blob_annotation == "healthcheck":
             return HealthcheckAnalysisCard(
@@ -1221,6 +1229,7 @@ class Decoder:
                 df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
                 blob=blob,
                 timestamp=analysis_card_sqa.timestamp,
+                subtitle_toggle_label=subtitle_toggle_label,
             )
         if blob_annotation == "graphviz":
             return GraphvizAnalysisCard(
@@ -1230,6 +1239,7 @@ class Decoder:
                 df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
                 blob=blob,
                 timestamp=analysis_card_sqa.timestamp,
+                subtitle_toggle_label=subtitle_toggle_label,
             )
         return AnalysisCard(
             name=analysis_card_sqa.name,
@@ -1238,6 +1248,7 @@ class Decoder:
             df=read_json(StringIO(analysis_card_sqa.dataframe_json)),
             blob=blob,
             timestamp=analysis_card_sqa.timestamp,
+            subtitle_toggle_label=subtitle_toggle_label,
         )
 
     def _metric_from_sqa_util(self, metric_sqa: SQAMetric) -> Metric:

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -1264,6 +1264,7 @@ class Encoder:
                 dataframe_json=None,
                 blob=None,
                 blob_annotation=None,
+                subtitle_toggle_label=analysis_card.subtitle_toggle_label or None,
             )
 
             for i, child_card in enumerate(analysis_card.children):
@@ -1304,4 +1305,5 @@ class Encoder:
             dataframe_json=card.df.to_json(),
             blob=card.blob,
             blob_annotation=blob_annotation,
+            subtitle_toggle_label=card.subtitle_toggle_label or None,
         )

--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -455,6 +455,9 @@ class SQAAnalysisCard(Base):
     blob_annotation: Column[str | None] = Column(
         String(NAME_OR_TYPE_FIELD_LENGTH), nullable=True
     )
+    subtitle_toggle_label: Column[str | None] = Column(
+        "subtitle_toggle_label", String(LONG_STRING_FIELD_LENGTH), nullable=True
+    )
     parent: Any = relationship(
         "SQAAnalysisCard",
         back_populates="children",

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -18,6 +18,8 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pandas as pd
 from ax.adapter.registry import Generators
+from ax.analysis.graphviz.graphviz_analysis import GraphvizAnalysisCard
+from ax.analysis.healthcheck.healthcheck_analysis import HealthcheckAnalysisCard
 from ax.analysis.markdown.markdown_analysis import MarkdownAnalysisCard
 from ax.analysis.plotly.plotly_analysis import PlotlyAnalysisCard
 from ax.api.utils.generation_strategy_dispatch import (
@@ -3019,6 +3021,7 @@ class SQAStoreTest(TestCase):
             subtitle="test_subtitle",
             df=test_df,
             blob="test blob",
+            subtitle_toggle_label="Expand to see details.",
         )
         markdown_analysis_card = MarkdownAnalysisCard(
             name="test_markdown_analysis_card",
@@ -3034,12 +3037,29 @@ class SQAStoreTest(TestCase):
             df=test_df,
             blob=pio.to_json(go.Figure()),
         )
+        healthcheck_card = HealthcheckAnalysisCard(
+            name="test_healthcheck_card",
+            title="test_title",
+            subtitle="test_subtitle",
+            df=test_df,
+            blob='{"status": 0}',
+            subtitle_toggle_label="Expand to see healthcheck.",
+        )
+        graphviz_card = GraphvizAnalysisCard(
+            name="test_graphviz_card",
+            title="test_title",
+            subtitle="test_subtitle",
+            df=test_df,
+            blob="digraph {}",
+            subtitle_toggle_label="Expand to see graph.",
+        )
         na_card = NotApplicableStateAnalysisCard(
             name="test_na_card",
             title="test_title",
             subtitle="test_subtitle",
             df=test_df,
             blob="Not enough data.",
+            subtitle_toggle_label="Expand to see why.",
         )
 
         # Create two groups which hold the leaf cards
@@ -3052,8 +3072,11 @@ class SQAStoreTest(TestCase):
                 base_analysis_card,
                 markdown_analysis_card,
                 plotly_analysis_card,
+                healthcheck_card,
+                graphviz_card,
                 na_card,
             ],
+            subtitle_toggle_label="Expand to see group children.",
         )
         big_group = AnalysisCardGroup(
             name="big_group",
@@ -3083,12 +3106,14 @@ class SQAStoreTest(TestCase):
             self.assertEqual(loaded_big_group.name, big_group.name)
             self.assertEqual(loaded_big_group.title, big_group.title)
             self.assertEqual(loaded_big_group.subtitle, big_group.subtitle)
+            self.assertEqual(loaded_big_group.subtitle_toggle_label, "See more")
 
             loaded_big_group_plotly = assert_is_instance(
                 loaded_big_group.children[0], PlotlyAnalysisCard
             )
             self.assertEqual(loaded_big_group_plotly.name, plotly_analysis_card.name)
             self.assertEqual(loaded_big_group_plotly.blob, plotly_analysis_card.blob)
+            self.assertEqual(loaded_big_group_plotly.subtitle_toggle_label, "See more")
 
             loaded_small_group = assert_is_instance(
                 loaded_big_group.children[1], AnalysisCardGroup
@@ -3096,30 +3121,63 @@ class SQAStoreTest(TestCase):
             self.assertEqual(loaded_small_group.name, small_group.name)
             self.assertEqual(loaded_small_group.title, small_group.title)
             self.assertEqual(loaded_small_group.subtitle, small_group.subtitle)
+            self.assertEqual(
+                loaded_small_group.subtitle_toggle_label,
+                "Expand to see group children.",
+            )
 
             loaded_base = assert_is_instance(
                 loaded_small_group.children[0], AnalysisCard
             )
             self.assertEqual(loaded_base.name, base_analysis_card.name)
             self.assertEqual(loaded_base.blob, base_analysis_card.blob)
+            self.assertEqual(
+                loaded_base.subtitle_toggle_label, "Expand to see details."
+            )
 
             loaded_markdown = assert_is_instance(
                 loaded_small_group.children[1], MarkdownAnalysisCard
             )
             self.assertEqual(loaded_markdown.name, markdown_analysis_card.name)
             self.assertEqual(loaded_markdown.blob, markdown_analysis_card.blob)
+            self.assertEqual(loaded_markdown.subtitle_toggle_label, "See more")
 
             loaded_small_group_plotly = assert_is_instance(
                 loaded_small_group.children[2], PlotlyAnalysisCard
             )
             self.assertEqual(loaded_small_group_plotly.name, plotly_analysis_card.name)
             self.assertEqual(loaded_small_group_plotly.blob, plotly_analysis_card.blob)
+            self.assertEqual(loaded_small_group_plotly.subtitle_toggle_label, "See more")
+
+            loaded_healthcheck = assert_is_instance(
+                loaded_small_group.children[3], HealthcheckAnalysisCard
+            )
+            self.assertEqual(loaded_healthcheck.name, healthcheck_card.name)
+            self.assertEqual(loaded_healthcheck.blob, healthcheck_card.blob)
+            self.assertEqual(
+                loaded_healthcheck.subtitle_toggle_label,
+                "Expand to see healthcheck.",
+            )
+
+            loaded_graphviz = assert_is_instance(
+                loaded_small_group.children[4], GraphvizAnalysisCard
+            )
+            self.assertEqual(loaded_graphviz.name, graphviz_card.name)
+            self.assertEqual(loaded_graphviz.blob, graphviz_card.blob)
+            self.assertEqual(
+                loaded_graphviz.subtitle_toggle_label,
+                "Expand to see graph.",
+            )
 
             loaded_na = assert_is_instance(
-                loaded_small_group.children[3], NotApplicableStateAnalysisCard
+                loaded_small_group.children[5], NotApplicableStateAnalysisCard
             )
             self.assertEqual(loaded_na.name, na_card.name)
             self.assertEqual(loaded_na.blob, na_card.blob)
+            self.assertEqual(
+                loaded_na.subtitle_toggle_label,
+                "Expand to see why.",
+            )
 
     def test_delete_generation_strategy(self) -> None:
         # GIVEN an experiment with a generation strategy


### PR DESCRIPTION
Summary:

Adds a serializable `toggle_label: str` field to `AnalysisCardBase` that allows
analyses to customize the subtitle expand/collapse toggle button text.

When non-empty, `toggle_label` replaces the default "See more" text with
a context-specific label (e.g., "Expand to see annotated parameters.").
The field is persisted to both SQA and JSON storage backends, and used by
the notebook HTML template for rendering.

Changes:
- Add `toggle_label` field + constructor param (default "") to AnalysisCardBase
- Update notebook `_to_html()` to use `self.toggle_label or "See more"`
- Add `toggle_label` nullable column to SQAAnalysisCard
- Update SQA encoder/decoder (all 8 card-type callsites)
- Update JSON encoder for both card and group dicts
- Unit tests

Reviewed By: bernardbeckerman

Differential Revision: D98738752
