### PR TITLE
Drop all-NaN step index from observation_data

### DIFF
--- a/ax/adapter/transforms/tests/test_stratified_standardize_y_transform.py
+++ b/ax/adapter/transforms/tests/test_stratified_standardize_y_transform.py
@@ -24,7 +24,10 @@ from ax.core.search_space import SearchSpace
 from ax.core.types import ComparisonOp, TParamValue
 from ax.exceptions.core import DataRequiredError
 from ax.utils.common.testutils import TestCase
-from ax.utils.testing.core_stubs import get_experiment_with_observations
+from ax.utils.testing.core_stubs import (
+    get_branin_experiment_with_timestamp_map_metric,
+    get_experiment_with_observations,
+)
 from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 
@@ -505,4 +508,31 @@ class StratifiedStandardizeYTransformTest(TestCase):
                 [w for _, w in untransformed_constraint.metric_weights],
                 original_weights,
             )
+        )
+
+    def test_with_filtered_map_data(self) -> None:
+        """Regression test: StratifiedStandardizeY should not raise when the
+        experiment has mixed map/non-map metrics but all map metric rows are
+        filtered out (leaving an all-NaN step column)."""
+        exp = get_branin_experiment_with_timestamp_map_metric(
+            with_trials_and_data=True,
+            with_choice_parameter=True,
+        )
+        # All trials are RUNNING. With fit_only_completed_map_metrics=True
+        # (the default), map metric rows are filtered out, leaving only
+        # the non-map "branin" metric with all-NaN step values.
+        experiment_data = extract_experiment_data(
+            experiment=exp,
+            data_loader_config=DataLoaderConfig(fit_only_completed_map_metrics=True),
+        )
+        # The observation_data should have a 2-level index (no step level).
+        self.assertEqual(
+            experiment_data.observation_data.index.names,
+            ["trial_index", "arm_name"],
+        )
+        # StratifiedStandardizeY should not raise.
+        StratifiedStandardizeY(
+            search_space=exp.search_space,
+            experiment_data=experiment_data,
+            config={"parameter_name": "x2"},
         )

--- a/ax/core/data_utils.py
+++ b/ax/core/data_utils.py
@@ -486,10 +486,21 @@ def _extract_observation_data(
     if df.empty:
         df = df.assign(mean=None, sem=None)
 
+    # Determine whether the step column carries meaningful (non-NaN) data.
+    # After filtering, all rows with real step values may have been removed
+    # (e.g., when fit_only_completed_map_metrics=True filters out map metric
+    # rows). In that case, we should not include step in the index — the data
+    # is semantically non-map.
+    has_step = (
+        data.has_step_column and MAP_KEY in df.columns and not df[MAP_KEY].isna().all()
+    )
+
     # Identify potential metadata columns.
     index_cols = ["trial_index", "arm_name"]
-    if data.has_step_column:
+    if has_step:
         index_cols.append(MAP_KEY)
+    elif MAP_KEY in df.columns:
+        df = df.drop(columns=[MAP_KEY])
 
     standard_columns = set(index_cols).union(
         {"metric_name", "metric_signature", "mean", "sem"}

--- a/ax/core/tests/test_data_utils.py
+++ b/ax/core/tests/test_data_utils.py
@@ -279,6 +279,12 @@ class TestDataUtils(TestCase):
         metrics = set(experiment_data.metric_signatures)
         self.assertEqual(metrics, {"branin"})
         self.assertEqual(len(experiment_data.observation_data), 2)
+        # Since all map metric rows were filtered out, the step index level
+        # (which would be all NaN) should be dropped, leaving a 2-level index.
+        self.assertEqual(
+            experiment_data.observation_data.index.names,
+            ["trial_index", "arm_name"],
+        )
         # Complete a trial to include map metrics.
         exp.trials[0].complete()
         experiment_data = extract_experiment_data(


### PR DESCRIPTION
Summary:
`StratifiedStandardizeY` throws `NotImplementedError` when `observation_data` has a 3-level index `(trial_index, arm_name, step)`, even when `step` is all NaN — meaning the data is semantically non-map data.

The most common trigger is the new `Client` API: `Client.attach_data` unconditionally wraps user data as `TMapTrialEvaluation` with `step=np.nan` when no `progression` is provided (the default for non-timeseries optimization). This means **every** `Client` user's `Data` has `has_step_column=True` with all-NaN step values, causing `StratifiedStandardizeY` and `TimeAsFeature` to crash.

The same issue also arises with the older `AxClient`/`Adapter` path when an experiment has mixed map and non-map metrics and filtering (e.g., `fit_only_completed_map_metrics=True`) removes all map metric rows, leaving only non-map rows with `step=NaN`.

The root cause is in `_extract_observation_data`: it decides whether to include `"step"` in the pivot index based on `data.has_step_column`, which is `True` whenever any `DataRow` has `step != None`. Since `float('nan') is not None` evaluates to `True`, all-NaN step columns are treated as map data.

The fix checks whether the filtered DataFrame's step column is all NaN after status-based filtering. If so, step is excluded from the pivot index and the column is dropped, producing a clean 2-level index. This fixes the issue for all downstream transforms at the source.

Differential Revision: D100724162


