### PR TITLE
Dedup children metrics by name in SQA decoder

### DIFF
--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -1466,6 +1466,8 @@ class Decoder:
         4. Applying skip_runners_and_metrics logic to children.
             This step requires setting skip_runners_and_metrics in
             `_set_sqa_metric_to_base_type` ahead of time.
+        5. Deduplicating children by metric name, keeping the first
+            occurrence and logging a warning if duplicates are found.
 
         Args:
             parent_metric_sqa: The parent metric SQA object.
@@ -1493,7 +1495,20 @@ class Decoder:
             for child_metric in children_metrics_sqa:
                 child_metric.metric_type = self.config.metric_registry[Metric]
 
-        return children_metrics_sqa
+        # Dedup children by metric name, keeping the first occurrence.
+        seen_names: set[str] = set()
+        deduped_children: list[SQAMetric] = []
+        for child in children_metrics_sqa:
+            if child.name not in seen_names:
+                seen_names.add(child.name)
+                deduped_children.append(child)
+            else:
+                logger.warning(
+                    f"Duplicate child metric '{child.name}' found in "
+                    f"{metric_type_name}; dropping duplicate."
+                )
+
+        return deduped_children
 
 
 def _get_scalarized_objective_children_metrics(


### PR DESCRIPTION
Summary:
The `_get_and_process_children_metrics` helper in the SQA decoder can return multiple children with the same metric name. This causes duplicate objectives/metrics when constructing `MultiObjective`, `ScalarizedObjective`, or `ScalarizedOutcomeConstraint` from SQA.

Fix this by deduplicating children by name (keeping the first occurrence) in `_get_and_process_children_metrics`, which is the shared helper used by all three callers.

Reviewed By: saitcakmak

Differential Revision: D101184789


