### PR TITLE
Thread equality constraints through adapter layer and TorchOptConfig (#5176)

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -76,29 +76,65 @@ if TYPE_CHECKING:
     from ax import adapter as adapter_module  # noqa F401
 
 
-def extract_parameter_constraints(
+def _extract_constraints(
+    parameter_constraints: list[ParameterConstraint],
+    param_names: list[str],
+    is_equality: bool,
+) -> TBounds:
+    """Extract linear constraints into a tuple of NumPy arrays.
+
+    Shared helper for extracting inequality (``A x <= b``) or equality
+    (``A x = b``) constraints.
+
+    Args:
+        parameter_constraints: A list of parameter constraint objects.
+        param_names: A list of parameter names.
+        is_equality: If True, extract equality constraints; otherwise
+            extract inequality constraints.
+
+    Returns:
+        An optional tuple of NumPy arrays (A, b).
+    """
+    filtered = [c for c in parameter_constraints if c.is_equality == is_equality]
+    if len(filtered) == 0:
+        return None
+    A = np.zeros((len(filtered), len(param_names)))
+    b = np.zeros((len(filtered), 1))
+    for i, c in enumerate(filtered):
+        b[i, 0] = c.bound
+        for name, val in c.constraint_dict.items():
+            A[i, param_names.index(name)] = val
+    return (A, b)
+
+
+def extract_inequality_constraints(
     parameter_constraints: list[ParameterConstraint], param_names: list[str]
 ) -> TBounds:
-    """Convert Ax parameter constraints into a tuple of NumPy arrays representing the
-    system of linear inequality constraints.
+    """Convert Ax inequality parameter constraints into NumPy arrays.
 
     Args:
         parameter_constraints: A list of parameter constraint objects.
         param_names: A list of parameter names.
 
     Returns:
-        An optional tuple of NumPy arrays (A, b) representing the system of linear
-        inequality constraints A x < b.
+        An optional tuple of NumPy arrays (A, b) with ``A x <= b``.
     """
-    if len(parameter_constraints) == 0:
-        return None
-    A = np.zeros((len(parameter_constraints), len(param_names)))
-    b = np.zeros((len(parameter_constraints), 1))
-    for i, c in enumerate(parameter_constraints):
-        b[i, 0] = c.bound
-        for name, val in c.constraint_dict.items():
-            A[i, param_names.index(name)] = val
-    return (A, b)
+    return _extract_constraints(parameter_constraints, param_names, is_equality=False)
+
+
+def extract_equality_constraints(
+    parameter_constraints: list[ParameterConstraint], param_names: list[str]
+) -> TBounds:
+    """Convert Ax equality parameter constraints into NumPy arrays.
+
+    Args:
+        parameter_constraints: A list of parameter constraint objects.
+        param_names: A list of parameter names.
+
+    Returns:
+        An optional tuple of NumPy arrays (A, b) with ``A x = b``.
+    """
+    return _extract_constraints(parameter_constraints, param_names, is_equality=True)
 
 
 def extract_search_space_digest(
@@ -402,6 +438,7 @@ def validate_and_apply_final_transform(
     pending_observations: list[npt.NDArray] | None,
     objective_thresholds: npt.NDArray | None = None,
     pruning_target_point: npt.NDArray | None = None,
+    equality_constraints: tuple[npt.NDArray, npt.NDArray] | None = None,
     final_transform: Callable[[npt.NDArray], Tensor] = torch.tensor,
 ) -> tuple[
     Tensor,
@@ -410,6 +447,7 @@ def validate_and_apply_final_transform(
     list[Tensor] | None,
     Tensor | None,
     Tensor | None,
+    tuple[Tensor, Tensor] | None,
 ]:
     # TODO: use some container down the road (similar to
     # SearchSpaceDigest) to limit the return arguments
@@ -437,6 +475,12 @@ def validate_and_apply_final_transform(
     pruning_target_tensor: Tensor | None = None
     if pruning_target_point is not None:
         pruning_target_tensor = final_transform(pruning_target_point)
+    equality_constraints_tensors: tuple[Tensor, Tensor] | None = None
+    if equality_constraints is not None:
+        equality_constraints_tensors = (
+            final_transform(equality_constraints[0]),
+            final_transform(equality_constraints[1]),
+        )
     return (
         obj_weights_tensor,
         outcome_constraints_tensors,
@@ -444,6 +488,7 @@ def validate_and_apply_final_transform(
         pending_obs_tensors,
         obj_thresholds_tensor,
         pruning_target_tensor,
+        equality_constraints_tensors,
     )
 
 
@@ -700,7 +745,7 @@ def get_pareto_frontier_and_configs(
     if obj_t is not None:
         obj_t = array_to_tensor(obj_t)
     # Transform to tensors.
-    obj_w, oc_c, _, _, _, _ = validate_and_apply_final_transform(
+    obj_w, oc_c, _, _, _, _, _ = validate_and_apply_final_transform(
         objective_weights=objective_weights,
         outcome_constraints=outcome_constraints,
         linear_constraints=None,

--- a/ax/adapter/random.py
+++ b/ax/adapter/random.py
@@ -11,7 +11,7 @@ from collections.abc import Mapping, Sequence
 
 import numpy as np
 from ax.adapter.adapter_utils import (
-    extract_parameter_constraints,
+    extract_inequality_constraints,
     extract_search_space_digest,
     get_fixed_features,
     parse_observation_features,
@@ -92,7 +92,7 @@ class RandomAdapter(Adapter):
         # Get fixed features
         fixed_features_dict = get_fixed_features(fixed_features, self.parameters)
         # Extract param constraints
-        linear_constraints = extract_parameter_constraints(
+        linear_constraints = extract_inequality_constraints(
             search_space.parameter_constraints, self.parameters
         )
         # Extract generated points.

--- a/ax/adapter/tests/test_adapter_utils.py
+++ b/ax/adapter/tests/test_adapter_utils.py
@@ -15,6 +15,8 @@ from ax.adapter.adapter_utils import (
     _get_fresh_pairwise_trial_indices,
     arm_to_np_array,
     can_map_to_binary,
+    extract_equality_constraints,
+    extract_inequality_constraints,
     extract_objective_weight_matrix,
     extract_search_space_digest,
     feasible_hypervolume,
@@ -35,6 +37,7 @@ from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
+from ax.core.parameter_constraint import ParameterConstraint
 from ax.core.search_space import SearchSpace
 from ax.core.types import ComparisonOp
 from ax.exceptions.core import UserInputError
@@ -377,6 +380,7 @@ class TestAdapterUtils(TestCase):
             _,
             _,
             target_p,
+            _,
         ) = validate_and_apply_final_transform(
             objective_weights=objective_weights,
             outcome_constraints=outcome_constraints,
@@ -412,6 +416,7 @@ class TestAdapterUtils(TestCase):
             _,
             _,
             target_p,
+            _,
         ) = validate_and_apply_final_transform(
             objective_weights=objective_weights,
             outcome_constraints=outcome_constraints,
@@ -652,3 +657,90 @@ class TestAdapterUtils(TestCase):
             self.assertNotIn(0, result)
             self.assertNotIn(1, result)
             self.assertIn(2, result)
+
+    def test_extract_inequality_constraints(self) -> None:
+        param_names = ["x", "y"]
+        ineq = ParameterConstraint(inequality="x + y <= 1")
+        eq = ParameterConstraint(equality="x + y == 1")
+
+        # Only inequality constraints are extracted
+        result = extract_inequality_constraints([ineq, eq], param_names)
+        self.assertIsNotNone(result)
+        assert result is not None
+        A, b = result
+        self.assertEqual(A.shape, (1, 2))
+        self.assertEqual(b.shape, (1, 1))
+        np.testing.assert_array_equal(A[0], [1.0, 1.0])
+        np.testing.assert_array_equal(b[0], [1.0])
+
+        # Returns None when no inequality constraints
+        result = extract_inequality_constraints([eq], param_names)
+        self.assertIsNone(result)
+
+        # Returns None for empty list
+        result = extract_inequality_constraints([], param_names)
+        self.assertIsNone(result)
+
+    def test_extract_equality_constraints(self) -> None:
+        param_names = ["x", "y"]
+        ineq = ParameterConstraint(inequality="x + y <= 1")
+        eq = ParameterConstraint(equality="x + y == 1")
+
+        # Only equality constraints are extracted
+        result = extract_equality_constraints([ineq, eq], param_names)
+        self.assertIsNotNone(result)
+        assert result is not None
+        A, b = result
+        self.assertEqual(A.shape, (1, 2))
+        self.assertEqual(b.shape, (1, 1))
+        np.testing.assert_array_equal(A[0], [1.0, 1.0])
+        np.testing.assert_array_equal(b[0], [1.0])
+
+        # Returns None when no equality constraints
+        result = extract_equality_constraints([ineq], param_names)
+        self.assertIsNone(result)
+
+    def test_extract_constraints_mixed(self) -> None:
+        """Both functions correctly partition a mixed list."""
+        param_names = ["x", "y"]
+        ineq1 = ParameterConstraint(inequality="x <= 0.5")
+        ineq2 = ParameterConstraint(inequality="y <= 0.8")
+        eq1 = ParameterConstraint(equality="x + y == 1")
+
+        ineq_result = extract_inequality_constraints([ineq1, eq1, ineq2], param_names)
+        eq_result = extract_equality_constraints([ineq1, eq1, ineq2], param_names)
+
+        assert ineq_result is not None
+        assert eq_result is not None
+        self.assertEqual(ineq_result[0].shape, (2, 2))  # 2 inequalities
+        self.assertEqual(eq_result[0].shape, (1, 2))  # 1 equality
+
+    def test_validate_and_apply_final_transform_equality_constraints(self) -> None:
+        """equality_constraints are converted to tensors."""
+        objective_weights = np.array([1.0, 0.0])
+        A_eq = np.array([[1.0, 1.0]])
+        b_eq = np.array([[1.0]])
+
+        _, _, _, _, _, _, eq_c = validate_and_apply_final_transform(
+            objective_weights=objective_weights,
+            outcome_constraints=None,
+            linear_constraints=None,
+            pending_observations=None,
+            equality_constraints=(A_eq, b_eq),
+        )
+        self.assertIsNotNone(eq_c)
+        assert eq_c is not None
+        self.assertTrue(torch.equal(eq_c[0], torch.tensor(A_eq)))
+        self.assertTrue(torch.equal(eq_c[1], torch.tensor(b_eq)))
+
+    def test_validate_and_apply_final_transform_no_equality_constraints(self) -> None:
+        """equality_constraints defaults to None."""
+        objective_weights = np.array([1.0])
+
+        _, _, _, _, _, _, eq_c = validate_and_apply_final_transform(
+            objective_weights=objective_weights,
+            outcome_constraints=None,
+            linear_constraints=None,
+            pending_observations=None,
+        )
+        self.assertIsNone(eq_c)

--- a/ax/adapter/torch.py
+++ b/ax/adapter/torch.py
@@ -20,10 +20,11 @@ from ax.adapter.adapter_utils import (
     _get_fresh_pairwise_trial_indices,
     arm_to_np_array,
     array_to_observation_data,
+    extract_equality_constraints,
+    extract_inequality_constraints,
     extract_objective_thresholds,
     extract_objective_weight_matrix,
     extract_outcome_constraints,
-    extract_parameter_constraints,
     extract_search_space_digest,
     get_fixed_features,
     observation_data_to_array,
@@ -1044,7 +1045,10 @@ class TorchAdapter(Adapter):
             arm=optimization_config.pruning_target_parameterization,
             parameters=self.parameters,
         )
-        linear_constraints = extract_parameter_constraints(
+        linear_constraints = extract_inequality_constraints(
+            search_space.parameter_constraints, self.parameters
+        )
+        equality_constraints_np = extract_equality_constraints(
             search_space.parameter_constraints, self.parameters
         )
         fixed_features_dict = get_fixed_features(fixed_features, self.parameters)
@@ -1065,7 +1069,7 @@ class TorchAdapter(Adapter):
         pending_array = pending_observations_as_array_list(
             pending_observations, self.outcomes, self.parameters
         )
-        obj_w, out_c, lin_c, pend_o, obj_t, pruning_target_p = (
+        obj_w, out_c, lin_c, pend_o, obj_t, pruning_target_p, eq_c = (
             validate_and_apply_final_transform(
                 objective_weights=objective_weights,
                 outcome_constraints=outcome_constraints,
@@ -1073,6 +1077,7 @@ class TorchAdapter(Adapter):
                 pending_observations=pending_array,
                 objective_thresholds=objective_thresholds,
                 pruning_target_point=pruning_target_point,
+                equality_constraints=equality_constraints_np,
                 final_transform=self._array_to_tensor,
             )
         )
@@ -1089,6 +1094,7 @@ class TorchAdapter(Adapter):
             outcome_constraints=out_c,
             objective_thresholds=obj_t,
             linear_constraints=lin_c,
+            equality_constraints=eq_c,
             fixed_features=fixed_features_dict,
             pending_observations=pend_o,
             model_gen_options=model_gen_options or {},

--- a/ax/core/parameter_constraint.py
+++ b/ax/core/parameter_constraint.py
@@ -21,6 +21,9 @@ from ax.utils.common.sympy import (
 from pyre_extensions import none_throws
 
 
+PARAMETER_CONSTRAINT_TOLERANCE: float = 1e-8
+
+
 class ParameterConstraint(SortableBase):
     """Base class for linear parameter constraints.
 
@@ -120,8 +123,8 @@ class ParameterConstraint(SortableBase):
             for param, weight in self.constraint_dict.items()
         )
         if self.is_equality:
-            return abs(weighted_sum - self._bound) <= 1e-8
-        return weighted_sum <= self._bound + 1e-8  # allow for numerical imprecision
+            return abs(weighted_sum - self._bound) <= PARAMETER_CONSTRAINT_TOLERANCE
+        return weighted_sum <= self._bound + PARAMETER_CONSTRAINT_TOLERANCE
 
     def clone(self) -> ParameterConstraint:
         """Clone."""

--- a/ax/core/parameter_constraint.py
+++ b/ax/core/parameter_constraint.py
@@ -14,27 +14,54 @@ from ax.core.parameter import ChoiceParameter, Parameter, RangeParameter
 from ax.exceptions.core import UserInputError
 from ax.utils.common.base import SortableBase
 from ax.utils.common.string_utils import unsanitize_name
-from ax.utils.common.sympy import extract_coefficient_dict_from_inequality
+from ax.utils.common.sympy import (
+    extract_coefficient_dict_from_equality,
+    extract_coefficient_dict_from_inequality,
+)
+from pyre_extensions import none_throws
 
 
 class ParameterConstraint(SortableBase):
     """Base class for linear parameter constraints.
 
-    Constraints are expressed as a SymPy parsable inequality string.
+    Supports both inequality constraints (``w^T x <= b``) and equality
+    constraints (``w^T x == b``).  Exactly one of ``inequality`` or
+    ``equality`` must be provided.
     """
 
-    def __init__(self, inequality: str) -> None:
-        """Initialize ParameterConstraint
+    def __init__(
+        self,
+        inequality: str | None = None,
+        *,
+        equality: str | None = None,
+    ) -> None:
+        """Initialize ParameterConstraint.
 
         Args:
-            inequality: String representation of the constraint. At this point in time
-            Ax only accepts linear inequality constraints.
-        """
-        self._inequality_str = inequality
+            inequality: String representation of a linear inequality
+                constraint, e.g. ``"x1 + x2 <= 3"``.
+            equality: String representation of a linear equality
+                constraint, e.g. ``"x1 + x2 == 3"``.
 
-        coefficient_dict = extract_coefficient_dict_from_inequality(
-            inequality_str=inequality
-        )
+        Exactly one of ``inequality`` or ``equality`` must be provided.
+        """
+        if (inequality is None) == (equality is None):
+            raise UserInputError(
+                "Exactly one of `inequality` or `equality` must be provided."
+            )
+
+        self.is_equality: bool = equality is not None
+        constraint_str = none_throws(equality if self.is_equality else inequality)
+        self._constraint_str: str = constraint_str
+
+        if self.is_equality:
+            coefficient_dict = extract_coefficient_dict_from_equality(
+                equality_str=constraint_str
+            )
+        else:
+            coefficient_dict = extract_coefficient_dict_from_inequality(
+                inequality_str=constraint_str
+            )
 
         # Iterate through the coefficients to extract the parameter names and weights
         # and the bound
@@ -47,9 +74,12 @@ class ParameterConstraint(SortableBase):
                 # Invert because we are "moving" the bound to the right hand side
                 self._bound = -1 * coefficient
             else:
+                constraint_type = "equality" if self.is_equality else "inequality"
+                other_type = "inequality" if self.is_equality else "equality"
                 raise UserInputError(
-                    "Only linear inequality parameter constraints are supported, found "
-                    f"{inequality}"
+                    f"Only linear {constraint_type} parameter constraints are "
+                    f"supported, found {constraint_str}. "
+                    f"Did you mean to use the `{other_type}` argument?"
                 )
 
     @property
@@ -59,7 +89,7 @@ class ParameterConstraint(SortableBase):
 
     @property
     def bound(self) -> float:
-        """Get bound of the inequality of the constraint."""
+        """Get bound of the constraint."""
         return self._bound
 
     @bound.setter
@@ -71,7 +101,9 @@ class ParameterConstraint(SortableBase):
         """Whether or not the set of parameter values satisfies the constraint.
 
         Does a weighted sum of the parameter values based on the constraint_dict
-        and checks that the sum is less than the bound.
+        and checks against the bound. For inequality constraints checks
+        ``weighted_sum <= bound``; for equality constraints checks
+        ``|weighted_sum - bound| <= tolerance``.
 
         Args:
             parameter_dict: Map from parameter name to parameter value.
@@ -87,13 +119,15 @@ class ParameterConstraint(SortableBase):
             float(parameter_dict[param]) * weight
             for param, weight in self.constraint_dict.items()
         )
-        # Expected `int` for 2nd anonymous parameter to call `int.__le__` but got
-        # `float`.
+        if self.is_equality:
+            return abs(weighted_sum - self._bound) <= 1e-8
         return weighted_sum <= self._bound + 1e-8  # allow for numerical imprecision
 
     def clone(self) -> ParameterConstraint:
         """Clone."""
-        return ParameterConstraint(inequality=self._inequality_str)
+        if self.is_equality:
+            return ParameterConstraint(equality=self._constraint_str)
+        return ParameterConstraint(inequality=self._constraint_str)
 
     def clone_with_transformed_parameters(
         self, transformed_parameters: dict[str, Parameter]
@@ -102,10 +136,11 @@ class ParameterConstraint(SortableBase):
         return self.clone()
 
     def __repr__(self) -> str:
+        op = "==" if self.is_equality else "<="
         return (
             "ParameterConstraint("
             + " + ".join(f"{v}*{k}" for k, v in sorted(self.constraint_dict.items()))
-            + f" <= {self._bound})"
+            + f" {op} {self._bound})"
         )
 
     @property

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -30,6 +30,7 @@ from ax.core.parameter import (
     TParamValue,
 )
 from ax.core.parameter_constraint import (
+    PARAMETER_CONSTRAINT_TOLERANCE,
     ParameterConstraint,
     validate_constraint_parameters,
 )
@@ -515,7 +516,7 @@ class SearchSpace(Base):
                 valid = valid | is_null
             in_design &= pd.Series(valid, index=df.index)
 
-        # Check parameter constraints (linear inequalities) vectorized
+        # Check parameter constraints vectorized
         for constraint in self._parameter_constraints:
             weighted_sum = pd.Series(0.0, index=df.index)
             for param_name, weight in constraint.constraint_dict.items():
@@ -525,7 +526,15 @@ class SearchSpace(Base):
                     break
                 # NaN values propagate if exists, causing comparison to return False
                 weighted_sum = weighted_sum + df[param_name] * weight
-            in_design &= weighted_sum <= constraint.bound + 1e-8
+            if constraint.is_equality:
+                in_design &= (
+                    np.abs(weighted_sum - constraint.bound)
+                    <= PARAMETER_CONSTRAINT_TOLERANCE
+                )
+            else:
+                in_design &= (
+                    weighted_sum <= constraint.bound + PARAMETER_CONSTRAINT_TOLERANCE
+                )
 
         # Handle hierarchical search space structure
         if self.is_hierarchical:
@@ -759,10 +768,14 @@ class SearchSpace(Base):
         feasible region defined by the parameter constraints. This is computed
         by solving a linear program. It is most limited by the tightest constraint.
 
-        For a polytope defined by a @ x <= b, the Chebyshev center (x_c, r) is
-        the solution to:
-            maximize r, where r is the radius of the inscribed ball
+        For inequality constraints a_i^T x <= b_i, the inscribed ball must fit
+        inside each half-space, so the radius is augmented:
+            maximize r
             subject to: a_i^T x + r ||a_i||_2 <= b_i for all i
+
+        Equality constraints c_j^T x = d_j require the center to lie on the
+        hyperplane and are passed through without radius augmentation (the ball
+        is inscribed within the lower-dimensional affine subspace).
 
         Note: this only considers natural (non-log, non-logit) range parameters.
         Other parameter types are handled naively via compute_naive_center.
@@ -781,8 +794,10 @@ class SearchSpace(Base):
         if not natural_range_params:
             return {}
 
-        constraint_matrix = []
-        bound_vector = []
+        ineq_constraint_matrix = []
+        ineq_bound_vector = []
+        eq_constraint_matrix = []
+        eq_bound_vector = []
         param_names = list(natural_range_params.keys())
         num_params = len(natural_range_params)
         param_name_to_idx = {name: idx for idx, name in enumerate(param_names)}
@@ -794,30 +809,47 @@ class SearchSpace(Base):
                 if param_name in param_name_to_idx:
                     row[param_name_to_idx[param_name]] = weight
 
-            constraint_matrix.append(row)
-            bound_vector.append(constraint.bound)
+            if constraint.is_equality:
+                eq_constraint_matrix.append(row)
+                eq_bound_vector.append(constraint.bound)
+            else:
+                ineq_constraint_matrix.append(row)
+                ineq_bound_vector.append(constraint.bound)
 
-        # Add parameter bounds
+        # Add parameter bounds (always inequality)
         for name, idx in param_name_to_idx.items():
             param = natural_range_params[name]
             # lower bound: -x_i <= -lower_i
             row_lower = np.zeros(num_params)
             row_lower[idx] = -1.0
-            constraint_matrix.append(row_lower)
-            bound_vector.append(-float(param.lower))
+            ineq_constraint_matrix.append(row_lower)
+            ineq_bound_vector.append(-float(param.lower))
 
             # upper bound: x_i <= upper_i
             row_upper = np.zeros(num_params)
             row_upper[idx] = 1.0
-            constraint_matrix.append(row_upper)
-            bound_vector.append(float(param.upper))
+            ineq_constraint_matrix.append(row_upper)
+            ineq_bound_vector.append(float(param.upper))
 
-        constraint_matrix = np.array(constraint_matrix)
-        bound_vector = np.array(bound_vector)
+        ineq_constraint_matrix_np = np.array(ineq_constraint_matrix)
+        ineq_bound_vector_np = np.array(ineq_bound_vector)
 
-        # Compute norm for each vector in constraint matrix
-        row_norms = np.linalg.norm(constraint_matrix, axis=1)
-        augmented_constraint_matrix = np.column_stack([constraint_matrix, row_norms])
+        # For the Chebyshev center, augment inequality constraints with
+        # r * ||a_i|| (the ball must fit inside each half-space).
+        row_norms = np.linalg.norm(ineq_constraint_matrix_np, axis=1)
+        augmented_constraint_matrix = np.column_stack(
+            [ineq_constraint_matrix_np, row_norms]
+        )
+
+        # Equality constraints: the ball center must lie on the hyperplane,
+        # so no radius augmentation is needed.
+        A_eq = None
+        b_eq = None
+        if eq_constraint_matrix:
+            # Pad equality rows with a zero column for the radius variable
+            eq_matrix_np = np.array(eq_constraint_matrix)
+            A_eq = np.column_stack([eq_matrix_np, np.zeros(eq_matrix_np.shape[0])])
+            b_eq = np.array(eq_bound_vector)
 
         # Set objective vector which maximizes r (minimize -r == maximize r)
         radius_objective_vector = np.zeros(num_params + 1)
@@ -825,7 +857,9 @@ class SearchSpace(Base):
         result = linprog(
             c=radius_objective_vector,
             A_ub=augmented_constraint_matrix,
-            b_ub=bound_vector,
+            b_ub=ineq_bound_vector_np,
+            A_eq=A_eq,
+            b_eq=b_eq,
             bounds=[(None, None)] * num_params + [(0, None)],  # no bounds except r >= 0
         )
 

--- a/ax/core/tests/test_parameter_constraint.py
+++ b/ax/core/tests/test_parameter_constraint.py
@@ -20,6 +20,8 @@ class ParameterConstraintTest(TestCase):
         super().setUp()
         self.constraint = ParameterConstraint(inequality="2 * x - 3 * y <= 6.0")
         self.constraint_repr = "ParameterConstraint(2.0*x + -3.0*y <= 6.0)"
+        self.eq_constraint = ParameterConstraint(equality="x + y == 1.0")
+        self.eq_constraint_repr = "ParameterConstraint(1.0*x + 1.0*y == 1.0)"
 
     def test_constraint_dict_and_bounds(self) -> None:
         constraint = ParameterConstraint(inequality="x1 + x2 <= 1")
@@ -122,6 +124,74 @@ class ParameterConstraintTest(TestCase):
             inequality="2 * x - 3 * y <= 6.0",
         )
         self.assertTrue(constraint1 < constraint2)
+
+    def test_equality_constraint_init(self) -> None:
+        cases = [
+            ("x + y == 1.0", {"x": 1.0, "y": 1.0}, 1.0),
+            ("2 * x + 3 * y == 5.0", {"x": 2.0, "y": 3.0}, 5.0),
+            ("-x + y == 1.0", {"x": -1.0, "y": 1.0}, 1.0),
+            ("- x + y == 1.0", {"x": -1.0, "y": 1.0}, 1.0),
+        ]
+        for expr, expected_dict, expected_bound in cases:
+            with self.subTest(expr=expr):
+                c = ParameterConstraint(equality=expr)
+                self.assertTrue(c.is_equality)
+                self.assertEqual(c.constraint_dict, expected_dict)
+                self.assertEqual(c.bound, expected_bound)
+
+        c_ineq = ParameterConstraint(inequality="x + y <= 1.0")
+        self.assertFalse(c_ineq.is_equality)
+
+    def test_equality_constraint_must_provide_one(self) -> None:
+        # Neither provided
+        with self.assertRaisesRegex(UserInputError, "Exactly one"):
+            ParameterConstraint()
+
+        # Both provided
+        with self.assertRaisesRegex(UserInputError, "Exactly one"):
+            ParameterConstraint(inequality="x <= 1", equality="x == 1")
+
+    def test_equality_constraint_check(self) -> None:
+        c = ParameterConstraint(equality="x + y == 1.0")
+
+        cases = [
+            ({"x": 0.5, "y": 0.5}, True, "exact"),
+            ({"x": 0.5, "y": 0.5 + 0.5e-9}, True, "within tolerance"),
+            ({"x": 0.5, "y": 0.6}, False, "violated above"),
+            ({"x": 0.5, "y": 0.4}, False, "violated below"),
+        ]
+        for params, expected, label in cases:
+            with self.subTest(label=label):
+                self.assertEqual(c.check(params), expected)
+
+    def test_equality_constraint_repr(self) -> None:
+        self.assertEqual(str(self.eq_constraint), self.eq_constraint_repr)
+
+    def test_equality_constraint_clone(self) -> None:
+        clone = self.eq_constraint.clone()
+        self.assertTrue(clone.is_equality)
+        self.assertEqual(clone.constraint_dict, self.eq_constraint.constraint_dict)
+        self.assertEqual(clone.bound, self.eq_constraint.bound)
+
+        # Mutation of clone doesn't affect original
+        clone._bound = 99.0
+        self.assertNotEqual(self.eq_constraint.bound, clone.bound)
+
+    def test_equality_constraint_clone_with_transformed_parameters(self) -> None:
+        clone = self.eq_constraint.clone_with_transformed_parameters(
+            transformed_parameters={}
+        )
+        self.assertTrue(clone.is_equality)
+        self.assertEqual(clone.bound, self.eq_constraint.bound)
+
+    def test_equality_constraint_eq(self) -> None:
+        c1 = ParameterConstraint(equality="x + y == 1.0")
+        c2 = ParameterConstraint(equality="x + y == 1.0")
+        self.assertEqual(c1, c2)
+
+        # Different from inequality with same coefficients
+        c3 = ParameterConstraint(inequality="x + y <= 1.0")
+        self.assertNotEqual(c1, c3)
 
 
 class ValidateConstraintParametersTest(TestCase):

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -1054,6 +1054,126 @@ class SearchSpaceTest(TestCase):
             self.assertIsNotNone(result)
             self.assertEqual(result.parameters, {"x2": 0.0})
 
+    def test_check_membership_df_equality_constraint(self) -> None:
+        """Test vectorized membership check with equality constraints."""
+        ss = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+                RangeParameter(
+                    name="y",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            ],
+            parameter_constraints=[
+                ParameterConstraint(equality="x + y == 1.0"),
+            ],
+        )
+        df = pd.DataFrame({"x": [0.3, 0.5, 0.7, 0.6], "y": [0.7, 0.5, 0.2, 0.4]})
+
+        result = ss.check_membership_df(df)
+        # Rows 0, 1, 3 satisfy x + y == 1.0; row 2 has x + y = 0.9
+        self.assertEqual(result, [True, True, False, True])
+
+    def test_check_membership_df_mixed_constraints(self) -> None:
+        """Test vectorized membership with both equality and inequality."""
+        ss = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+                RangeParameter(
+                    name="y",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            ],
+            parameter_constraints=[
+                ParameterConstraint(equality="x + y == 1.0"),
+                ParameterConstraint(inequality="x <= 0.6"),
+            ],
+        )
+        df = pd.DataFrame({"x": [0.3, 0.7, 0.5], "y": [0.7, 0.3, 0.5]})
+
+        result = ss.check_membership_df(df)
+        # Row 0: x+y=1 OK, x=0.3<=0.6 OK  -> True
+        # Row 1: x+y=1 OK, x=0.7<=0.6 FAIL -> False
+        # Row 2: x+y=1 OK, x=0.5<=0.6 OK  -> True
+        self.assertEqual(result, [True, False, True])
+
+    def test_compute_chebyshev_center_with_equality_constraint(self) -> None:
+        """Chebyshev center must lie on the equality hyperplane."""
+        ss = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+                RangeParameter(
+                    name="y",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            ],
+            parameter_constraints=[
+                ParameterConstraint(equality="x + y == 1.0"),
+            ],
+        )
+        center = ss.compute_chebyshev_center()
+        self.assertIsNotNone(center)
+        assert center is not None
+        # Center must satisfy x + y == 1
+        self.assertAlmostEqual(center["x"] + center["y"], 1.0, places=6)
+        # By symmetry, center should be at (0.5, 0.5)
+        self.assertAlmostEqual(center["x"], 0.5, places=6)
+        self.assertAlmostEqual(center["y"], 0.5, places=6)
+
+    def test_compute_chebyshev_center_equality_and_inequality(self) -> None:
+        """Chebyshev center with both equality and inequality constraints."""
+        ss = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+                RangeParameter(
+                    name="y",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            ],
+            parameter_constraints=[
+                ParameterConstraint(equality="x + y == 1.0"),
+                ParameterConstraint(inequality="x <= 0.8"),
+            ],
+        )
+        center = ss.compute_chebyshev_center()
+        self.assertIsNotNone(center)
+        assert center is not None
+        # Must satisfy equality constraint
+        self.assertAlmostEqual(center["x"] + center["y"], 1.0, places=6)
+        # Must satisfy inequality: x <= 0.8
+        self.assertLessEqual(center["x"], 0.8 + 1e-6)
+        # Must satisfy bounds
+        self.assertGreaterEqual(center["x"], -1e-6)
+        self.assertGreaterEqual(center["y"], -1e-6)
+
 
 class SearchSpaceDigestTest(TestCase):
     def setUp(self) -> None:

--- a/ax/generators/torch_base.py
+++ b/ax/generators/torch_base.py
@@ -50,6 +50,9 @@ class TorchOptConfig:
         linear_constraints: A tuple of (A, b). For k linear constraints on
             d-dimensional x, A is (k x d) and b is (k x 1) such that
             A x <= b for feasible x.
+        equality_constraints: A tuple of (A, b). For k equality constraints on
+            d-dimensional x, A is (k x d) and b is (k x 1) such that
+            A x = b for feasible x.
         fixed_features: A map {feature_index: value} for features that
             should be fixed to a particular value during generation.
         pending_observations:  A list of m (k_i x d) feature tensors X
@@ -91,6 +94,7 @@ class TorchOptConfig:
     outcome_constraints: tuple[Tensor, Tensor] | None = None
     objective_thresholds: Tensor | None = None
     linear_constraints: tuple[Tensor, Tensor] | None = None
+    equality_constraints: tuple[Tensor, Tensor] | None = None
     fixed_features: dict[int, float] | None = None
     pending_observations: list[Tensor] | None = None
     model_gen_options: TConfig = field(default_factory=dict)

--- a/ax/service/tests/test_instantiation_utils.py
+++ b/ax/service/tests/test_instantiation_utils.py
@@ -115,12 +115,7 @@ class TestInstantiationtUtils(TestCase):
             )
         with self.assertRaisesRegex(
             ValueError,
-            (
-                r"Received invalid parameter constraint format: "
-                r"`x1 \+ x2 \+ x3 = 3`\. "
-                r"Please use one of the following forms:\n"
-                r".*\n.*\n.*\nAcceptable comparison operators are \">=\" and \"<=\"\."
-            ),
+            r"Received invalid parameter constraint format: `x1 \+ x2 \+ x3 = 3`",
         ):
             InstantiationBase.constraint_from_str(
                 "x1 + x2 + x3 = 3", {"x1": x1, "x2": x2, "x3": x3}
@@ -192,6 +187,38 @@ class TestInstantiationtUtils(TestCase):
             InstantiationBase.constraint_from_str(
                 "x1 + x2 / 2.0 + x3 >= 3", {"x1": x1, "x2": x2, "x3": x3}
             )
+
+        # --- Equality constraints ---
+        eq_constraint = InstantiationBase.constraint_from_str(
+            "x1 + x2 == 1", {"x1": x1, "x2": x2}
+        )
+        self.assertTrue(eq_constraint.is_equality)
+        self.assertEqual(eq_constraint.constraint_dict, {"x1": 1.0, "x2": 1.0})
+        self.assertEqual(eq_constraint.bound, 1.0)
+
+        # Weighted equality
+        eq_weighted = InstantiationBase.constraint_from_str(
+            "2*x1 + 3*x2 == 5", {"x1": x1, "x2": x2}
+        )
+        self.assertTrue(eq_weighted.is_equality)
+        self.assertEqual(eq_weighted.constraint_dict, {"x1": 2.0, "x2": 3.0})
+        self.assertEqual(eq_weighted.bound, 5.0)
+
+        # Single parameter equality
+        eq_single = InstantiationBase.constraint_from_str(
+            "x1 == 3", {"x1": x1, "x2": x2}
+        )
+        self.assertTrue(eq_single.is_equality)
+        self.assertEqual(eq_single.constraint_dict, {"x1": 1.0})
+        self.assertEqual(eq_single.bound, 3.0)
+
+        # Order equality constraint should error
+        with self.assertRaisesRegex(ValueError, "DerivedParameter"):
+            InstantiationBase.constraint_from_str("x1 == x2", {"x1": x1, "x2": x2})
+
+        # Linear equality that equates two params should also error
+        with self.assertRaisesRegex(ValueError, "DerivedParameter"):
+            InstantiationBase.constraint_from_str("x1 - x2 == 0", {"x1": x1, "x2": x2})
 
     def test_spaces_in_metric_and_parameter_names(self) -> None:
         # Metric and parameter names with spaces are allowed everywhere

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -86,6 +86,8 @@ EXPECTED_KEYS_IN_PARAM_REPR = {
 }
 
 
+COMPARISON_OPS_WITH_EQ: set[str] = {"<=", ">=", "=="}
+
 INVALID_CONSTRAINT_ERROR_MSG = (
     "Received invalid parameter constraint format: `{}`. "
     "Please use one of the following forms:\n"
@@ -96,7 +98,10 @@ INVALID_CONSTRAINT_ERROR_MSG = (
     "* Weighted linear constraints: `<w1>*<p1> >= <b>` or "
     "`<w1>*<p1> + <w2>*<p2> <= <b>`, where you can add one or more weighted terms on "
     "the left side, and there should be no spaces between weights and parameter "
-    'names.\nAcceptable comparison operators are ">=" and "<=".'
+    "names.\n"
+    "* Equality constraints: `<p1> + <p2> == <b>` or `<w1>*<p1> + <w2>*<p2> == <b>`, "
+    "same as linear constraints but using `==` instead of `<=` or `>=`.\n"
+    'Acceptable comparison operators are ">=", "<=", and "==".'
 )
 
 
@@ -440,27 +445,42 @@ class InstantiationBase:
             last_token_is_numeric = True
         except ValueError:
             last_token_is_numeric = False
+
+        # Identify the comparison operator (second-to-last for linear, middle
+        # for order constraints).
         is_order_constraint = (
             len(tokens) == 3
-            and tokens[1] in COMPARISON_OPS
+            and tokens[1] in COMPARISON_OPS_WITH_EQ
             and not last_token_is_numeric
         )
         is_linear_constraint = (
-            # if len == 3, then this is a single parameter bound constraint, otherwise
-            # it corresponds to a numerical bound on a sum of parameters
+            # if len == 3, then this is a single parameter bound constraint,
+            # otherwise it corresponds to a numerical bound on a sum of
+            # parameters
             len(tokens) >= 3
             and len(tokens) % 2 == 1
-            and tokens[-2] in COMPARISON_OPS
+            and tokens[-2] in COMPARISON_OPS_WITH_EQ
             and last_token_is_numeric
         )
 
         if is_order_constraint:  # e.g. "x1 >= x2"
+            if tokens[1] == "==":
+                raise ValueError(
+                    "Equality order constraints (e.g. 'x1 == x2') are not "
+                    "supported. Use a DerivedParameter to express that two "
+                    "parameters must be equal."
+                )
             return _process_order_constraint(
                 tokens=tokens,
                 parameters=parameters,
             )
 
-        if is_linear_constraint:  # e.g. "x1 + x2 >= 3"
+        if is_linear_constraint:  # e.g. "x1 + x2 >= 3" or "x1 + x2 == 3"
+            if tokens[-2] == "==":
+                return _process_equality_constraint(
+                    tokens=tokens,
+                    parameters=parameters,
+                )
             return _process_linear_constraint(
                 tokens=tokens,
                 parameters=parameters,
@@ -1042,32 +1062,41 @@ def _process_order_constraint(
     )
 
 
-def _process_linear_constraint(
+def _parse_linear_constraint_tokens(
     tokens: Sequence[str],
     parameters: Mapping[str, Parameter],
-) -> ParameterConstraint:
-    """Processes a linear constraint, e.g. "x1 + x2 <= 3". The last token is expected
-    to be a numeric constant, and the other tokens are expected to be parameters, their
-    multiplicative coefficients (e.g."2.5*x1") and "+" or "-" operators (e.g. "+").
+    operator_str: str,
+) -> tuple[dict[str, float], float]:
+    """Parse tokens of a linear constraint into parameter weights and bound.
+
+    Shared helper for ``_process_linear_constraint`` and
+    ``_process_equality_constraint``.  Validates ``*`` placement, processes
+    alternating monomials / operators, and returns the raw
+    ``parameter_weights`` dict and ``bound``.
 
     Args:
         tokens: A list of tokens in the constraint string.
         parameters: A mapping from parameter names to their definitions.
+        operator_str: The comparison operator string (e.g. ``"<="``/``">="``
+            /``"=="``), used only for error messages.
 
     Returns:
-        A ParameterConstraint object representing the linear constraint.
+        A tuple of (parameter_weights, bound).
     """
     parameter_names = parameters.keys()
 
     bound = float(tokens[-1])
     if any(token[0] == "*" or token[-1] == "*" for token in tokens):
         raise ValueError(
-            "A linear constraint should be the form a*x + b*y - c*z <= d"
-            ", where a,b,c,d are float constants and x,y,z are parameters. "
-            "There should be no space in each term around the operator `*`, and "
-            "there should be a single space around each operator +, -, <= and >=."
+            f"A linear constraint should be the form "
+            f"a*x + b*y - c*z {operator_str} d"
+            ", where a,b,c,d are float constants and x,y,z are "
+            "parameters. There should be no space in each term "
+            "around the operator `*`, and there should be a "
+            f"single space around each operator +, -, "
+            f"and {operator_str}."
         )
-    parameter_weights = {}
+    parameter_weights: dict[str, float] = {}
     current_sign = 1.0  # Determines whether the operator is + or -
     # tokens are alternating monomials and operators
     for idx, token in enumerate(tokens[:-2]):
@@ -1091,6 +1120,27 @@ def _process_linear_constraint(
                 raise ValueError(
                     f"Expected a mixed constraint, found operator `{token}`."
                 )
+    return parameter_weights, bound
+
+
+def _process_linear_constraint(
+    tokens: Sequence[str],
+    parameters: Mapping[str, Parameter],
+) -> ParameterConstraint:
+    """Processes a linear constraint, e.g. "x1 + x2 <= 3". The last token is expected
+    to be a numeric constant, and the other tokens are expected to be parameters, their
+    multiplicative coefficients (e.g."2.5*x1") and "+" or "-" operators (e.g. "+").
+
+    Args:
+        tokens: A list of tokens in the constraint string.
+        parameters: A mapping from parameter names to their definitions.
+
+    Returns:
+        A ParameterConstraint object representing the linear constraint.
+    """
+    parameter_weights, bound = _parse_linear_constraint_tokens(
+        tokens=tokens, parameters=parameters, operator_str="<= or >="
+    )
     # tokens[-2] is checked to be either LEQ or GEQ if sum_const is True
     comparison_multiplier = (
         1.0 if COMPARISON_OPS[tokens[-2]] is ComparisonOp.LEQ else -1.0
@@ -1102,6 +1152,45 @@ def _process_linear_constraint(
     return ParameterConstraint(
         inequality=f"{expr} <= {comparison_multiplier * bound}",
     )
+
+
+def _process_equality_constraint(
+    tokens: Sequence[str],
+    parameters: Mapping[str, Parameter],
+) -> ParameterConstraint:
+    """Processes a linear equality constraint, e.g. "x1 + x2 == 3".
+
+    The last token is expected to be a numeric constant, the second-to-last
+    is ``"=="``, and the other tokens are parameters, their multiplicative
+    coefficients (e.g. ``"2.5*x1"``) and ``"+"`` or ``"-"`` operators.
+
+    Args:
+        tokens: A list of tokens in the constraint string.
+        parameters: A mapping from parameter names to their definitions.
+
+    Returns:
+        A ParameterConstraint with ``equality=...``.
+    """
+    parameter_weights, bound = _parse_linear_constraint_tokens(
+        tokens=tokens, parameters=parameters, operator_str="=="
+    )
+    # Reject equality constraints that equate two parameters
+    # (e.g. "x1 - x2 == 0"). DerivedParameter is the correct tool.
+    if (
+        bound == 0.0
+        and len(parameter_weights) == 2
+        and set(parameter_weights.values()) == {1.0, -1.0}
+    ):
+        params = list(parameter_weights.keys())
+        raise ValueError(
+            f"Equality constraint '{' '.join(tokens)}' is equivalent to "
+            f"'{params[0]} == {params[1]}'. Use a DerivedParameter to "
+            "express that two parameters must be equal."
+        )
+    expr = " + ".join(
+        f"{coeff} * {param}" for param, coeff in parameter_weights.items()
+    )
+    return ParameterConstraint(equality=f"{expr} == {bound}")
 
 
 def _process_monomial(monomial_str: str) -> tuple[float, str]:

--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -207,9 +207,9 @@ def object_attribute_dicts_find_unequal_fields(
             equal = one_val is other_val is None or (one_val.db_id == other_val.db_id)
         elif field == "_db_id":
             equal = skip_db_id_check or one_val == other_val
-        # Do not check the inequality_str for ParameterConstraints, checking the bound
-        # and coefficients dict is sufficient.
-        elif field == "_inequality_str":
+        # Do not check the constraint string for ParameterConstraints, checking
+        # the bound and coefficients dict is sufficient.
+        elif field == "_constraint_str":
             equal = True
         else:
             equal = is_ax_equal(one_val, other_val)

--- a/ax/utils/common/sympy.py
+++ b/ax/utils/common/sympy.py
@@ -45,6 +45,41 @@ def extract_coefficient_dict_from_inequality(
     }
 
 
+def extract_coefficient_dict_from_equality(
+    equality_str: str,
+) -> dict[Symbol, float]:
+    """
+    Parse a string of the form ``"expr == bound"`` into a coefficient dictionary.
+
+    SymPy's ``sympify`` does not produce an ``Equality`` from ``==`` (Python
+    evaluates ``==`` as a boolean), so we split the string on ``" == "`` and
+    sympify each side independently.
+
+    All terms are moved to the left side (``lhs - rhs``), and the result is
+    returned as a coefficient dictionary -- the same format as
+    ``extract_coefficient_dict_from_inequality``.
+    """
+    parts = equality_str.split("==")
+    if len(parts) != 2:
+        raise UserInputError(
+            f"Expected an equality constraint containing '==', found {equality_str}"
+        )
+
+    try:
+        lhs = sympify(sanitize_name(parts[0].strip(), sanitize_parens=True))
+        rhs = sympify(sanitize_name(parts[1].strip(), sanitize_parens=True))
+    except SympifyError:
+        raise UserInputError(f"Could not parse equality constraint: {equality_str}")
+
+    if not isinstance(lhs, Expr) or not isinstance(rhs, Expr):
+        raise UserInputError(f"Could not parse equality constraint: {equality_str}")
+
+    expression = lhs - rhs
+    return {
+        key: float(value) for key, value in expression.as_coefficients_dict().items()
+    }
+
+
 def parse_objective_expression(expression_str: str) -> Expr | tuple[Expr, ...]:
     """Sanitize and sympify an objective expression string.
 

--- a/ax/utils/common/tests/test_sympy.py
+++ b/ax/utils/common/tests/test_sympy.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.exceptions.core import UserInputError
+from ax.utils.common.sympy import extract_coefficient_dict_from_equality
+from ax.utils.common.testutils import TestCase
+from sympy import Symbol
+
+
+def _to_str_keys(d: dict[Symbol, float]) -> dict[str, float]:
+    return {str(k): v for k, v in d.items()}
+
+
+class ExtractCoefficientDictFromEqualityTest(TestCase):
+    def test_valid_expressions(self) -> None:
+        cases = [
+            ("x + y == 1.0", {"x": 1.0, "y": 1.0, "1": -1.0}),
+            ("2 * x + 3 * y == 5.0", {"x": 2.0, "y": 3.0, "1": -5.0}),
+            ("x == 3", {"x": 1.0, "1": -3.0}),
+            ("-x + y == 0", {"x": -1.0, "y": 1.0}),
+            ("- x + y == 1.0", {"x": -1.0, "y": 1.0, "1": -1.0}),
+            ("x + y  ==  1", {"x": 1.0, "y": 1.0, "1": -1.0}),
+        ]
+        for expr, expected in cases:
+            with self.subTest(expr=expr):
+                result = _to_str_keys(extract_coefficient_dict_from_equality(expr))
+                self.assertEqual(result, expected)
+
+    def test_sanitized_names(self) -> None:
+        result = _to_str_keys(
+            extract_coefficient_dict_from_equality("foo.bar + foo.baz == 1")
+        )
+        self.assertEqual(result.pop("1"), -1.0)
+        self.assertEqual(len(result), 2)
+
+    def test_error_missing_operator(self) -> None:
+        with self.assertRaisesRegex(UserInputError, "=="):
+            extract_coefficient_dict_from_equality("x + y <= 1")
+
+    def test_error_multiple_operators(self) -> None:
+        with self.assertRaisesRegex(UserInputError, "=="):
+            extract_coefficient_dict_from_equality("x == y == 1")
+
+    def test_error_empty_string(self) -> None:
+        with self.assertRaisesRegex(UserInputError, "=="):
+            extract_coefficient_dict_from_equality("")


### PR DESCRIPTION
Summary:

Add equality constraint extraction and propagation through the adapter layer
to TorchOptConfig, enabling downstream generators to receive equality
constraints.

- Add `extract_equality_constraints` in `adapter_utils.py` (filters for
  `is_equality=True` constraints, returns `(A, b)` matrices).
- Update `extract_parameter_constraints` to filter out equality constraints.
- Add `equality_constraints` parameter to `validate_and_apply_final_transform`
  (now returns a 7-tuple).
- Add `equality_constraints: tuple[Tensor, Tensor] | None` field to
  `TorchOptConfig`.
- Update `TorchAdapter._get_transformed_model_gen_args` to extract equality
  constraints and pass them through to `TorchOptConfig`.

Reviewed By: bletham

Differential Revision: D100256480
