### PR TITLE
Handle equality constraints in UnitX transform (#5179)

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -76,29 +76,65 @@ if TYPE_CHECKING:
     from ax import adapter as adapter_module  # noqa F401
 
 
-def extract_parameter_constraints(
+def _extract_constraints(
+    parameter_constraints: list[ParameterConstraint],
+    param_names: list[str],
+    is_equality: bool,
+) -> TBounds:
+    """Extract linear constraints into a tuple of NumPy arrays.
+
+    Shared helper for extracting inequality (``A x <= b``) or equality
+    (``A x = b``) constraints.
+
+    Args:
+        parameter_constraints: A list of parameter constraint objects.
+        param_names: A list of parameter names.
+        is_equality: If True, extract equality constraints; otherwise
+            extract inequality constraints.
+
+    Returns:
+        An optional tuple of NumPy arrays (A, b).
+    """
+    filtered = [c for c in parameter_constraints if c.is_equality == is_equality]
+    if len(filtered) == 0:
+        return None
+    A = np.zeros((len(filtered), len(param_names)))
+    b = np.zeros((len(filtered), 1))
+    for i, c in enumerate(filtered):
+        b[i, 0] = c.bound
+        for name, val in c.constraint_dict.items():
+            A[i, param_names.index(name)] = val
+    return (A, b)
+
+
+def extract_inequality_constraints(
     parameter_constraints: list[ParameterConstraint], param_names: list[str]
 ) -> TBounds:
-    """Convert Ax parameter constraints into a tuple of NumPy arrays representing the
-    system of linear inequality constraints.
+    """Convert Ax inequality parameter constraints into NumPy arrays.
 
     Args:
         parameter_constraints: A list of parameter constraint objects.
         param_names: A list of parameter names.
 
     Returns:
-        An optional tuple of NumPy arrays (A, b) representing the system of linear
-        inequality constraints A x < b.
+        An optional tuple of NumPy arrays (A, b) with ``A x <= b``.
     """
-    if len(parameter_constraints) == 0:
-        return None
-    A = np.zeros((len(parameter_constraints), len(param_names)))
-    b = np.zeros((len(parameter_constraints), 1))
-    for i, c in enumerate(parameter_constraints):
-        b[i, 0] = c.bound
-        for name, val in c.constraint_dict.items():
-            A[i, param_names.index(name)] = val
-    return (A, b)
+    return _extract_constraints(parameter_constraints, param_names, is_equality=False)
+
+
+def extract_equality_constraints(
+    parameter_constraints: list[ParameterConstraint], param_names: list[str]
+) -> TBounds:
+    """Convert Ax equality parameter constraints into NumPy arrays.
+
+    Args:
+        parameter_constraints: A list of parameter constraint objects.
+        param_names: A list of parameter names.
+
+    Returns:
+        An optional tuple of NumPy arrays (A, b) with ``A x = b``.
+    """
+    return _extract_constraints(parameter_constraints, param_names, is_equality=True)
 
 
 def extract_search_space_digest(
@@ -402,6 +438,7 @@ def validate_and_apply_final_transform(
     pending_observations: list[npt.NDArray] | None,
     objective_thresholds: npt.NDArray | None = None,
     pruning_target_point: npt.NDArray | None = None,
+    equality_constraints: tuple[npt.NDArray, npt.NDArray] | None = None,
     final_transform: Callable[[npt.NDArray], Tensor] = torch.tensor,
 ) -> tuple[
     Tensor,
@@ -410,6 +447,7 @@ def validate_and_apply_final_transform(
     list[Tensor] | None,
     Tensor | None,
     Tensor | None,
+    tuple[Tensor, Tensor] | None,
 ]:
     # TODO: use some container down the road (similar to
     # SearchSpaceDigest) to limit the return arguments
@@ -437,6 +475,12 @@ def validate_and_apply_final_transform(
     pruning_target_tensor: Tensor | None = None
     if pruning_target_point is not None:
         pruning_target_tensor = final_transform(pruning_target_point)
+    equality_constraints_tensors: tuple[Tensor, Tensor] | None = None
+    if equality_constraints is not None:
+        equality_constraints_tensors = (
+            final_transform(equality_constraints[0]),
+            final_transform(equality_constraints[1]),
+        )
     return (
         obj_weights_tensor,
         outcome_constraints_tensors,
@@ -444,6 +488,7 @@ def validate_and_apply_final_transform(
         pending_obs_tensors,
         obj_thresholds_tensor,
         pruning_target_tensor,
+        equality_constraints_tensors,
     )
 
 
@@ -700,7 +745,7 @@ def get_pareto_frontier_and_configs(
     if obj_t is not None:
         obj_t = array_to_tensor(obj_t)
     # Transform to tensors.
-    obj_w, oc_c, _, _, _, _ = validate_and_apply_final_transform(
+    obj_w, oc_c, _, _, _, _, _ = validate_and_apply_final_transform(
         objective_weights=objective_weights,
         outcome_constraints=outcome_constraints,
         linear_constraints=None,

--- a/ax/adapter/random.py
+++ b/ax/adapter/random.py
@@ -11,6 +11,7 @@ from collections.abc import Mapping, Sequence
 
 import numpy as np
 from ax.adapter.adapter_utils import (
+    extract_equality_constraints,
     extract_inequality_constraints,
     extract_search_space_digest,
     get_fixed_features,
@@ -95,6 +96,9 @@ class RandomAdapter(Adapter):
         linear_constraints = extract_inequality_constraints(
             search_space.parameter_constraints, self.parameters
         )
+        equality_constraints_np = extract_equality_constraints(
+            search_space.parameter_constraints, self.parameters
+        )
         # Extract generated points.
         # For normal generators these are used to deduplicate against.
         # For in-sample generators (LILO labeling) they are the selection
@@ -177,6 +181,7 @@ class RandomAdapter(Adapter):
             n=n,
             search_space_digest=search_space_digest,
             linear_constraints=linear_constraints,
+            equality_constraints=equality_constraints_np,
             fixed_features=fixed_features_dict,
             model_gen_options=model_gen_options,
             rounding_func=transform_callback(self.parameters, self.transforms),

--- a/ax/adapter/random.py
+++ b/ax/adapter/random.py
@@ -11,7 +11,7 @@ from collections.abc import Mapping, Sequence
 
 import numpy as np
 from ax.adapter.adapter_utils import (
-    extract_parameter_constraints,
+    extract_inequality_constraints,
     extract_search_space_digest,
     get_fixed_features,
     parse_observation_features,
@@ -92,7 +92,7 @@ class RandomAdapter(Adapter):
         # Get fixed features
         fixed_features_dict = get_fixed_features(fixed_features, self.parameters)
         # Extract param constraints
-        linear_constraints = extract_parameter_constraints(
+        linear_constraints = extract_inequality_constraints(
             search_space.parameter_constraints, self.parameters
         )
         # Extract generated points.

--- a/ax/adapter/tests/test_adapter_utils.py
+++ b/ax/adapter/tests/test_adapter_utils.py
@@ -15,6 +15,8 @@ from ax.adapter.adapter_utils import (
     _get_fresh_pairwise_trial_indices,
     arm_to_np_array,
     can_map_to_binary,
+    extract_equality_constraints,
+    extract_inequality_constraints,
     extract_objective_weight_matrix,
     extract_search_space_digest,
     feasible_hypervolume,
@@ -35,6 +37,7 @@ from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
 from ax.core.outcome_constraint import ObjectiveThreshold, OutcomeConstraint
 from ax.core.parameter import ChoiceParameter, ParameterType, RangeParameter
+from ax.core.parameter_constraint import ParameterConstraint
 from ax.core.search_space import SearchSpace
 from ax.core.types import ComparisonOp
 from ax.exceptions.core import UserInputError
@@ -377,6 +380,7 @@ class TestAdapterUtils(TestCase):
             _,
             _,
             target_p,
+            _,
         ) = validate_and_apply_final_transform(
             objective_weights=objective_weights,
             outcome_constraints=outcome_constraints,
@@ -412,6 +416,7 @@ class TestAdapterUtils(TestCase):
             _,
             _,
             target_p,
+            _,
         ) = validate_and_apply_final_transform(
             objective_weights=objective_weights,
             outcome_constraints=outcome_constraints,
@@ -652,3 +657,90 @@ class TestAdapterUtils(TestCase):
             self.assertNotIn(0, result)
             self.assertNotIn(1, result)
             self.assertIn(2, result)
+
+    def test_extract_inequality_constraints(self) -> None:
+        param_names = ["x", "y"]
+        ineq = ParameterConstraint(inequality="x + y <= 1")
+        eq = ParameterConstraint(equality="x + y == 1")
+
+        # Only inequality constraints are extracted
+        result = extract_inequality_constraints([ineq, eq], param_names)
+        self.assertIsNotNone(result)
+        assert result is not None
+        A, b = result
+        self.assertEqual(A.shape, (1, 2))
+        self.assertEqual(b.shape, (1, 1))
+        np.testing.assert_array_equal(A[0], [1.0, 1.0])
+        np.testing.assert_array_equal(b[0], [1.0])
+
+        # Returns None when no inequality constraints
+        result = extract_inequality_constraints([eq], param_names)
+        self.assertIsNone(result)
+
+        # Returns None for empty list
+        result = extract_inequality_constraints([], param_names)
+        self.assertIsNone(result)
+
+    def test_extract_equality_constraints(self) -> None:
+        param_names = ["x", "y"]
+        ineq = ParameterConstraint(inequality="x + y <= 1")
+        eq = ParameterConstraint(equality="x + y == 1")
+
+        # Only equality constraints are extracted
+        result = extract_equality_constraints([ineq, eq], param_names)
+        self.assertIsNotNone(result)
+        assert result is not None
+        A, b = result
+        self.assertEqual(A.shape, (1, 2))
+        self.assertEqual(b.shape, (1, 1))
+        np.testing.assert_array_equal(A[0], [1.0, 1.0])
+        np.testing.assert_array_equal(b[0], [1.0])
+
+        # Returns None when no equality constraints
+        result = extract_equality_constraints([ineq], param_names)
+        self.assertIsNone(result)
+
+    def test_extract_constraints_mixed(self) -> None:
+        """Both functions correctly partition a mixed list."""
+        param_names = ["x", "y"]
+        ineq1 = ParameterConstraint(inequality="x <= 0.5")
+        ineq2 = ParameterConstraint(inequality="y <= 0.8")
+        eq1 = ParameterConstraint(equality="x + y == 1")
+
+        ineq_result = extract_inequality_constraints([ineq1, eq1, ineq2], param_names)
+        eq_result = extract_equality_constraints([ineq1, eq1, ineq2], param_names)
+
+        assert ineq_result is not None
+        assert eq_result is not None
+        self.assertEqual(ineq_result[0].shape, (2, 2))  # 2 inequalities
+        self.assertEqual(eq_result[0].shape, (1, 2))  # 1 equality
+
+    def test_validate_and_apply_final_transform_equality_constraints(self) -> None:
+        """equality_constraints are converted to tensors."""
+        objective_weights = np.array([1.0, 0.0])
+        A_eq = np.array([[1.0, 1.0]])
+        b_eq = np.array([[1.0]])
+
+        _, _, _, _, _, _, eq_c = validate_and_apply_final_transform(
+            objective_weights=objective_weights,
+            outcome_constraints=None,
+            linear_constraints=None,
+            pending_observations=None,
+            equality_constraints=(A_eq, b_eq),
+        )
+        self.assertIsNotNone(eq_c)
+        assert eq_c is not None
+        self.assertTrue(torch.equal(eq_c[0], torch.tensor(A_eq)))
+        self.assertTrue(torch.equal(eq_c[1], torch.tensor(b_eq)))
+
+    def test_validate_and_apply_final_transform_no_equality_constraints(self) -> None:
+        """equality_constraints defaults to None."""
+        objective_weights = np.array([1.0])
+
+        _, _, _, _, _, _, eq_c = validate_and_apply_final_transform(
+            objective_weights=objective_weights,
+            outcome_constraints=None,
+            linear_constraints=None,
+            pending_observations=None,
+        )
+        self.assertIsNone(eq_c)

--- a/ax/adapter/tests/test_random_adapter.py
+++ b/ax/adapter/tests/test_random_adapter.py
@@ -109,6 +109,65 @@ class RandomAdapterTest(TestCase):
         self.assertEqual(obsf[1].parameters, {"x": 3.0, "y": 4.0, "z": 3.0})
         self.assertTrue(np.array_equal(gen_results.weights, np.array([1.0, 2.0])))
 
+    def test_gen_w_equality_constraints(self) -> None:
+        # Verify that equality constraints from the search space are extracted
+        # and passed through to the generator's gen() call.
+        x = RangeParameter("x", ParameterType.FLOAT, lower=0, upper=1)
+        y = RangeParameter("y", ParameterType.FLOAT, lower=0, upper=1)
+        z = RangeParameter("z", ParameterType.FLOAT, lower=0, upper=1)
+        parameter_constraints = [
+            ParameterConstraint(equality="x + y == 0.5"),
+        ]
+        search_space = SearchSpace([x, y, z], parameter_constraints)
+        experiment = Experiment(search_space=search_space)
+        adapter = RandomAdapter(experiment=experiment, generator=RandomGenerator())
+        with mock.patch.object(
+            adapter.generator,
+            "gen",
+            return_value=(
+                np.array([[0.2, 0.3, 0.4]]),
+                np.array([1.0]),
+            ),
+        ) as mock_gen:
+            adapter._gen(
+                n=1,
+                search_space=search_space,
+                pending_observations={},
+                fixed_features=ObservationFeatures({}),
+                optimization_config=None,
+                model_gen_options=self.model_gen_options,
+            )
+        gen_args = mock_gen.mock_calls[0][2]
+        eq_constraints = gen_args["equality_constraints"]
+        self.assertIsNotNone(eq_constraints)
+        A, b = eq_constraints
+        # x + y = 0.5 => A = [[1, 1, 0]], b = [[0.5]]
+        self.assertTrue(np.array_equal(A, np.array([[1.0, 1.0, 0.0]])))
+        self.assertTrue(np.array_equal(b, np.array([[0.5]])))
+
+    def test_gen_no_equality_constraints(self) -> None:
+        # Verify that equality_constraints is None when there are no equality
+        # constraints on the search space.
+        adapter = RandomAdapter(experiment=self.experiment, generator=RandomGenerator())
+        with mock.patch.object(
+            adapter.generator,
+            "gen",
+            return_value=(
+                np.array([[0.5, 1.5, 2.5]]),
+                np.array([1.0]),
+            ),
+        ) as mock_gen:
+            adapter._gen(
+                n=1,
+                search_space=self.search_space,
+                pending_observations={},
+                fixed_features=ObservationFeatures({}),
+                optimization_config=None,
+                model_gen_options=self.model_gen_options,
+            )
+        gen_args = mock_gen.mock_calls[0][2]
+        self.assertIsNone(gen_args["equality_constraints"])
+
     def test_gen_simple(self) -> None:
         # Test with no constraints, no fixed feature, no pending observations
         search_space = SearchSpace(self.parameters[:2])

--- a/ax/adapter/torch.py
+++ b/ax/adapter/torch.py
@@ -20,10 +20,11 @@ from ax.adapter.adapter_utils import (
     _get_fresh_pairwise_trial_indices,
     arm_to_np_array,
     array_to_observation_data,
+    extract_equality_constraints,
+    extract_inequality_constraints,
     extract_objective_thresholds,
     extract_objective_weight_matrix,
     extract_outcome_constraints,
-    extract_parameter_constraints,
     extract_search_space_digest,
     get_fixed_features,
     observation_data_to_array,
@@ -1044,7 +1045,10 @@ class TorchAdapter(Adapter):
             arm=optimization_config.pruning_target_parameterization,
             parameters=self.parameters,
         )
-        linear_constraints = extract_parameter_constraints(
+        linear_constraints = extract_inequality_constraints(
+            search_space.parameter_constraints, self.parameters
+        )
+        equality_constraints_np = extract_equality_constraints(
             search_space.parameter_constraints, self.parameters
         )
         fixed_features_dict = get_fixed_features(fixed_features, self.parameters)
@@ -1065,7 +1069,7 @@ class TorchAdapter(Adapter):
         pending_array = pending_observations_as_array_list(
             pending_observations, self.outcomes, self.parameters
         )
-        obj_w, out_c, lin_c, pend_o, obj_t, pruning_target_p = (
+        obj_w, out_c, lin_c, pend_o, obj_t, pruning_target_p, eq_c = (
             validate_and_apply_final_transform(
                 objective_weights=objective_weights,
                 outcome_constraints=outcome_constraints,
@@ -1073,6 +1077,7 @@ class TorchAdapter(Adapter):
                 pending_observations=pending_array,
                 objective_thresholds=objective_thresholds,
                 pruning_target_point=pruning_target_point,
+                equality_constraints=equality_constraints_np,
                 final_transform=self._array_to_tensor,
             )
         )
@@ -1089,6 +1094,7 @@ class TorchAdapter(Adapter):
             outcome_constraints=out_c,
             objective_thresholds=obj_t,
             linear_constraints=lin_c,
+            equality_constraints=eq_c,
             fixed_features=fixed_features_dict,
             pending_observations=pend_o,
             model_gen_options=model_gen_options or {},

--- a/ax/adapter/transforms/tests/test_unit_x_transform.py
+++ b/ax/adapter/transforms/tests/test_unit_x_transform.py
@@ -133,6 +133,40 @@ class UnitXTransformTest(TestCase):
             self.search_space_with_target.parameters["x"].target_value, 1.0
         )
 
+    def test_TransformSearchSpaceEqualityConstraints(self) -> None:
+        # Verify that equality constraints are preserved and correctly
+        # rescaled during UnitX transform_search_space.
+        ss = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    "x", lower=1, upper=3, parameter_type=ParameterType.FLOAT
+                ),
+                RangeParameter(
+                    "y", lower=1, upper=2, parameter_type=ParameterType.FLOAT
+                ),
+            ],
+            parameter_constraints=[
+                ParameterConstraint(equality="-0.5*x + y == 0.5"),
+                ParameterConstraint(inequality="-0.5*x + y <= 0.5"),
+            ],
+        )
+        t = UnitX(search_space=ss)
+        ss = t.transform_search_space(ss)
+
+        # Both constraints have the same math; only the type differs.
+        eq_c = ss.parameter_constraints[0]
+        ineq_c = ss.parameter_constraints[1]
+
+        # Equality constraint preserved.
+        self.assertTrue(eq_c.is_equality)
+        self.assertEqual(eq_c.constraint_dict, {"x": -1.0, "y": 1.0})
+        self.assertEqual(eq_c.bound, 0.0)
+
+        # Inequality constraint preserved.
+        self.assertFalse(ineq_c.is_equality)
+        self.assertEqual(ineq_c.constraint_dict, {"x": -1.0, "y": 1.0})
+        self.assertEqual(ineq_c.bound, 0.0)
+
     def test_transform_search_space_clears_digits(self) -> None:
         """Test that digits is cleared during transform to avoid rounding
         in unit space. Regression test for a bug where digits=-3 (round to

--- a/ax/adapter/transforms/unit_x.py
+++ b/ax/adapter/transforms/unit_x.py
@@ -103,11 +103,14 @@ class UnitX(Transform):
             expr = " + ".join(
                 f"{coeff} * {param}" for param, coeff in constraint_dict.items()
             )
-            new_constraints.append(
-                ParameterConstraint(
-                    inequality=f"{expr} <= {bound}",
+            if c.is_equality:
+                new_constraints.append(
+                    ParameterConstraint(equality=f"{expr} == {bound}")
                 )
-            )
+            else:
+                new_constraints.append(
+                    ParameterConstraint(inequality=f"{expr} <= {bound}")
+                )
         search_space.set_parameter_constraints(new_constraints)
         return search_space
 

--- a/ax/core/parameter_constraint.py
+++ b/ax/core/parameter_constraint.py
@@ -21,6 +21,9 @@ from ax.utils.common.sympy import (
 from pyre_extensions import none_throws
 
 
+PARAMETER_CONSTRAINT_TOLERANCE: float = 1e-8
+
+
 class ParameterConstraint(SortableBase):
     """Base class for linear parameter constraints.
 
@@ -120,8 +123,8 @@ class ParameterConstraint(SortableBase):
             for param, weight in self.constraint_dict.items()
         )
         if self.is_equality:
-            return abs(weighted_sum - self._bound) <= 1e-8
-        return weighted_sum <= self._bound + 1e-8  # allow for numerical imprecision
+            return abs(weighted_sum - self._bound) <= PARAMETER_CONSTRAINT_TOLERANCE
+        return weighted_sum <= self._bound + PARAMETER_CONSTRAINT_TOLERANCE
 
     def clone(self) -> ParameterConstraint:
         """Clone."""

--- a/ax/core/parameter_constraint.py
+++ b/ax/core/parameter_constraint.py
@@ -14,27 +14,54 @@ from ax.core.parameter import ChoiceParameter, Parameter, RangeParameter
 from ax.exceptions.core import UserInputError
 from ax.utils.common.base import SortableBase
 from ax.utils.common.string_utils import unsanitize_name
-from ax.utils.common.sympy import extract_coefficient_dict_from_inequality
+from ax.utils.common.sympy import (
+    extract_coefficient_dict_from_equality,
+    extract_coefficient_dict_from_inequality,
+)
+from pyre_extensions import none_throws
 
 
 class ParameterConstraint(SortableBase):
     """Base class for linear parameter constraints.
 
-    Constraints are expressed as a SymPy parsable inequality string.
+    Supports both inequality constraints (``w^T x <= b``) and equality
+    constraints (``w^T x == b``).  Exactly one of ``inequality`` or
+    ``equality`` must be provided.
     """
 
-    def __init__(self, inequality: str) -> None:
-        """Initialize ParameterConstraint
+    def __init__(
+        self,
+        inequality: str | None = None,
+        *,
+        equality: str | None = None,
+    ) -> None:
+        """Initialize ParameterConstraint.
 
         Args:
-            inequality: String representation of the constraint. At this point in time
-            Ax only accepts linear inequality constraints.
-        """
-        self._inequality_str = inequality
+            inequality: String representation of a linear inequality
+                constraint, e.g. ``"x1 + x2 <= 3"``.
+            equality: String representation of a linear equality
+                constraint, e.g. ``"x1 + x2 == 3"``.
 
-        coefficient_dict = extract_coefficient_dict_from_inequality(
-            inequality_str=inequality
-        )
+        Exactly one of ``inequality`` or ``equality`` must be provided.
+        """
+        if (inequality is None) == (equality is None):
+            raise UserInputError(
+                "Exactly one of `inequality` or `equality` must be provided."
+            )
+
+        self.is_equality: bool = equality is not None
+        constraint_str = none_throws(equality if self.is_equality else inequality)
+        self._constraint_str: str = constraint_str
+
+        if self.is_equality:
+            coefficient_dict = extract_coefficient_dict_from_equality(
+                equality_str=constraint_str
+            )
+        else:
+            coefficient_dict = extract_coefficient_dict_from_inequality(
+                inequality_str=constraint_str
+            )
 
         # Iterate through the coefficients to extract the parameter names and weights
         # and the bound
@@ -47,9 +74,12 @@ class ParameterConstraint(SortableBase):
                 # Invert because we are "moving" the bound to the right hand side
                 self._bound = -1 * coefficient
             else:
+                constraint_type = "equality" if self.is_equality else "inequality"
+                other_type = "inequality" if self.is_equality else "equality"
                 raise UserInputError(
-                    "Only linear inequality parameter constraints are supported, found "
-                    f"{inequality}"
+                    f"Only linear {constraint_type} parameter constraints are "
+                    f"supported, found {constraint_str}. "
+                    f"Did you mean to use the `{other_type}` argument?"
                 )
 
     @property
@@ -59,7 +89,7 @@ class ParameterConstraint(SortableBase):
 
     @property
     def bound(self) -> float:
-        """Get bound of the inequality of the constraint."""
+        """Get bound of the constraint."""
         return self._bound
 
     @bound.setter
@@ -71,7 +101,9 @@ class ParameterConstraint(SortableBase):
         """Whether or not the set of parameter values satisfies the constraint.
 
         Does a weighted sum of the parameter values based on the constraint_dict
-        and checks that the sum is less than the bound.
+        and checks against the bound. For inequality constraints checks
+        ``weighted_sum <= bound``; for equality constraints checks
+        ``|weighted_sum - bound| <= tolerance``.
 
         Args:
             parameter_dict: Map from parameter name to parameter value.
@@ -87,13 +119,15 @@ class ParameterConstraint(SortableBase):
             float(parameter_dict[param]) * weight
             for param, weight in self.constraint_dict.items()
         )
-        # Expected `int` for 2nd anonymous parameter to call `int.__le__` but got
-        # `float`.
+        if self.is_equality:
+            return abs(weighted_sum - self._bound) <= 1e-8
         return weighted_sum <= self._bound + 1e-8  # allow for numerical imprecision
 
     def clone(self) -> ParameterConstraint:
         """Clone."""
-        return ParameterConstraint(inequality=self._inequality_str)
+        if self.is_equality:
+            return ParameterConstraint(equality=self._constraint_str)
+        return ParameterConstraint(inequality=self._constraint_str)
 
     def clone_with_transformed_parameters(
         self, transformed_parameters: dict[str, Parameter]
@@ -102,10 +136,11 @@ class ParameterConstraint(SortableBase):
         return self.clone()
 
     def __repr__(self) -> str:
+        op = "==" if self.is_equality else "<="
         return (
             "ParameterConstraint("
             + " + ".join(f"{v}*{k}" for k, v in sorted(self.constraint_dict.items()))
-            + f" <= {self._bound})"
+            + f" {op} {self._bound})"
         )
 
     @property

--- a/ax/core/search_space.py
+++ b/ax/core/search_space.py
@@ -30,6 +30,7 @@ from ax.core.parameter import (
     TParamValue,
 )
 from ax.core.parameter_constraint import (
+    PARAMETER_CONSTRAINT_TOLERANCE,
     ParameterConstraint,
     validate_constraint_parameters,
 )
@@ -515,7 +516,7 @@ class SearchSpace(Base):
                 valid = valid | is_null
             in_design &= pd.Series(valid, index=df.index)
 
-        # Check parameter constraints (linear inequalities) vectorized
+        # Check parameter constraints vectorized
         for constraint in self._parameter_constraints:
             weighted_sum = pd.Series(0.0, index=df.index)
             for param_name, weight in constraint.constraint_dict.items():
@@ -525,7 +526,15 @@ class SearchSpace(Base):
                     break
                 # NaN values propagate if exists, causing comparison to return False
                 weighted_sum = weighted_sum + df[param_name] * weight
-            in_design &= weighted_sum <= constraint.bound + 1e-8
+            if constraint.is_equality:
+                in_design &= (
+                    np.abs(weighted_sum - constraint.bound)
+                    <= PARAMETER_CONSTRAINT_TOLERANCE
+                )
+            else:
+                in_design &= (
+                    weighted_sum <= constraint.bound + PARAMETER_CONSTRAINT_TOLERANCE
+                )
 
         # Handle hierarchical search space structure
         if self.is_hierarchical:
@@ -759,10 +768,14 @@ class SearchSpace(Base):
         feasible region defined by the parameter constraints. This is computed
         by solving a linear program. It is most limited by the tightest constraint.
 
-        For a polytope defined by a @ x <= b, the Chebyshev center (x_c, r) is
-        the solution to:
-            maximize r, where r is the radius of the inscribed ball
+        For inequality constraints a_i^T x <= b_i, the inscribed ball must fit
+        inside each half-space, so the radius is augmented:
+            maximize r
             subject to: a_i^T x + r ||a_i||_2 <= b_i for all i
+
+        Equality constraints c_j^T x = d_j require the center to lie on the
+        hyperplane and are passed through without radius augmentation (the ball
+        is inscribed within the lower-dimensional affine subspace).
 
         Note: this only considers natural (non-log, non-logit) range parameters.
         Other parameter types are handled naively via compute_naive_center.
@@ -781,8 +794,10 @@ class SearchSpace(Base):
         if not natural_range_params:
             return {}
 
-        constraint_matrix = []
-        bound_vector = []
+        ineq_constraint_matrix = []
+        ineq_bound_vector = []
+        eq_constraint_matrix = []
+        eq_bound_vector = []
         param_names = list(natural_range_params.keys())
         num_params = len(natural_range_params)
         param_name_to_idx = {name: idx for idx, name in enumerate(param_names)}
@@ -794,30 +809,47 @@ class SearchSpace(Base):
                 if param_name in param_name_to_idx:
                     row[param_name_to_idx[param_name]] = weight
 
-            constraint_matrix.append(row)
-            bound_vector.append(constraint.bound)
+            if constraint.is_equality:
+                eq_constraint_matrix.append(row)
+                eq_bound_vector.append(constraint.bound)
+            else:
+                ineq_constraint_matrix.append(row)
+                ineq_bound_vector.append(constraint.bound)
 
-        # Add parameter bounds
+        # Add parameter bounds (always inequality)
         for name, idx in param_name_to_idx.items():
             param = natural_range_params[name]
             # lower bound: -x_i <= -lower_i
             row_lower = np.zeros(num_params)
             row_lower[idx] = -1.0
-            constraint_matrix.append(row_lower)
-            bound_vector.append(-float(param.lower))
+            ineq_constraint_matrix.append(row_lower)
+            ineq_bound_vector.append(-float(param.lower))
 
             # upper bound: x_i <= upper_i
             row_upper = np.zeros(num_params)
             row_upper[idx] = 1.0
-            constraint_matrix.append(row_upper)
-            bound_vector.append(float(param.upper))
+            ineq_constraint_matrix.append(row_upper)
+            ineq_bound_vector.append(float(param.upper))
 
-        constraint_matrix = np.array(constraint_matrix)
-        bound_vector = np.array(bound_vector)
+        ineq_constraint_matrix_np = np.array(ineq_constraint_matrix)
+        ineq_bound_vector_np = np.array(ineq_bound_vector)
 
-        # Compute norm for each vector in constraint matrix
-        row_norms = np.linalg.norm(constraint_matrix, axis=1)
-        augmented_constraint_matrix = np.column_stack([constraint_matrix, row_norms])
+        # For the Chebyshev center, augment inequality constraints with
+        # r * ||a_i|| (the ball must fit inside each half-space).
+        row_norms = np.linalg.norm(ineq_constraint_matrix_np, axis=1)
+        augmented_constraint_matrix = np.column_stack(
+            [ineq_constraint_matrix_np, row_norms]
+        )
+
+        # Equality constraints: the ball center must lie on the hyperplane,
+        # so no radius augmentation is needed.
+        A_eq = None
+        b_eq = None
+        if eq_constraint_matrix:
+            # Pad equality rows with a zero column for the radius variable
+            eq_matrix_np = np.array(eq_constraint_matrix)
+            A_eq = np.column_stack([eq_matrix_np, np.zeros(eq_matrix_np.shape[0])])
+            b_eq = np.array(eq_bound_vector)
 
         # Set objective vector which maximizes r (minimize -r == maximize r)
         radius_objective_vector = np.zeros(num_params + 1)
@@ -825,7 +857,9 @@ class SearchSpace(Base):
         result = linprog(
             c=radius_objective_vector,
             A_ub=augmented_constraint_matrix,
-            b_ub=bound_vector,
+            b_ub=ineq_bound_vector_np,
+            A_eq=A_eq,
+            b_eq=b_eq,
             bounds=[(None, None)] * num_params + [(0, None)],  # no bounds except r >= 0
         )
 

--- a/ax/core/tests/test_parameter_constraint.py
+++ b/ax/core/tests/test_parameter_constraint.py
@@ -20,6 +20,8 @@ class ParameterConstraintTest(TestCase):
         super().setUp()
         self.constraint = ParameterConstraint(inequality="2 * x - 3 * y <= 6.0")
         self.constraint_repr = "ParameterConstraint(2.0*x + -3.0*y <= 6.0)"
+        self.eq_constraint = ParameterConstraint(equality="x + y == 1.0")
+        self.eq_constraint_repr = "ParameterConstraint(1.0*x + 1.0*y == 1.0)"
 
     def test_constraint_dict_and_bounds(self) -> None:
         constraint = ParameterConstraint(inequality="x1 + x2 <= 1")
@@ -122,6 +124,74 @@ class ParameterConstraintTest(TestCase):
             inequality="2 * x - 3 * y <= 6.0",
         )
         self.assertTrue(constraint1 < constraint2)
+
+    def test_equality_constraint_init(self) -> None:
+        cases = [
+            ("x + y == 1.0", {"x": 1.0, "y": 1.0}, 1.0),
+            ("2 * x + 3 * y == 5.0", {"x": 2.0, "y": 3.0}, 5.0),
+            ("-x + y == 1.0", {"x": -1.0, "y": 1.0}, 1.0),
+            ("- x + y == 1.0", {"x": -1.0, "y": 1.0}, 1.0),
+        ]
+        for expr, expected_dict, expected_bound in cases:
+            with self.subTest(expr=expr):
+                c = ParameterConstraint(equality=expr)
+                self.assertTrue(c.is_equality)
+                self.assertEqual(c.constraint_dict, expected_dict)
+                self.assertEqual(c.bound, expected_bound)
+
+        c_ineq = ParameterConstraint(inequality="x + y <= 1.0")
+        self.assertFalse(c_ineq.is_equality)
+
+    def test_equality_constraint_must_provide_one(self) -> None:
+        # Neither provided
+        with self.assertRaisesRegex(UserInputError, "Exactly one"):
+            ParameterConstraint()
+
+        # Both provided
+        with self.assertRaisesRegex(UserInputError, "Exactly one"):
+            ParameterConstraint(inequality="x <= 1", equality="x == 1")
+
+    def test_equality_constraint_check(self) -> None:
+        c = ParameterConstraint(equality="x + y == 1.0")
+
+        cases = [
+            ({"x": 0.5, "y": 0.5}, True, "exact"),
+            ({"x": 0.5, "y": 0.5 + 0.5e-9}, True, "within tolerance"),
+            ({"x": 0.5, "y": 0.6}, False, "violated above"),
+            ({"x": 0.5, "y": 0.4}, False, "violated below"),
+        ]
+        for params, expected, label in cases:
+            with self.subTest(label=label):
+                self.assertEqual(c.check(params), expected)
+
+    def test_equality_constraint_repr(self) -> None:
+        self.assertEqual(str(self.eq_constraint), self.eq_constraint_repr)
+
+    def test_equality_constraint_clone(self) -> None:
+        clone = self.eq_constraint.clone()
+        self.assertTrue(clone.is_equality)
+        self.assertEqual(clone.constraint_dict, self.eq_constraint.constraint_dict)
+        self.assertEqual(clone.bound, self.eq_constraint.bound)
+
+        # Mutation of clone doesn't affect original
+        clone._bound = 99.0
+        self.assertNotEqual(self.eq_constraint.bound, clone.bound)
+
+    def test_equality_constraint_clone_with_transformed_parameters(self) -> None:
+        clone = self.eq_constraint.clone_with_transformed_parameters(
+            transformed_parameters={}
+        )
+        self.assertTrue(clone.is_equality)
+        self.assertEqual(clone.bound, self.eq_constraint.bound)
+
+    def test_equality_constraint_eq(self) -> None:
+        c1 = ParameterConstraint(equality="x + y == 1.0")
+        c2 = ParameterConstraint(equality="x + y == 1.0")
+        self.assertEqual(c1, c2)
+
+        # Different from inequality with same coefficients
+        c3 = ParameterConstraint(inequality="x + y <= 1.0")
+        self.assertNotEqual(c1, c3)
 
 
 class ValidateConstraintParametersTest(TestCase):

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -1054,6 +1054,126 @@ class SearchSpaceTest(TestCase):
             self.assertIsNotNone(result)
             self.assertEqual(result.parameters, {"x2": 0.0})
 
+    def test_check_membership_df_equality_constraint(self) -> None:
+        """Test vectorized membership check with equality constraints."""
+        ss = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+                RangeParameter(
+                    name="y",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            ],
+            parameter_constraints=[
+                ParameterConstraint(equality="x + y == 1.0"),
+            ],
+        )
+        df = pd.DataFrame({"x": [0.3, 0.5, 0.7, 0.6], "y": [0.7, 0.5, 0.2, 0.4]})
+
+        result = ss.check_membership_df(df)
+        # Rows 0, 1, 3 satisfy x + y == 1.0; row 2 has x + y = 0.9
+        self.assertEqual(result, [True, True, False, True])
+
+    def test_check_membership_df_mixed_constraints(self) -> None:
+        """Test vectorized membership with both equality and inequality."""
+        ss = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+                RangeParameter(
+                    name="y",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            ],
+            parameter_constraints=[
+                ParameterConstraint(equality="x + y == 1.0"),
+                ParameterConstraint(inequality="x <= 0.6"),
+            ],
+        )
+        df = pd.DataFrame({"x": [0.3, 0.7, 0.5], "y": [0.7, 0.3, 0.5]})
+
+        result = ss.check_membership_df(df)
+        # Row 0: x+y=1 OK, x=0.3<=0.6 OK  -> True
+        # Row 1: x+y=1 OK, x=0.7<=0.6 FAIL -> False
+        # Row 2: x+y=1 OK, x=0.5<=0.6 OK  -> True
+        self.assertEqual(result, [True, False, True])
+
+    def test_compute_chebyshev_center_with_equality_constraint(self) -> None:
+        """Chebyshev center must lie on the equality hyperplane."""
+        ss = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+                RangeParameter(
+                    name="y",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            ],
+            parameter_constraints=[
+                ParameterConstraint(equality="x + y == 1.0"),
+            ],
+        )
+        center = ss.compute_chebyshev_center()
+        self.assertIsNotNone(center)
+        assert center is not None
+        # Center must satisfy x + y == 1
+        self.assertAlmostEqual(center["x"] + center["y"], 1.0, places=6)
+        # By symmetry, center should be at (0.5, 0.5)
+        self.assertAlmostEqual(center["x"], 0.5, places=6)
+        self.assertAlmostEqual(center["y"], 0.5, places=6)
+
+    def test_compute_chebyshev_center_equality_and_inequality(self) -> None:
+        """Chebyshev center with both equality and inequality constraints."""
+        ss = SearchSpace(
+            parameters=[
+                RangeParameter(
+                    name="x",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+                RangeParameter(
+                    name="y",
+                    parameter_type=ParameterType.FLOAT,
+                    lower=0.0,
+                    upper=1.0,
+                ),
+            ],
+            parameter_constraints=[
+                ParameterConstraint(equality="x + y == 1.0"),
+                ParameterConstraint(inequality="x <= 0.8"),
+            ],
+        )
+        center = ss.compute_chebyshev_center()
+        self.assertIsNotNone(center)
+        assert center is not None
+        # Must satisfy equality constraint
+        self.assertAlmostEqual(center["x"] + center["y"], 1.0, places=6)
+        # Must satisfy inequality: x <= 0.8
+        self.assertLessEqual(center["x"], 0.8 + 1e-6)
+        # Must satisfy bounds
+        self.assertGreaterEqual(center["x"], -1e-6)
+        self.assertGreaterEqual(center["y"], -1e-6)
+
 
 class SearchSpaceDigestTest(TestCase):
     def setUp(self) -> None:

--- a/ax/generators/random/base.py
+++ b/ax/generators/random/base.py
@@ -113,6 +113,7 @@ class RandomGenerator(Generator):
         n: int,
         search_space_digest: SearchSpaceDigest,
         linear_constraints: tuple[npt.NDArray, npt.NDArray] | None = None,
+        equality_constraints: tuple[npt.NDArray, npt.NDArray] | None = None,
         fixed_features: dict[int, float] | None = None,
         model_gen_options: TConfig | None = None,
         rounding_func: Callable[[npt.NDArray], npt.NDArray] | None = None,
@@ -127,6 +128,9 @@ class RandomGenerator(Generator):
             linear_constraints: A tuple of (A, b). For k linear constraints on
                 d-dimensional x, A is (k x d) and b is (k x 1) such that
                 A x <= b.
+            equality_constraints: A tuple of (A, b). For k equality constraints
+                on d-dimensional x, A is (k x d) and b is (k x 1) such that
+                A x = b.
             fixed_features: A map {feature_index: value} for features that
                 should be fixed to a particular value during generation.
             model_gen_options: A config dictionary that is passed along to the
@@ -205,9 +209,10 @@ class RandomGenerator(Generator):
                     inequality_constraints=self._convert_inequality_constraints(
                         linear_constraints,
                     ),
-                    equality_constraints=self._convert_equality_constraints(
+                    equality_constraints=self._combine_equality_constraints(
                         d=len(search_space_digest.bounds),
                         fixed_features=fixed_features,
+                        equality_constraints=equality_constraints,
                     ),
                     bounds=self._convert_bounds(bounds=search_space_digest.bounds),
                     interior_point=interior_point,
@@ -352,6 +357,43 @@ class RandomGenerator(Generator):
         for index in range(0, len(fixed_vals)):
             constraint_matrix[index, fixed_indices[index]] = 1.0
         return constraint_matrix, fixed_vals
+
+    def _combine_equality_constraints(
+        self,
+        d: int,
+        fixed_features: dict[int, float] | None,
+        equality_constraints: tuple[npt.NDArray, npt.NDArray] | None = None,
+    ) -> tuple[Tensor, Tensor] | None:
+        """Combine fixed-feature equality constraints with parameter equality
+        constraints into a single (C, c) matrix for the polytope sampler.
+
+        Args:
+            d: Dimension of samples.
+            fixed_features: A map {feature_index: value} for features that
+                should be fixed to a particular value during generation.
+            equality_constraints: A tuple of (A, b) NumPy arrays from
+                ``extract_equality_constraints``.
+
+        Returns:
+            Optional 2-element tuple containing C and c such that Cx = c.
+        """
+        fixed_eq = self._convert_equality_constraints(
+            d=d, fixed_features=fixed_features
+        )
+        param_eq = None
+        if equality_constraints is not None:
+            A = torch.as_tensor(equality_constraints[0], dtype=torch.double)
+            b = torch.as_tensor(equality_constraints[1], dtype=torch.double).squeeze(-1)
+            param_eq = (A, b)
+
+        if fixed_eq is None and param_eq is None:
+            return None
+        if fixed_eq is not None and param_eq is not None:
+            return (
+                torch.cat([fixed_eq[0], param_eq[0]], dim=0),
+                torch.cat([fixed_eq[1], param_eq[1]], dim=0),
+            )
+        return fixed_eq if fixed_eq is not None else param_eq
 
     def _convert_bounds(self, bounds: list[tuple[float, float]]) -> Tensor | None:
         """Helper method to convert bounds list used by the rejectionsampler to the

--- a/ax/generators/random/in_sample.py
+++ b/ax/generators/random/in_sample.py
@@ -37,6 +37,7 @@ class InSampleUniformGenerator(RandomGenerator):
         n: int,
         search_space_digest: SearchSpaceDigest,
         linear_constraints: tuple[npt.NDArray, npt.NDArray] | None = None,
+        equality_constraints: tuple[npt.NDArray, npt.NDArray] | None = None,
         fixed_features: dict[int, float] | None = None,
         model_gen_options: TConfig | None = None,
         rounding_func: Callable[[npt.NDArray], npt.NDArray] | None = None,
@@ -49,6 +50,7 @@ class InSampleUniformGenerator(RandomGenerator):
             search_space_digest: A ``SearchSpaceDigest`` object containing
                 metadata on the features in the datasets.
             linear_constraints: Not used. Accepted for interface compatibility.
+            equality_constraints: Not used. Accepted for interface compatibility.
             fixed_features: Not used. Accepted for interface compatibility.
             model_gen_options: Not used. Accepted for interface compatibility.
             rounding_func: Not used. Accepted for interface compatibility.

--- a/ax/generators/random/sobol.py
+++ b/ax/generators/random/sobol.py
@@ -81,6 +81,7 @@ class SobolGenerator(RandomGenerator):
         n: int,
         search_space_digest: SearchSpaceDigest,
         linear_constraints: tuple[npt.NDArray, npt.NDArray] | None = None,
+        equality_constraints: tuple[npt.NDArray, npt.NDArray] | None = None,
         fixed_features: dict[int, float] | None = None,
         model_gen_options: TConfig | None = None,
         rounding_func: Callable[[npt.NDArray], npt.NDArray] | None = None,
@@ -95,6 +96,9 @@ class SobolGenerator(RandomGenerator):
             linear_constraints: A tuple of (A, b). For k linear constraints on
                 d-dimensional x, A is (k x d) and b is (k x 1) such that
                 A x <= b.
+            equality_constraints: A tuple of (A, b). For k equality constraints
+                on d-dimensional x, A is (k x d) and b is (k x 1) such that
+                A x = b.
             fixed_features: A map {feature_index: value} for features that
                 should be fixed to a particular value during generation.
             rounding_func: A function that rounds an optimization result
@@ -117,6 +121,7 @@ class SobolGenerator(RandomGenerator):
             n=n,
             search_space_digest=search_space_digest,
             linear_constraints=linear_constraints,
+            equality_constraints=equality_constraints,
             fixed_features=fixed_features,
             model_gen_options=model_gen_options,
             rounding_func=rounding_func,

--- a/ax/generators/tests/test_random.py
+++ b/ax/generators/tests/test_random.py
@@ -61,6 +61,62 @@ class RandomGeneratorTest(TestCase):
         self.assertEqual(C_comparison.any(), True)
         self.assertEqual(self.random_model._convert_equality_constraints(d, None), None)
 
+    def test_CombineEqualityConstraints(self) -> None:
+        d = 4
+        # Both None: returns None.
+        self.assertIsNone(
+            self.random_model._combine_equality_constraints(
+                d=d, fixed_features=None, equality_constraints=None
+            )
+        )
+
+        # Only fixed_features: returns the fixed-feature constraints.
+        fixed_features = {1: 0.5, 3: 0.7}
+        C, c = none_throws(
+            self.random_model._combine_equality_constraints(
+                d=d, fixed_features=fixed_features, equality_constraints=None
+            )
+        )
+        self.assertEqual(C.shape, (2, d))
+        self.assertEqual(c.shape, (2,))
+        self.assertEqual(C[0, 1].item(), 1.0)
+        self.assertEqual(C[1, 3].item(), 1.0)
+        self.assertAlmostEqual(c[0].item(), 0.5)
+        self.assertAlmostEqual(c[1].item(), 0.7)
+
+        # Only equality_constraints: returns the parameter constraints.
+        A_np = np.array([[1.0, 1.0, 0.0, 0.0]])
+        b_np = np.array([[2.0]])
+        C, c = none_throws(
+            self.random_model._combine_equality_constraints(
+                d=d,
+                fixed_features=None,
+                equality_constraints=(A_np, b_np),
+            )
+        )
+        self.assertEqual(C.shape, (1, d))
+        self.assertEqual(c.shape, (1,))
+        self.assertTrue(torch.equal(C, torch.tensor([[1.0, 1.0, 0.0, 0.0]])))
+        self.assertAlmostEqual(c[0].item(), 2.0)
+
+        # Both present: concatenates fixed-feature and parameter constraints.
+        C, c = none_throws(
+            self.random_model._combine_equality_constraints(
+                d=d,
+                fixed_features=fixed_features,
+                equality_constraints=(A_np, b_np),
+            )
+        )
+        # 2 from fixed_features + 1 from equality_constraints = 3 rows.
+        self.assertEqual(C.shape, (3, d))
+        self.assertEqual(c.shape, (3,))
+        # First two rows are from fixed_features (sorted by key: 1, 3).
+        self.assertEqual(C[0, 1].item(), 1.0)
+        self.assertEqual(C[1, 3].item(), 1.0)
+        # Third row is from the parameter equality constraint.
+        self.assertTrue(torch.equal(C[2], torch.tensor([1.0, 1.0, 0.0, 0.0])))
+        self.assertAlmostEqual(c[2].item(), 2.0)
+
     def test_ConvertInequalityConstraints(self) -> None:
         A = np.array([[1, 2], [3, 4]])
         b = np.array([[5], [6]])

--- a/ax/generators/tests/test_sobol.py
+++ b/ax/generators/tests/test_sobol.py
@@ -9,6 +9,7 @@
 from unittest import mock
 
 import numpy as np
+import torch
 from ax.core.search_space import SearchSpaceDigest
 from ax.exceptions.core import SearchSpaceExhausted
 from ax.generators.random.sobol import SobolGenerator
@@ -243,6 +244,81 @@ class SobolGeneratorTest(TestCase):
         self.assertEqual(wrapped_sampler.call_args.kwargs["n_thinning"], 3)
 
         rounding_func.assert_called()
+
+    def test_SobolGeneratorFallbackToPolytopeSamplerWithEqualityConstraints(
+        self,
+    ) -> None:
+        # Ten parameters with sum <= 1 (forces polytope fallback) plus
+        # an equality constraint x0 + x1 = 0.4 to verify equality constraints
+        # are threaded through to the polytope sampler.
+        generator = SobolGenerator(seed=0, fallback_to_sample_polytope=True)
+        ssd = self._create_ssd(n_tunable=10, n_fixed=0)
+        A_ineq = np.ones((1, 10))
+        b_ineq = np.array([1]).reshape((1, 1))
+        # Equality constraint: x0 + x1 = 0.4
+        A_eq = np.zeros((1, 10))
+        A_eq[0, 0] = 1.0
+        A_eq[0, 1] = 1.0
+        b_eq = np.array([[0.4]])
+        generated_points, _ = generator.gen(
+            n=3,
+            search_space_digest=ssd,
+            linear_constraints=(A_ineq, b_ineq),
+            equality_constraints=(A_eq, b_eq),
+            rounding_func=lambda x: x,
+        )
+        self.assertEqual(np.shape(generated_points), (3, 10))
+        # Inequality constraint satisfied.
+        self.assertTrue(np.all(generated_points @ A_ineq.T <= b_ineq + 1e-6))
+        # Equality constraint satisfied: x0 + x1 ≈ 0.4.
+        eq_vals = generated_points @ A_eq.T
+        np.testing.assert_allclose(eq_vals, 0.4, atol=1e-6)
+
+    def test_SobolGeneratorFallbackToPolytopeSamplerWithEqAndFixedFeatures(
+        self,
+    ) -> None:
+        # Verify that equality constraints and fixed features are combined
+        # correctly and passed to the polytope sampler.
+        generator = SobolGenerator(seed=0, fallback_to_sample_polytope=True)
+        ssd = self._create_ssd(n_tunable=10, n_fixed=1)
+        A_ineq = np.insert(np.ones((1, 10)), 10, 0, axis=1)
+        b_ineq = np.array([1]).reshape((1, 1))
+        # Equality constraint: x0 + x1 = 0.3.
+        A_eq = np.zeros((1, 11))
+        A_eq[0, 0] = 1.0
+        A_eq[0, 1] = 1.0
+        b_eq = np.array([[0.3]])
+
+        with mock.patch(
+            "ax.generators.random.base.HitAndRunPolytopeSampler"
+        ) as MockSampler:
+            mock_instance = MockSampler.return_value
+            mock_instance.draw.return_value = torch.rand(1, 11, dtype=torch.double)
+            try:
+                generator.gen(
+                    n=1,
+                    search_space_digest=ssd,
+                    linear_constraints=(A_ineq, b_ineq),
+                    equality_constraints=(A_eq, b_eq),
+                    fixed_features={10: 1},
+                    rounding_func=lambda x: x,
+                )
+            except Exception:
+                pass
+            if MockSampler.called:
+                eq_arg = MockSampler.call_args.kwargs["equality_constraints"]
+                self.assertIsNotNone(eq_arg)
+                C, c = eq_arg
+                # 1 from fixed features + 1 from parameter equality = 2 rows.
+                self.assertEqual(C.shape[0], 2)
+                self.assertEqual(C.shape[1], 11)
+                # Fixed feature: x[10] = 1 (last row from fixed, first in sorted).
+                self.assertEqual(C[0, 10].item(), 1.0)
+                self.assertAlmostEqual(c[0].item(), 1.0)
+                # Parameter equality: x[0] + x[1] = 0.3.
+                self.assertEqual(C[1, 0].item(), 1.0)
+                self.assertEqual(C[1, 1].item(), 1.0)
+                self.assertAlmostEqual(c[1].item(), 0.3)
 
     def test_SobolGeneratorFallbackToPolytopeSamplerWithFixedParam(self) -> None:
         # Ten parameters with sum less than 1. In this example, the rejection

--- a/ax/generators/tests/test_sobol.py
+++ b/ax/generators/tests/test_sobol.py
@@ -305,20 +305,20 @@ class SobolGeneratorTest(TestCase):
                 )
             except Exception:
                 pass
-            if MockSampler.called:
-                eq_arg = MockSampler.call_args.kwargs["equality_constraints"]
-                self.assertIsNotNone(eq_arg)
-                C, c = eq_arg
-                # 1 from fixed features + 1 from parameter equality = 2 rows.
-                self.assertEqual(C.shape[0], 2)
-                self.assertEqual(C.shape[1], 11)
-                # Fixed feature: x[10] = 1 (last row from fixed, first in sorted).
-                self.assertEqual(C[0, 10].item(), 1.0)
-                self.assertAlmostEqual(c[0].item(), 1.0)
-                # Parameter equality: x[0] + x[1] = 0.3.
-                self.assertEqual(C[1, 0].item(), 1.0)
-                self.assertEqual(C[1, 1].item(), 1.0)
-                self.assertAlmostEqual(c[1].item(), 0.3)
+            self.assertTrue(MockSampler.called)
+            eq_arg = MockSampler.call_args.kwargs["equality_constraints"]
+            self.assertIsNotNone(eq_arg)
+            C, c = eq_arg
+            # 1 from fixed features + 1 from parameter equality = 2 rows.
+            self.assertEqual(C.shape[0], 2)
+            self.assertEqual(C.shape[1], 11)
+            # Fixed feature: x[10] = 1 (last row from fixed, first in sorted).
+            self.assertEqual(C[0, 10].item(), 1.0)
+            self.assertAlmostEqual(c[0].item(), 1.0)
+            # Parameter equality: x[0] + x[1] = 0.3.
+            self.assertEqual(C[1, 0].item(), 1.0)
+            self.assertEqual(C[1, 1].item(), 1.0)
+            self.assertAlmostEqual(c[1].item(), 0.3)
 
     def test_SobolGeneratorFallbackToPolytopeSamplerWithFixedParam(self) -> None:
         # Ten parameters with sum less than 1. In this example, the rejection

--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -596,6 +596,7 @@ class Acquisition(Base):
         n: int,
         search_space_digest: SearchSpaceDigest,
         inequality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
+        equality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
         fixed_features: dict[int, float] | None = None,
         rounding_func: Callable[[Tensor], Tensor] | None = None,
         optimizer_options: dict[str, Any] | None = None,
@@ -612,6 +613,9 @@ class Acquisition(Base):
             inequality_constraints: A list of tuples (indices, coefficients, rhs),
                 with each tuple encoding an inequality constraint of the form
                 ``sum_i (X[indices[i]] * coefficients[i]) >= rhs``.
+            equality_constraints: A list of tuples (indices, coefficients, rhs),
+                with each tuple encoding an equality constraint of the form
+                ``sum_i (X[indices[i]] * coefficients[i]) = rhs``.
             fixed_features: A map `{feature_index: value}` for features that
                 should be fixed to a particular value during generation.
             rounding_func: A function that post-processes an optimization
@@ -664,8 +668,8 @@ class Acquisition(Base):
         # Ax expects `optimize_acqf` to return tensors of a certain shape.
         if optimizer_options is not None:
             forbidden_optimizer_options = [
-                "equality_constraints",
-                "inequality_constraints",  # These should be constructed by Ax
+                "equality_constraints",  # Constructed by Ax
+                "inequality_constraints",  # Constructed by Ax
                 "batch_initial_conditions",
                 "return_best_only",
                 "return_full_tree",
@@ -716,6 +720,7 @@ class Acquisition(Base):
                 bounds=bounds,
                 q=n,
                 inequality_constraints=inequality_constraints,
+                equality_constraints=equality_constraints,
                 fixed_features=fixed_features,
                 post_processing_func=rounding_func,
                 acq_function_sequence=self.acq_function_sequence,
@@ -727,6 +732,11 @@ class Acquisition(Base):
             "optimize_acqf_discrete",
             "optimize_acqf_discrete_local_search",
         ):
+            if equality_constraints:
+                raise ValueError(
+                    "Equality constraints are not supported with discrete "
+                    f"optimizer '{optimizer}'."
+                )
             X_observed = self.X_observed
             if self.X_pending is not None:
                 if X_observed is None:
@@ -805,6 +815,7 @@ class Acquisition(Base):
                     discrete_choices=discrete_choices
                 ),
                 inequality_constraints=inequality_constraints,
+                equality_constraints=equality_constraints,
                 post_processing_func=rounding_func,
                 **optimizer_options_with_defaults,
             )
@@ -832,9 +843,15 @@ class Acquisition(Base):
                 post_processing_func=rounding_func,
                 fixed_features=fixed_features,
                 inequality_constraints=inequality_constraints,
+                equality_constraints=equality_constraints,
                 **optimizer_options_with_defaults,
             )
         elif optimizer == "optimize_with_nsgaii":
+            if equality_constraints:
+                raise ValueError(
+                    "Equality constraints are not supported with "
+                    "optimizer 'optimize_with_nsgaii'."
+                )
             if optimize_with_nsgaii is not None:
                 acqf = assert_is_instance(
                     self.acqf, MultiOutputAcquisitionFunctionWrapper
@@ -873,6 +890,7 @@ class Acquisition(Base):
                     candidates=candidates,
                     search_space_digest=search_space_digest,
                     inequality_constraints=inequality_constraints,
+                    equality_constraints=equality_constraints,
                     fixed_features=fixed_features,
                 )
         # Validate candidates before returning
@@ -883,6 +901,7 @@ class Acquisition(Base):
             inequality_constraints=inequality_constraints,
             feature_names=search_space_digest.feature_names,
             task_features=search_space_digest.task_features,
+            equality_constraints=equality_constraints,
         )
 
         n_candidates = candidates.shape[0]
@@ -986,6 +1005,7 @@ class Acquisition(Base):
         candidates: Tensor,
         search_space_digest: SearchSpaceDigest,
         inequality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
+        equality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
         fixed_features: dict[int, float] | None = None,
     ) -> tuple[Tensor, Tensor]:
         r"""Prune irrelevant parameters from the candidates using BONSAI.
@@ -1092,6 +1112,7 @@ class Acquisition(Base):
                         candidates=pruned_candidates,
                         indices=indices,
                         inequality_constraints=inequality_constraints,
+                        equality_constraints=equality_constraints,
                     )
                     if pruned_candidates.shape[0] == 0:
                         # no feasible points, continue to
@@ -1205,6 +1226,7 @@ def _remove_infeasible_candidates(
     candidates: Tensor,
     indices: Tensor,
     inequality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
+    equality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
 ) -> tuple[Tensor, Tensor]:
     r"""Filter out infeasible candidates, based on the parameter constraints.
 
@@ -1214,24 +1236,19 @@ def _remove_infeasible_candidates(
             in [0, d-1).
         inequality_constraints: A list of tuples (indices, coefficients, rhs),
             with each tuple encoding an inequality constraint of the form
-            `\sum_i (X[indices[i]] * coefficients[i]) >= rhs`. `indices` and
-            `coefficients` should be torch tensors. See the docstring of
-            `make_scipy_linear_constraints` for an example. When q=1, or when
-            applying the same constraint to each candidate in the batch
-            (intra-point constraint), `indices` should be a 1-d tensor.
-            For inter-point constraints, in which the constraint is applied to the
-            whole batch of candidates, `indices` must be a 2-d tensor, where
-            in each row `indices[i] =(k_i, l_i)` the first index `k_i` corresponds
-            to the `k_i`-th element of the `q`-batch and the second index `l_i`
-            corresponds to the `l_i`-th feature of that element.
+            `\sum_i (X[indices[i]] * coefficients[i]) >= rhs`.
+        equality_constraints: A list of tuples (indices, coefficients, rhs),
+            with each tuple encoding an equality constraint of the form
+            `\sum_i (X[indices[i]] * coefficients[i]) = rhs`.
 
     Returns:
-        A two-element tuple containing the filter candidates and indices.
+        A two-element tuple containing the filtered candidates and indices.
     """
-    if inequality_constraints is not None:
+    if inequality_constraints is not None or equality_constraints is not None:
         is_feasible = evaluate_feasibility(
             X=candidates,
             inequality_constraints=inequality_constraints,
+            equality_constraints=equality_constraints,
         )
         candidates = candidates[is_feasible]
         indices = indices[is_feasible]

--- a/ax/generators/torch/botorch_modular/generator.py
+++ b/ax/generators/torch/botorch_modular/generator.py
@@ -26,6 +26,7 @@ from ax.generators.torch.botorch_modular.utils import (
     ModelConfig,
 )
 from ax.generators.torch.utils import (
+    _to_equality_constraints,
     _to_inequality_constraints,
     get_feature_importances_from_botorch_model,
     get_rounding_func,
@@ -400,6 +401,9 @@ class BoTorchGenerator(TorchGenerator, Base):
             search_space_digest=search_space_digest,
             inequality_constraints=_to_inequality_constraints(
                 linear_constraints=torch_opt_config.linear_constraints
+            ),
+            equality_constraints=_to_equality_constraints(
+                equality_constraints=torch_opt_config.equality_constraints
             ),
             fixed_features=torch_opt_config.fixed_features,
             rounding_func=botorch_rounding_func,

--- a/ax/generators/torch/botorch_modular/surrogate.py
+++ b/ax/generators/torch/botorch_modular/surrogate.py
@@ -42,6 +42,7 @@ from ax.generators.torch.botorch_modular.utils import (
     use_model_list,
 )
 from ax.generators.torch.utils import (
+    _to_equality_constraints,
     _to_inequality_constraints,
     pick_best_out_of_sample_point_acqf_class,
     predict_from_model,
@@ -1058,6 +1059,9 @@ class Surrogate(Base):
             search_space_digest=search_space_digest,
             inequality_constraints=_to_inequality_constraints(
                 linear_constraints=torch_opt_config.linear_constraints
+            ),
+            equality_constraints=_to_equality_constraints(
+                equality_constraints=torch_opt_config.equality_constraints
             ),
             fixed_features=torch_opt_config.fixed_features,
         )

--- a/ax/generators/torch/botorch_modular/utils.py
+++ b/ax/generators/torch/botorch_modular/utils.py
@@ -892,8 +892,9 @@ def validate_candidates(
     inequality_constraints: list[tuple[Tensor, Tensor, float]] | None,
     feature_names: list[str] | None = None,
     task_features: list[int] | None = None,
+    equality_constraints: list[tuple[Tensor, Tensor, float]] | None = None,
 ) -> None:
-    """Validate candidates satisfy bounds, discrete, and inequality constraints.
+    """Validate candidates satisfy bounds, discrete, and linear constraints.
 
     Args:
         candidates: A `n x d`-dim Tensor of candidates to validate.
@@ -906,6 +907,9 @@ def validate_candidates(
         task_features: Optional list of task feature indices to skip discrete value
             validation for. Task features can be fixed to new task values via
             fixed_features that are not in the search space's discrete_choices.
+        equality_constraints: A list of tuples (indices, coefficients, rhs),
+            representing equality constraints of the form
+            `sum_i (X[indices[i]] * coefficients[i]) = rhs`.
 
     Raises:
         CandidateGenerationError: If any candidate violates constraints.
@@ -958,4 +962,18 @@ def validate_candidates(
                 f"Candidates violate inequality constraints. "
                 f"Infeasible candidate indices: {infeasible_indices}. "
                 f"Number of constraints: {len(inequality_constraints)}."
+            )
+
+    # 4. Equality constraint validation
+    if equality_constraints:
+        is_feasible = evaluate_feasibility(
+            X=candidates.unsqueeze(-2),  # Add q dimension
+            equality_constraints=equality_constraints,
+        )
+        if not is_feasible.all():
+            infeasible_indices = torch.where(~is_feasible)[0].tolist()
+            raise CandidateGenerationError(
+                f"Candidates violate equality constraints. "
+                f"Infeasible candidate indices: {infeasible_indices}. "
+                f"Number of constraints: {len(equality_constraints)}."
             )

--- a/ax/generators/torch/tests/test_acquisition.py
+++ b/ax/generators/torch/tests/test_acquisition.py
@@ -384,6 +384,7 @@ class AcquisitionTest(TestCase):
                     "max_optimization_problem_aggregation_size": MAX_OPT_AGG_SIZE,
                 },
                 inequality_constraints=self.inequality_constraints,
+                equality_constraints=None,
                 fixed_features=self.fixed_features,
                 post_processing_func=self.rounding_func,
                 acq_function_sequence=None,
@@ -1011,6 +1012,7 @@ class AcquisitionTest(TestCase):
             options={"init_batch_limit": INIT_BATCH_LIMIT, "batch_limit": BATCH_LIMIT},
             fixed_features_list=[{1: 0}, {1: 1}, {1: 2}],
             inequality_constraints=self.inequality_constraints,
+            equality_constraints=None,
             post_processing_func=self.rounding_func,
             **self.optimizer_options,
         )
@@ -1062,6 +1064,7 @@ class AcquisitionTest(TestCase):
                 "maxiter_alternating": 2,
             },
             inequality_constraints=self.inequality_constraints,
+            equality_constraints=None,
             fixed_features={0: 0.5},
             post_processing_func=self.rounding_func,
             num_restarts=2,
@@ -1101,6 +1104,7 @@ class AcquisitionTest(TestCase):
                 "maxiter_alternating": 2,
             },
             inequality_constraints=self.inequality_constraints,
+            equality_constraints=None,
             fixed_features={0: 0.5},
             post_processing_func=self.rounding_func,
             num_restarts=2,
@@ -2240,6 +2244,211 @@ class AcquisitionTest(TestCase):
             task_features=[0],
         )
 
+    @mock_botorch_optimize
+    def test_optimize_with_equality_constraints(self) -> None:
+        """Test that equality_constraints are forwarded to optimize_acqf."""
+        acquisition = self.get_acquisition_function(
+            fixed_features=self.fixed_features,
+        )
+        # Equality constraint: x[0] + x[2] = 4.0
+        # Compatible with fixed_features={1: 2.0} and
+        # inequality_constraints: -x[0] + x[1] >= 1 (i.e. x[0] <= 1.0).
+        equality_constraints = [
+            (
+                torch.tensor([0, 2], dtype=torch.int),
+                torch.tensor([1.0, 1.0], **self.tkwargs),
+                4.0,
+            )
+        ]
+        n = 3
+        with mock.patch(
+            f"{ACQUISITION_PATH}.optimize_acqf", wraps=optimize_acqf
+        ) as mock_optimize_acqf:
+            acquisition.optimize(
+                n=n,
+                search_space_digest=self.search_space_digest,
+                inequality_constraints=self.inequality_constraints,
+                equality_constraints=equality_constraints,
+                fixed_features=self.fixed_features,
+                rounding_func=self.rounding_func,
+                optimizer_options=self.optimizer_options,
+            )
+        mock_optimize_acqf.assert_called_with(
+            acq_function=acquisition.acqf,
+            sequential=True,
+            bounds=mock.ANY,
+            q=n,
+            options={
+                "init_batch_limit": INIT_BATCH_LIMIT,
+                "batch_limit": BATCH_LIMIT,
+                "max_optimization_problem_aggregation_size": MAX_OPT_AGG_SIZE,
+            },
+            inequality_constraints=self.inequality_constraints,
+            equality_constraints=equality_constraints,
+            fixed_features=self.fixed_features,
+            post_processing_func=self.rounding_func,
+            acq_function_sequence=None,
+            **self.optimizer_options,
+        )
+
+    @mock_botorch_optimize
+    def test_optimize_mixed_with_equality_constraints(self) -> None:
+        """Test that equality_constraints are forwarded to optimize_acqf_mixed."""
+        ssd = SearchSpaceDigest(
+            feature_names=["a", "b"],
+            bounds=[(0, 1), (0, 2)],
+            categorical_features=[1],
+            discrete_choices={1: [0, 1, 2]},
+        )
+        acquisition = self.get_acquisition_function()
+        equality_constraints = [
+            (
+                torch.tensor([0], dtype=torch.int),
+                torch.tensor([1.0], **self.tkwargs),
+                0.5,
+            )
+        ]
+        with (
+            mock.patch(
+                f"{ACQUISITION_PATH}.optimize_acqf_mixed",
+                wraps=optimize_acqf_mixed,
+            ) as mock_optimize_acqf_mixed,
+            mock.patch(
+                f"{ACQUISITION_PATH}.validate_candidates",
+            ),
+        ):
+            acquisition.optimize(
+                n=3,
+                search_space_digest=ssd,
+                inequality_constraints=self.inequality_constraints,
+                equality_constraints=equality_constraints,
+                fixed_features=None,
+                rounding_func=self.rounding_func,
+                optimizer_options=self.optimizer_options,
+            )
+        mock_optimize_acqf_mixed.assert_called_with(
+            acq_function=acquisition.acqf,
+            bounds=mock.ANY,
+            q=3,
+            options={"init_batch_limit": INIT_BATCH_LIMIT, "batch_limit": BATCH_LIMIT},
+            fixed_features_list=[{1: 0}, {1: 1}, {1: 2}],
+            inequality_constraints=self.inequality_constraints,
+            equality_constraints=equality_constraints,
+            post_processing_func=self.rounding_func,
+            **self.optimizer_options,
+        )
+
+    @mock_botorch_optimize
+    def test_optimize_acqf_mixed_alternating_with_equality_constraints(
+        self,
+    ) -> None:
+        """Test equality_constraints forwarded to optimize_acqf_mixed_alternating."""
+        ssd = SearchSpaceDigest(
+            feature_names=["a", "b", "c"],
+            bounds=[(0, 1), (0, 15), (0, 5)],
+            ordinal_features=[1],
+            discrete_choices={1: list(range(16))},
+        )
+        acquisition = self.get_acquisition_function()
+        equality_constraints = [
+            (
+                torch.tensor([0], dtype=torch.int),
+                torch.tensor([1.0], **self.tkwargs),
+                0.5,
+            )
+        ]
+        with (
+            mock.patch(
+                f"{ACQUISITION_PATH}.optimize_acqf_mixed_alternating",
+                wraps=optimize_acqf_mixed_alternating,
+            ) as mock_alternating,
+            mock.patch(
+                f"{ACQUISITION_PATH}.validate_candidates",
+            ),
+        ):
+            acquisition.optimize(
+                n=3,
+                search_space_digest=ssd,
+                inequality_constraints=self.inequality_constraints,
+                equality_constraints=equality_constraints,
+                fixed_features={0: 0.5},
+                rounding_func=self.rounding_func,
+                optimizer_options={
+                    "options": {"maxiter_alternating": 2},
+                    "num_restarts": 2,
+                    "raw_samples": 4,
+                },
+            )
+        mock_alternating.assert_called_with(
+            acq_function=acquisition.acqf,
+            bounds=mock.ANY,
+            discrete_dims={1: list(range(16))},
+            cat_dims={},
+            q=3,
+            options={
+                "init_batch_limit": INIT_BATCH_LIMIT,
+                "batch_limit": BATCH_LIMIT,
+                "maxiter_alternating": 2,
+            },
+            inequality_constraints=self.inequality_constraints,
+            equality_constraints=equality_constraints,
+            fixed_features={0: 0.5},
+            post_processing_func=self.rounding_func,
+            num_restarts=2,
+            raw_samples=4,
+        )
+
+    def test_optimize_discrete_raises_with_equality_constraints(self) -> None:
+        """Test that discrete optimizers raise ValueError with equality constraints."""
+        ssd = SearchSpaceDigest(
+            feature_names=["a", "b", "c"],
+            bounds=[(1, 2), (2, 3), (3, 4)],
+            categorical_features=[0, 1, 2],
+            discrete_choices={0: [1, 2], 1: [2, 3], 2: [3, 4]},
+        )
+        acquisition = self.get_acquisition_function()
+        equality_constraints = [
+            (
+                torch.tensor([0], dtype=torch.int),
+                torch.tensor([1.0], **self.tkwargs),
+                1.0,
+            )
+        ]
+        with self.assertRaisesRegex(
+            ValueError, "Equality constraints are not supported with discrete"
+        ):
+            acquisition.optimize(
+                n=2,
+                search_space_digest=ssd,
+                equality_constraints=equality_constraints,
+                rounding_func=self.rounding_func,
+            )
+
+    def test_validate_candidates_equality_constraints(self) -> None:
+        """Test validate_candidates with equality constraints."""
+        bounds = torch.tensor([[0.0, 0.0], [1.0, 1.0]])
+        # Equality constraint: x[0] + x[1] = 1.0
+        equality_constraints = [(torch.tensor([0, 1]), torch.tensor([1.0, 1.0]), 1.0)]
+
+        # Feasible candidate: 0.5 + 0.5 = 1.0
+        validate_candidates(
+            candidates=torch.tensor([[0.5, 0.5]]),
+            bounds=bounds,
+            discrete_choices=None,
+            inequality_constraints=None,
+            equality_constraints=equality_constraints,
+        )
+
+        # Infeasible candidate: 0.2 + 0.2 = 0.4 != 1.0
+        with self.assertRaisesRegex(CandidateGenerationError, "equality constraints"):
+            validate_candidates(
+                candidates=torch.tensor([[0.2, 0.2]]),
+                bounds=bounds,
+                discrete_choices=None,
+                inequality_constraints=None,
+                equality_constraints=equality_constraints,
+            )
+
 
 class MultiAcquisitionTest(AcquisitionTest):
     acquisition_class = MultiAcquisition
@@ -2270,6 +2479,20 @@ class MultiAcquisitionTest(AcquisitionTest):
         pass
 
     def test_optimize_acqf_mixed_alternating(self) -> None:
+        pass
+
+    def test_optimize_with_equality_constraints(self) -> None:
+        pass
+
+    def test_optimize_mixed_with_equality_constraints(self) -> None:
+        pass
+
+    def test_optimize_acqf_mixed_alternating_with_equality_constraints(
+        self,
+    ) -> None:
+        pass
+
+    def test_optimize_discrete_raises_with_equality_constraints(self) -> None:
         pass
 
     def test_no_pruning_with_qLogProbabilityOfFeasibility(self) -> None:
@@ -2482,6 +2705,31 @@ class MultiAcquisitionTest(AcquisitionTest):
                 is_valid,
                 f"Candidate {i} has invalid discrete value {val.item()} "
                 f"for dimension 0. Allowed: {allowed_values.tolist()}",
+            )
+
+    def test_optimize_nsgaii_raises_with_equality_constraints(self) -> None:
+        """Test optimize_with_nsgaii raises with equality constraints."""
+        acquisition = self.get_acquisition_function(fixed_features=self.fixed_features)
+        equality_constraints = [
+            (
+                torch.tensor([0], dtype=torch.int),
+                torch.tensor([1.0], **self.tkwargs),
+                5.0,
+            )
+        ]
+        with self.assertRaisesRegex(
+            ValueError,
+            "Equality constraints are not supported with optimizer "
+            "'optimize_with_nsgaii'",
+        ):
+            acquisition.optimize(
+                n=3,
+                search_space_digest=self.search_space_digest,
+                inequality_constraints=self.inequality_constraints,
+                equality_constraints=equality_constraints,
+                fixed_features=self.fixed_features,
+                rounding_func=self.rounding_func,
+                optimizer_options={"max_gen": 5, "population_size": 20},
             )
 
     def test_evaluate(self) -> None:

--- a/ax/generators/torch/tests/test_generator.py
+++ b/ax/generators/torch/tests/test_generator.py
@@ -602,6 +602,7 @@ class BoTorchGeneratorTest(TestCase):
             n=1,
             search_space_digest=search_space_digest,
             inequality_constraints=None,
+            equality_constraints=None,
             fixed_features=self.fixed_features,
             rounding_func=None,
             optimizer_options=self.optimizer_options,

--- a/ax/generators/torch/tests/test_utils.py
+++ b/ax/generators/torch/tests/test_utils.py
@@ -1196,17 +1196,21 @@ class BoTorchGeneratorUtilsTest(TestCase):
         self.assertAllClose(weights, torch.tensor([0.5, 0.5]))
 
     def test_to_inequality_constraints(self) -> None:
-        A = torch.tensor([[0, 1, -2, 3], [0, 1, 0, 0]])
-        b = torch.tensor([[1], [2]])
+        A = torch.tensor([[0, 1, -2, 3], [0, 1, 0, 0]], dtype=torch.double)
+        b = torch.tensor([[1], [2]], dtype=torch.double)
         ineq_constraints = none_throws(
             _to_inequality_constraints(linear_constraints=(A, b))
         )
         self.assertEqual(len(ineq_constraints), 2)
         self.assertAllClose(ineq_constraints[0][0], torch.tensor([1, 2, 3]))
-        self.assertAllClose(ineq_constraints[0][1], torch.tensor([-1, 2, -3]))
+        self.assertAllClose(
+            ineq_constraints[0][1], torch.tensor([-1.0, 2.0, -3.0], dtype=torch.double)
+        )
         self.assertEqual(ineq_constraints[0][2], -1.0)
         self.assertAllClose(ineq_constraints[1][0], torch.tensor([1]))
-        self.assertAllClose(ineq_constraints[1][1], torch.tensor([-1]))
+        self.assertAllClose(
+            ineq_constraints[1][1], torch.tensor([-1.0], dtype=torch.double)
+        )
         self.assertEqual(ineq_constraints[1][2], -2.0)
 
     def test_subset_state_dict(self) -> None:

--- a/ax/generators/torch/utils.py
+++ b/ax/generators/torch/utils.py
@@ -279,21 +279,42 @@ def subset_model(
     )
 
 
+def _to_botorch_constraints(
+    constraints: tuple[Tensor, Tensor] | None,
+    negate: bool,
+) -> list[tuple[Tensor, Tensor, float]] | None:
+    """Convert (A, b) constraint tensors to BoTorch's (indices, coeffs, rhs) format.
+
+    Args:
+        constraints: A tuple (A, b) where A is ``k x d`` and b is ``k x 1``.
+        negate: If True, negate coefficients and rhs. Used for inequality
+            constraints where Ax uses ``Ax <= b`` but BoTorch uses
+            ``sum(coeffs * X) >= rhs``.
+    """
+    if constraints is None:
+        return None
+    A, b = constraints
+    result = []
+    k, d = A.shape
+    sign = -1.0 if negate else 1.0
+    for i in range(k):
+        indices = torch.atleast_1d(A[i, :].nonzero(as_tuple=False).squeeze())
+        coefficients = torch.atleast_1d(sign * A[i, indices])
+        rhs = sign * b[i, 0].item()
+        result.append((indices, coefficients, rhs))
+    return result
+
+
 def _to_inequality_constraints(
     linear_constraints: tuple[Tensor, Tensor] | None = None,
 ) -> list[tuple[Tensor, Tensor, float]] | None:
-    if linear_constraints is not None:
-        A, b = linear_constraints
-        inequality_constraints = []
-        k, d = A.shape
-        for i in range(k):
-            indices = torch.atleast_1d(A[i, :].nonzero(as_tuple=False).squeeze())
-            coefficients = torch.atleast_1d(-A[i, indices])
-            rhs = -b[i, 0].item()
-            inequality_constraints.append((indices, coefficients, rhs))
-    else:
-        inequality_constraints = None
-    return inequality_constraints
+    return _to_botorch_constraints(linear_constraints, negate=True)
+
+
+def _to_equality_constraints(
+    equality_constraints: tuple[Tensor, Tensor] | None = None,
+) -> list[tuple[Tensor, Tensor, float]] | None:
+    return _to_botorch_constraints(equality_constraints, negate=False)
 
 
 def tensor_callable_to_array_callable(

--- a/ax/generators/torch_base.py
+++ b/ax/generators/torch_base.py
@@ -50,6 +50,9 @@ class TorchOptConfig:
         linear_constraints: A tuple of (A, b). For k linear constraints on
             d-dimensional x, A is (k x d) and b is (k x 1) such that
             A x <= b for feasible x.
+        equality_constraints: A tuple of (A, b). For k equality constraints on
+            d-dimensional x, A is (k x d) and b is (k x 1) such that
+            A x = b for feasible x.
         fixed_features: A map {feature_index: value} for features that
             should be fixed to a particular value during generation.
         pending_observations:  A list of m (k_i x d) feature tensors X
@@ -91,6 +94,7 @@ class TorchOptConfig:
     outcome_constraints: tuple[Tensor, Tensor] | None = None
     objective_thresholds: Tensor | None = None
     linear_constraints: tuple[Tensor, Tensor] | None = None
+    equality_constraints: tuple[Tensor, Tensor] | None = None
     fixed_features: dict[int, float] | None = None
     pending_observations: list[Tensor] | None = None
     model_gen_options: TConfig = field(default_factory=dict)

--- a/ax/service/tests/test_instantiation_utils.py
+++ b/ax/service/tests/test_instantiation_utils.py
@@ -115,12 +115,7 @@ class TestInstantiationtUtils(TestCase):
             )
         with self.assertRaisesRegex(
             ValueError,
-            (
-                r"Received invalid parameter constraint format: "
-                r"`x1 \+ x2 \+ x3 = 3`\. "
-                r"Please use one of the following forms:\n"
-                r".*\n.*\n.*\nAcceptable comparison operators are \">=\" and \"<=\"\."
-            ),
+            r"Received invalid parameter constraint format: `x1 \+ x2 \+ x3 = 3`",
         ):
             InstantiationBase.constraint_from_str(
                 "x1 + x2 + x3 = 3", {"x1": x1, "x2": x2, "x3": x3}
@@ -192,6 +187,38 @@ class TestInstantiationtUtils(TestCase):
             InstantiationBase.constraint_from_str(
                 "x1 + x2 / 2.0 + x3 >= 3", {"x1": x1, "x2": x2, "x3": x3}
             )
+
+        # --- Equality constraints ---
+        eq_constraint = InstantiationBase.constraint_from_str(
+            "x1 + x2 == 1", {"x1": x1, "x2": x2}
+        )
+        self.assertTrue(eq_constraint.is_equality)
+        self.assertEqual(eq_constraint.constraint_dict, {"x1": 1.0, "x2": 1.0})
+        self.assertEqual(eq_constraint.bound, 1.0)
+
+        # Weighted equality
+        eq_weighted = InstantiationBase.constraint_from_str(
+            "2*x1 + 3*x2 == 5", {"x1": x1, "x2": x2}
+        )
+        self.assertTrue(eq_weighted.is_equality)
+        self.assertEqual(eq_weighted.constraint_dict, {"x1": 2.0, "x2": 3.0})
+        self.assertEqual(eq_weighted.bound, 5.0)
+
+        # Single parameter equality
+        eq_single = InstantiationBase.constraint_from_str(
+            "x1 == 3", {"x1": x1, "x2": x2}
+        )
+        self.assertTrue(eq_single.is_equality)
+        self.assertEqual(eq_single.constraint_dict, {"x1": 1.0})
+        self.assertEqual(eq_single.bound, 3.0)
+
+        # Order equality constraint should error
+        with self.assertRaisesRegex(ValueError, "DerivedParameter"):
+            InstantiationBase.constraint_from_str("x1 == x2", {"x1": x1, "x2": x2})
+
+        # Linear equality that equates two params should also error
+        with self.assertRaisesRegex(ValueError, "DerivedParameter"):
+            InstantiationBase.constraint_from_str("x1 - x2 == 0", {"x1": x1, "x2": x2})
 
     def test_spaces_in_metric_and_parameter_names(self) -> None:
         # Metric and parameter names with spaces are allowed everywhere

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -86,6 +86,8 @@ EXPECTED_KEYS_IN_PARAM_REPR = {
 }
 
 
+COMPARISON_OPS_WITH_EQ: set[str] = {"<=", ">=", "=="}
+
 INVALID_CONSTRAINT_ERROR_MSG = (
     "Received invalid parameter constraint format: `{}`. "
     "Please use one of the following forms:\n"
@@ -96,7 +98,10 @@ INVALID_CONSTRAINT_ERROR_MSG = (
     "* Weighted linear constraints: `<w1>*<p1> >= <b>` or "
     "`<w1>*<p1> + <w2>*<p2> <= <b>`, where you can add one or more weighted terms on "
     "the left side, and there should be no spaces between weights and parameter "
-    'names.\nAcceptable comparison operators are ">=" and "<=".'
+    "names.\n"
+    "* Equality constraints: `<p1> + <p2> == <b>` or `<w1>*<p1> + <w2>*<p2> == <b>`, "
+    "same as linear constraints but using `==` instead of `<=` or `>=`.\n"
+    'Acceptable comparison operators are ">=", "<=", and "==".'
 )
 
 
@@ -440,27 +445,42 @@ class InstantiationBase:
             last_token_is_numeric = True
         except ValueError:
             last_token_is_numeric = False
+
+        # Identify the comparison operator (second-to-last for linear, middle
+        # for order constraints).
         is_order_constraint = (
             len(tokens) == 3
-            and tokens[1] in COMPARISON_OPS
+            and tokens[1] in COMPARISON_OPS_WITH_EQ
             and not last_token_is_numeric
         )
         is_linear_constraint = (
-            # if len == 3, then this is a single parameter bound constraint, otherwise
-            # it corresponds to a numerical bound on a sum of parameters
+            # if len == 3, then this is a single parameter bound constraint,
+            # otherwise it corresponds to a numerical bound on a sum of
+            # parameters
             len(tokens) >= 3
             and len(tokens) % 2 == 1
-            and tokens[-2] in COMPARISON_OPS
+            and tokens[-2] in COMPARISON_OPS_WITH_EQ
             and last_token_is_numeric
         )
 
         if is_order_constraint:  # e.g. "x1 >= x2"
+            if tokens[1] == "==":
+                raise ValueError(
+                    "Equality order constraints (e.g. 'x1 == x2') are not "
+                    "supported. Use a DerivedParameter to express that two "
+                    "parameters must be equal."
+                )
             return _process_order_constraint(
                 tokens=tokens,
                 parameters=parameters,
             )
 
-        if is_linear_constraint:  # e.g. "x1 + x2 >= 3"
+        if is_linear_constraint:  # e.g. "x1 + x2 >= 3" or "x1 + x2 == 3"
+            if tokens[-2] == "==":
+                return _process_equality_constraint(
+                    tokens=tokens,
+                    parameters=parameters,
+                )
             return _process_linear_constraint(
                 tokens=tokens,
                 parameters=parameters,
@@ -1042,32 +1062,41 @@ def _process_order_constraint(
     )
 
 
-def _process_linear_constraint(
+def _parse_linear_constraint_tokens(
     tokens: Sequence[str],
     parameters: Mapping[str, Parameter],
-) -> ParameterConstraint:
-    """Processes a linear constraint, e.g. "x1 + x2 <= 3". The last token is expected
-    to be a numeric constant, and the other tokens are expected to be parameters, their
-    multiplicative coefficients (e.g."2.5*x1") and "+" or "-" operators (e.g. "+").
+    operator_str: str,
+) -> tuple[dict[str, float], float]:
+    """Parse tokens of a linear constraint into parameter weights and bound.
+
+    Shared helper for ``_process_linear_constraint`` and
+    ``_process_equality_constraint``.  Validates ``*`` placement, processes
+    alternating monomials / operators, and returns the raw
+    ``parameter_weights`` dict and ``bound``.
 
     Args:
         tokens: A list of tokens in the constraint string.
         parameters: A mapping from parameter names to their definitions.
+        operator_str: The comparison operator string (e.g. ``"<="``/``">="``
+            /``"=="``), used only for error messages.
 
     Returns:
-        A ParameterConstraint object representing the linear constraint.
+        A tuple of (parameter_weights, bound).
     """
     parameter_names = parameters.keys()
 
     bound = float(tokens[-1])
     if any(token[0] == "*" or token[-1] == "*" for token in tokens):
         raise ValueError(
-            "A linear constraint should be the form a*x + b*y - c*z <= d"
-            ", where a,b,c,d are float constants and x,y,z are parameters. "
-            "There should be no space in each term around the operator `*`, and "
-            "there should be a single space around each operator +, -, <= and >=."
+            f"A linear constraint should be the form "
+            f"a*x + b*y - c*z {operator_str} d"
+            ", where a,b,c,d are float constants and x,y,z are "
+            "parameters. There should be no space in each term "
+            "around the operator `*`, and there should be a "
+            f"single space around each operator +, -, "
+            f"and {operator_str}."
         )
-    parameter_weights = {}
+    parameter_weights: dict[str, float] = {}
     current_sign = 1.0  # Determines whether the operator is + or -
     # tokens are alternating monomials and operators
     for idx, token in enumerate(tokens[:-2]):
@@ -1091,6 +1120,27 @@ def _process_linear_constraint(
                 raise ValueError(
                     f"Expected a mixed constraint, found operator `{token}`."
                 )
+    return parameter_weights, bound
+
+
+def _process_linear_constraint(
+    tokens: Sequence[str],
+    parameters: Mapping[str, Parameter],
+) -> ParameterConstraint:
+    """Processes a linear constraint, e.g. "x1 + x2 <= 3". The last token is expected
+    to be a numeric constant, and the other tokens are expected to be parameters, their
+    multiplicative coefficients (e.g."2.5*x1") and "+" or "-" operators (e.g. "+").
+
+    Args:
+        tokens: A list of tokens in the constraint string.
+        parameters: A mapping from parameter names to their definitions.
+
+    Returns:
+        A ParameterConstraint object representing the linear constraint.
+    """
+    parameter_weights, bound = _parse_linear_constraint_tokens(
+        tokens=tokens, parameters=parameters, operator_str="<= or >="
+    )
     # tokens[-2] is checked to be either LEQ or GEQ if sum_const is True
     comparison_multiplier = (
         1.0 if COMPARISON_OPS[tokens[-2]] is ComparisonOp.LEQ else -1.0
@@ -1102,6 +1152,45 @@ def _process_linear_constraint(
     return ParameterConstraint(
         inequality=f"{expr} <= {comparison_multiplier * bound}",
     )
+
+
+def _process_equality_constraint(
+    tokens: Sequence[str],
+    parameters: Mapping[str, Parameter],
+) -> ParameterConstraint:
+    """Processes a linear equality constraint, e.g. "x1 + x2 == 3".
+
+    The last token is expected to be a numeric constant, the second-to-last
+    is ``"=="``, and the other tokens are parameters, their multiplicative
+    coefficients (e.g. ``"2.5*x1"``) and ``"+"`` or ``"-"`` operators.
+
+    Args:
+        tokens: A list of tokens in the constraint string.
+        parameters: A mapping from parameter names to their definitions.
+
+    Returns:
+        A ParameterConstraint with ``equality=...``.
+    """
+    parameter_weights, bound = _parse_linear_constraint_tokens(
+        tokens=tokens, parameters=parameters, operator_str="=="
+    )
+    # Reject equality constraints that equate two parameters
+    # (e.g. "x1 - x2 == 0"). DerivedParameter is the correct tool.
+    if (
+        bound == 0.0
+        and len(parameter_weights) == 2
+        and set(parameter_weights.values()) == {1.0, -1.0}
+    ):
+        params = list(parameter_weights.keys())
+        raise ValueError(
+            f"Equality constraint '{' '.join(tokens)}' is equivalent to "
+            f"'{params[0]} == {params[1]}'. Use a DerivedParameter to "
+            "express that two parameters must be equal."
+        )
+    expr = " + ".join(
+        f"{coeff} * {param}" for param, coeff in parameter_weights.items()
+    )
+    return ParameterConstraint(equality=f"{expr} == {bound}")
 
 
 def _process_monomial(monomial_str: str) -> tuple[float, str]:

--- a/ax/utils/common/equality.py
+++ b/ax/utils/common/equality.py
@@ -207,9 +207,9 @@ def object_attribute_dicts_find_unequal_fields(
             equal = one_val is other_val is None or (one_val.db_id == other_val.db_id)
         elif field == "_db_id":
             equal = skip_db_id_check or one_val == other_val
-        # Do not check the inequality_str for ParameterConstraints, checking the bound
-        # and coefficients dict is sufficient.
-        elif field == "_inequality_str":
+        # Do not check the constraint string for ParameterConstraints, checking
+        # the bound and coefficients dict is sufficient.
+        elif field == "_constraint_str":
             equal = True
         else:
             equal = is_ax_equal(one_val, other_val)

--- a/ax/utils/common/sympy.py
+++ b/ax/utils/common/sympy.py
@@ -45,6 +45,41 @@ def extract_coefficient_dict_from_inequality(
     }
 
 
+def extract_coefficient_dict_from_equality(
+    equality_str: str,
+) -> dict[Symbol, float]:
+    """
+    Parse a string of the form ``"expr == bound"`` into a coefficient dictionary.
+
+    SymPy's ``sympify`` does not produce an ``Equality`` from ``==`` (Python
+    evaluates ``==`` as a boolean), so we split the string on ``" == "`` and
+    sympify each side independently.
+
+    All terms are moved to the left side (``lhs - rhs``), and the result is
+    returned as a coefficient dictionary -- the same format as
+    ``extract_coefficient_dict_from_inequality``.
+    """
+    parts = equality_str.split("==")
+    if len(parts) != 2:
+        raise UserInputError(
+            f"Expected an equality constraint containing '==', found {equality_str}"
+        )
+
+    try:
+        lhs = sympify(sanitize_name(parts[0].strip(), sanitize_parens=True))
+        rhs = sympify(sanitize_name(parts[1].strip(), sanitize_parens=True))
+    except SympifyError:
+        raise UserInputError(f"Could not parse equality constraint: {equality_str}")
+
+    if not isinstance(lhs, Expr) or not isinstance(rhs, Expr):
+        raise UserInputError(f"Could not parse equality constraint: {equality_str}")
+
+    expression = lhs - rhs
+    return {
+        key: float(value) for key, value in expression.as_coefficients_dict().items()
+    }
+
+
 def parse_objective_expression(expression_str: str) -> Expr | tuple[Expr, ...]:
     """Sanitize and sympify an objective expression string.
 

--- a/ax/utils/common/tests/test_sympy.py
+++ b/ax/utils/common/tests/test_sympy.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from ax.exceptions.core import UserInputError
+from ax.utils.common.sympy import extract_coefficient_dict_from_equality
+from ax.utils.common.testutils import TestCase
+from sympy import Symbol
+
+
+def _to_str_keys(d: dict[Symbol, float]) -> dict[str, float]:
+    return {str(k): v for k, v in d.items()}
+
+
+class ExtractCoefficientDictFromEqualityTest(TestCase):
+    def test_valid_expressions(self) -> None:
+        cases = [
+            ("x + y == 1.0", {"x": 1.0, "y": 1.0, "1": -1.0}),
+            ("2 * x + 3 * y == 5.0", {"x": 2.0, "y": 3.0, "1": -5.0}),
+            ("x == 3", {"x": 1.0, "1": -3.0}),
+            ("-x + y == 0", {"x": -1.0, "y": 1.0}),
+            ("- x + y == 1.0", {"x": -1.0, "y": 1.0, "1": -1.0}),
+            ("x + y  ==  1", {"x": 1.0, "y": 1.0, "1": -1.0}),
+        ]
+        for expr, expected in cases:
+            with self.subTest(expr=expr):
+                result = _to_str_keys(extract_coefficient_dict_from_equality(expr))
+                self.assertEqual(result, expected)
+
+    def test_sanitized_names(self) -> None:
+        result = _to_str_keys(
+            extract_coefficient_dict_from_equality("foo.bar + foo.baz == 1")
+        )
+        self.assertEqual(result.pop("1"), -1.0)
+        self.assertEqual(len(result), 2)
+
+    def test_error_missing_operator(self) -> None:
+        with self.assertRaisesRegex(UserInputError, "=="):
+            extract_coefficient_dict_from_equality("x + y <= 1")
+
+    def test_error_multiple_operators(self) -> None:
+        with self.assertRaisesRegex(UserInputError, "=="):
+            extract_coefficient_dict_from_equality("x == y == 1")
+
+    def test_error_empty_string(self) -> None:
+        with self.assertRaisesRegex(UserInputError, "=="):
+            extract_coefficient_dict_from_equality("")


### PR DESCRIPTION
Summary:

Update the UnitX transform to preserve equality constraint type when
transforming constraints to unit space. When constructing new constraints,
check `c.is_equality` and use `ParameterConstraint(equality=...)` for
equality constraints. The math is identical for both types (rescale
coefficients by `(u - l)` and adjust bound by `w * l`).

Other transforms (OneHot, IntToFloat, RemoveFixed, etc.) use `pc.clone()`
which automatically preserves `is_equality` — no changes needed.

Reviewed By: esantorella

Differential Revision: D100256484
