### PR TITLE
Remove `generated_points` argument to `RandomGenerator` (#5186)

### DIFF
--- a/ax/adapter/tests/test_registry.py
+++ b/ax/adapter/tests/test_registry.py
@@ -177,7 +177,6 @@ class ModelRegistryTest(TestCase):
                     "deduplicate": True,
                     "init_position": 0,
                     "scramble": True,
-                    "generated_points": None,
                     "fallback_to_sample_polytope": False,
                     "polytope_sampler_kwargs": None,
                 },

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -673,7 +673,6 @@ class TestGenerationStrategy(TestCase):
                         "scramble": True,
                         "fallback_to_sample_polytope": False,
                         "polytope_sampler_kwargs": None,
-                        "generated_points": None,
                     },
                 )
                 self.assertEqual(
@@ -1631,7 +1630,6 @@ class TestGenerationStrategy(TestCase):
                         "scramble": True,
                         "fallback_to_sample_polytope": False,
                         "polytope_sampler_kwargs": None,
-                        "generated_points": None,
                     },
                 )
                 self.assertEqual(

--- a/ax/generators/random/base.py
+++ b/ax/generators/random/base.py
@@ -6,7 +6,6 @@
 
 # pyre-strict
 
-import warnings
 from collections.abc import Callable
 from logging import Logger
 from typing import Any
@@ -57,9 +56,6 @@ class RandomGenerator(Generator):
             of samples to fast-forward before generating new samples.
             Used to ensure that the re-loaded generator will continue generating
             from the same sequence rather than starting from scratch.
-        generated_points: A set of previously generated points to use
-            for deduplication. These should be provided in the raw transformed
-            space the model operates in.
         fallback_to_sample_polytope: If True, when rejection sampling fails,
             we fall back to the HitAndRunPolytopeSampler.
     """
@@ -69,7 +65,6 @@ class RandomGenerator(Generator):
         deduplicate: bool = True,
         seed: int | None = None,
         init_position: int = 0,
-        generated_points: npt.NDArray | None = None,
         fallback_to_sample_polytope: bool = False,
         polytope_sampler_kwargs: dict[str, Any] | None = None,
     ) -> None:
@@ -86,15 +81,6 @@ class RandomGenerator(Generator):
         self.polytope_sampler_kwargs: dict[str, Any] = polytope_sampler_kwargs or {}
         self._bounds: npt.NDArray = np.empty((0, 2))
         self.attempted_draws: int = 0
-        if generated_points is not None:
-            # generated_points was deprecated in Ax 1.0.0, so it can now be reaped.
-            warnings.warn(
-                "The `generated_points` argument is deprecated and will be removed "
-                "in a future version of Ax. It is being ignored in favor of "
-                "extracting the generated points directly from the experiment.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
 
     @property
     def can_predict(self) -> bool:

--- a/ax/generators/random/sobol.py
+++ b/ax/generators/random/sobol.py
@@ -38,7 +38,6 @@ class SobolGenerator(RandomGenerator):
         seed: int | None = None,
         init_position: int = 0,
         scramble: bool = True,
-        generated_points: npt.NDArray | None = None,
         fallback_to_sample_polytope: bool = False,
         polytope_sampler_kwargs: dict[str, Any] | None = None,
     ) -> None:
@@ -46,7 +45,6 @@ class SobolGenerator(RandomGenerator):
             deduplicate=deduplicate,
             seed=seed,
             init_position=init_position,
-            generated_points=generated_points,
             fallback_to_sample_polytope=fallback_to_sample_polytope,
             polytope_sampler_kwargs=polytope_sampler_kwargs,
         )

--- a/ax/generators/random/uniform.py
+++ b/ax/generators/random/uniform.py
@@ -26,14 +26,12 @@ class UniformGenerator(RandomGenerator):
         deduplicate: bool = True,
         seed: int | None = None,
         init_position: int = 0,
-        generated_points: npt.NDArray | None = None,
         fallback_to_sample_polytope: bool = False,
     ) -> None:
         super().__init__(
             deduplicate=deduplicate,
             seed=seed,
             init_position=init_position,
-            generated_points=generated_points,
             fallback_to_sample_polytope=fallback_to_sample_polytope,
         )
         self._rs = np.random.RandomState(seed=self.seed)

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -140,6 +140,7 @@ _DEPRECATED_GENERATOR_KWARGS: tuple[str, ...] = (
     "torch_dtype",
     "status_quo_name",
     "status_quo_features",
+    "generated_points",
 )
 
 # Deprecated node input constructors, removed from GNodes.

--- a/ax/storage/json_store/tests/test_json_store.py
+++ b/ax/storage/json_store/tests/test_json_store.py
@@ -1261,6 +1261,7 @@ class JSONStoreTest(TestCase):
                 "deduplicate": False,
                 "seed": None,
                 "torch_dtype": None,
+                "generated_points": None,
             },
             "bridge_kwargs": {
                 "transforms": {},

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -833,13 +833,13 @@ class SQAStoreTest(TestCase):
             # 3. Try case with model state and search space + opt.config on a
             # generator run in the experiment.
             gr = Generators.SOBOL(experiment=exp).gen(1)
-            # Expecting model kwargs to have 7 fields (seed, deduplicate, init_position,
-            # scramble, generated_points, fallback_to_sample_polytope,
+            # Expecting model kwargs to have 6 fields (seed, deduplicate, init_position,
+            # scramble, fallback_to_sample_polytope,
             # polytope_sampler_kwargs)
             # and the rest of model-state info on generator run to have values too.
             generator_kwargs = gr._generator_kwargs
             self.assertIsNotNone(generator_kwargs)
-            self.assertEqual(len(generator_kwargs), 7)
+            self.assertEqual(len(generator_kwargs), 6)
             adapter_kwargs = gr._adapter_kwargs
             self.assertIsNotNone(adapter_kwargs)
             self.assertEqual(len(adapter_kwargs), 6)
@@ -1896,8 +1896,6 @@ class SQAStoreTest(TestCase):
         sqa_parameter_constraint = SQAParameterConstraint(
             bound=Decimal(0),
             constraint_dict={},
-            # pyre-fixme[6]: For 3rd param expected `IntEnum` but got
-            #  `ParameterConstraintType`.
             type=ParameterConstraintType.LINEAR,
         )
         with self.assertRaises(ValueError):
@@ -1915,8 +1913,6 @@ class SQAStoreTest(TestCase):
         sqa_parameter_constraint = SQAParameterConstraint(
             bound=Decimal(0),
             constraint_dict={},
-            # pyre-fixme[6]: For 3rd param expected `IntEnum` but got
-            #  `ParameterConstraintType`.
             type=ParameterConstraintType.LINEAR,
             generator_run_id=0,
         )
@@ -1929,8 +1925,6 @@ class SQAStoreTest(TestCase):
 
     def test_decode_order_parameter_constraint_failure(self) -> None:
         sqa_parameter = SQAParameterConstraint(
-            # pyre-fixme[6]: For 1st param expected `IntEnum` but got
-            #  `ParameterConstraintType`.
             type=ParameterConstraintType.ORDER,
             constraint_dict={},
             bound=Decimal(0),
@@ -1942,8 +1936,6 @@ class SQAStoreTest(TestCase):
 
     def test_decode_sum_parameter_constraint_failure(self) -> None:
         sqa_parameter = SQAParameterConstraint(
-            # pyre-fixme[6]: For 1st param expected `IntEnum` but got
-            #  `ParameterConstraintType`.
             type=ParameterConstraintType.SUM,
             constraint_dict={},
             bound=Decimal(0),


### PR DESCRIPTION
Summary:

**Context**: This was deprecated in Ax 1.0.0 and has not done anything since then.

**This PR**:
* Removes `generated_points` argument to `RandomGenerator`
* Removes places where this is passed (which would have been recursively triggering the warning)

Reviewed By: saitcakmak

Differential Revision: D101824526


