### PR TITLE
Cache parsed metric names and weights to fix SymPy regression for special-char metric names

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -27,7 +27,7 @@ from ax.adapter.transforms.utils import (
 )
 from ax.core.arm import Arm
 from ax.core.experiment import Experiment
-from ax.core.objective import Objective
+from ax.core.objective import _build_objective_expression, Objective
 from ax.core.observation import Observation, ObservationData, ObservationFeatures
 from ax.core.optimization_config import (
     MultiObjectiveOptimizationConfig,
@@ -379,8 +379,9 @@ def extract_objective_weight_matrix(
             rows.append(
                 extract_objective_weights(
                     objective=Objective(
-                        expression=f"{weight} * {name}",
+                        expression=_build_objective_expression([(name, weight)]),
                         metric_name_to_signature={name: name_to_sig[name]},
+                        _parsed=([name], [[(name, weight)]]),
                     ),
                     outcomes=outcomes,
                 )

--- a/ax/core/objective.py
+++ b/ax/core/objective.py
@@ -10,16 +10,31 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Mapping
+from functools import cached_property
 from typing import Self
 
 from ax.core.metric import Metric
 from ax.exceptions.core import UserInputError
 from ax.utils.common.base import SortableBase
 from ax.utils.common.sympy import (
-    extract_metric_names_from_objective_expr,
     extract_metric_weights_from_objective_expr,
     parse_objective_expression,
 )
+
+
+def _build_objective_expression(
+    name_weights: list[tuple[str, float]],
+) -> str:
+    """Reconstruct an objective expression string from name-weight pairs."""
+    parts: list[str] = []
+    for name, weight in name_weights:
+        if weight == 1.0:
+            parts.append(name)
+        elif weight == -1.0:
+            parts.append(f"-{name}")
+        else:
+            parts.append(f"{weight}*{name}")
+    return " + ".join(parts).replace(" + -", " - ")
 
 
 class Objective(SortableBase):
@@ -48,6 +63,10 @@ class Objective(SortableBase):
         # Deprecated backward-compat kwargs
         metric: Metric | None = None,
         minimize: bool | None = None,
+        # Private: pre-computed parse result. Bypasses SymPy expression
+        # parsing, which is lossy for metric names containing characters
+        # SymPy interprets as operators (commas, parentheses, hyphens).
+        _parsed: tuple[list[str], list[list[tuple[str, float]]]] | None = None,
     ) -> None:
         """Create a new objective.
 
@@ -115,18 +134,48 @@ class Objective(SortableBase):
         self._expression_str: str = expression
         self._metric_name_to_signature: dict[str, str] = {**metric_name_to_signature}
 
-        # Eagerly validate: error on duplicate metric names
-        parsed = parse_objective_expression(expression)
+        # Pre-set _parsed for paths where SymPy parsing is unnecessary or
+        # would fail. Setting the instance attribute prevents the
+        # @cached_property from firing (it checks __dict__ first).
+        if _parsed is not None:
+            self.__dict__["_parsed"] = _parsed
+        elif metric is not None:
+            weight = -1.0 if minimize else 1.0
+            self.__dict__["_parsed"] = (
+                [metric.name],
+                [[(metric.name, weight)]],
+            )
+
+        # Eagerly validate (same pattern as OutcomeConstraint). For the
+        # expression path this triggers the @cached_property and parses via
+        # SymPy. For pre-set paths _parsed is already in __dict__ and this
+        # is a no-op.
+        _ = self._parsed
+
+    @cached_property
+    def _parsed(self) -> tuple[list[str], list[list[tuple[str, float]]]]:
+        """Parse the expression via SymPy.
+
+        Returns ``(metric_names, sub_objective_name_weights)`` where
+        ``sub_objective_name_weights`` is a list of per-sub-objective
+        ``(metric_name, weight)`` pairs.  All public properties delegate
+        to this parsed representation.
+        """
+        parsed = parse_objective_expression(self._expression_str)
         sub_exprs = parsed if isinstance(parsed, tuple) else (parsed,)
-        seen: list[str] = []
+        names: list[str] = []
+        sub_obj_nw: list[list[tuple[str, float]]] = []
         for sub_expr in sub_exprs:
-            for name in extract_metric_names_from_objective_expr(sub_expr):
-                if name in seen:
+            sub_nw = extract_metric_weights_from_objective_expr(sub_expr)
+            sub_obj_nw.append(sub_nw)
+            for name, _w in sub_nw:
+                if name in names:
                     raise UserInputError(
-                        f"Metric '{name}' appears more than once in the objective "
-                        f"expression '{expression}'."
+                        f"Metric '{name}' appears more than once in the "
+                        f"objective expression '{self._expression_str}'."
                     )
-                seen.append(name)
+                names.append(name)
+        return (names, sub_obj_nw)
 
     @property
     def expression(self) -> str:
@@ -136,14 +185,7 @@ class Objective(SortableBase):
     @property
     def metric_names(self) -> list[str]:
         """Get a list of all metric names referenced in the expression."""
-        parsed = parse_objective_expression(self._expression_str)
-        sub_exprs = parsed if isinstance(parsed, tuple) else (parsed,)
-        names: list[str] = []
-        for sub_expr in sub_exprs:
-            for name in extract_metric_names_from_objective_expr(sub_expr):
-                if name not in names:
-                    names.append(name)
-        return names
+        return list(self._parsed[0])
 
     @property
     def metric_name_to_signature(self) -> dict[str, str]:
@@ -180,22 +222,16 @@ class Objective(SortableBase):
         Each metric name from the expression is resolved to its canonical
         signature via ``metric_name_to_signature``.
         """
-        parsed = parse_objective_expression(self._expression_str)
-        sub_exprs = parsed if isinstance(parsed, tuple) else (parsed,)
         mapping = self.metric_name_to_signature
-
-        result: list[tuple[str, float]] = []
-        for sub_expr in sub_exprs:
-            for name, weight in extract_metric_weights_from_objective_expr(sub_expr):
-                result.append((mapping[name], weight))
-
-        return result
+        return [
+            (mapping[name], weight) for sub in self._parsed[1] for name, weight in sub
+        ]
 
     @property
     def is_multi_objective(self) -> bool:
         """True if the objective has multiple comma-separated
         sub-objectives."""
-        return isinstance(parse_objective_expression(self._expression_str), tuple)
+        return len(self._parsed[1]) > 1
 
     @property
     def is_scalarized_objective(self) -> bool:
@@ -239,6 +275,7 @@ class Objective(SortableBase):
         return self.__class__(
             expression=self._expression_str,
             metric_name_to_signature=self._metric_name_to_signature,
+            _parsed=(list(self._parsed[0]), [list(sub) for sub in self._parsed[1]]),
         )
 
     def __eq__(self, other: object) -> bool:
@@ -294,11 +331,21 @@ class MultiObjective(Objective):
             )
         expression = ", ".join(obj.expression for obj in objectives)
         merged_mapping: dict[str, str] = {}
+        child_names: list[str] = []
+        child_weights: list[list[tuple[str, float]]] = []
         for obj in objectives:
             merged_mapping.update(obj.metric_name_to_signature)
+            for name in obj.metric_names:
+                if name in child_names:
+                    raise UserInputError(
+                        f"Metric '{name}' appears in multiple child objectives."
+                    )
+                child_names.append(name)
+            child_weights.extend(obj._parsed[1])
         super().__init__(
             expression=expression,
             metric_name_to_signature=merged_mapping,
+            _parsed=(child_names, child_weights),
         )
 
     def clone(self) -> Objective:  # pyre-ignore[15]: Inconsistent override
@@ -306,6 +353,7 @@ class MultiObjective(Objective):
         return Objective(
             expression=self._expression_str,
             metric_name_to_signature=self._metric_name_to_signature,
+            _parsed=(list(self._parsed[0]), [list(sub) for sub in self._parsed[1]]),
         )
 
 
@@ -355,20 +403,11 @@ class ScalarizedObjective(Objective):
         # Build expression string
         # When minimize=True, flip sign so expression represents maximization
         sign = -1.0 if minimize else 1.0
-        parts: list[str] = []
-        for m, w in zip(metrics, weights):
-            effective_w = sign * w
-            if effective_w == 1.0:
-                parts.append(m.name)
-            elif effective_w == -1.0:
-                parts.append(f"-{m.name}")
-            else:
-                parts.append(f"{effective_w}*{m.name}")
-
-        expression_str = " + ".join(parts).replace(" + -", " - ")
+        name_weights = [(m.name, sign * w) for m, w in zip(metrics, weights)]
         super().__init__(
-            expression=expression_str,
+            expression=_build_objective_expression(name_weights),
             metric_name_to_signature={m.name: m.signature for m in metrics},
+            _parsed=([m.name for m in metrics], [name_weights]),
         )
 
     def clone(self) -> Objective:  # pyre-ignore[15]: Inconsistent override
@@ -376,4 +415,5 @@ class ScalarizedObjective(Objective):
         return Objective(
             expression=self._expression_str,
             metric_name_to_signature=self._metric_name_to_signature,
+            _parsed=(list(self._parsed[0]), [list(sub) for sub in self._parsed[1]]),
         )

--- a/ax/core/optimization_config.py
+++ b/ax/core/optimization_config.py
@@ -13,7 +13,7 @@ from itertools import groupby
 from typing import Self
 
 from ax.core.arm import Arm
-from ax.core.objective import Objective
+from ax.core.objective import _build_objective_expression, Objective
 from ax.core.outcome_constraint import ComparisonOp, OutcomeConstraint
 from ax.exceptions.core import UserInputError
 from ax.utils.common.base import Base
@@ -446,15 +446,19 @@ class MultiObjectiveOptimizationConfig(OptimizationConfig):
         objective_thresholds = objective_thresholds or []
         if objective.is_multi_objective:
             # Build objectives_by_name by decomposing the multi-objective
-            # expression into sub-objectives
-            parts = [p.strip() for p in objective.expression.split(",")]
+            # into per-sub-objective Objectives using cached parse results.
+            # (Cannot use expression.split(",") because metric names may
+            # themselves contain commas.)
             objectives_by_name: dict[str, Objective] = {}
-            for part in parts:
+            mapping = objective.metric_name_to_signature
+            for sub_nw in objective._parsed[1]:
+                sub_names = [name for name, _w in sub_nw]
                 sub_obj = Objective(
-                    expression=part,
-                    metric_name_to_signature=objective.metric_name_to_signature,
+                    expression=_build_objective_expression(sub_nw),
+                    metric_name_to_signature={n: mapping[n] for n in sub_names},
+                    _parsed=(sub_names, [sub_nw]),
                 )
-                for name in sub_obj.metric_names:
+                for name in sub_names:
                     objectives_by_name[name] = sub_obj
 
             check_objective_thresholds_match_objectives(

--- a/ax/core/outcome_constraint.py
+++ b/ax/core/outcome_constraint.py
@@ -121,7 +121,21 @@ class OutcomeConstraint(SortableBase):
 
         self._expression_str: str = expression
         self._metric_name_to_signature: dict[str, str] = {**metric_name_to_signature}
-        # Eagerly validate the expression so errors surface at construction time.
+
+        # Pre-set _parsed for the deprecated metric kwarg to bypass SymPy
+        # parsing, which fails for metric names containing characters SymPy
+        # interprets as operators (commas, parentheses, hyphens).
+        if metric is not None:
+            assert op is not None and bound is not None
+            self.__dict__["_parsed"] = (
+                [(metric.name, 1.0)],
+                op,
+                float(bound),
+                relative if relative is not None else False,
+            )
+
+        # Eagerly validate (same as before). For pre-set paths _parsed is
+        # already in __dict__ and the @cached_property returns immediately.
         _ = self._parsed
 
     @cached_property
@@ -265,6 +279,14 @@ class ObjectiveThreshold(OutcomeConstraint):
             bound=float(bound),
             relative=relative,
         )
+        # Pre-set _parsed before super().__init__() to bypass SymPy
+        # parsing of the expression string (same reason as Objective).
+        self.__dict__["_parsed"] = (
+            [(metric.name, 1.0)],
+            op,
+            float(bound),
+            relative,
+        )
         super().__init__(
             expression=expression,
             relative=relative,
@@ -276,6 +298,7 @@ class ObjectiveThreshold(OutcomeConstraint):
         ot = ObjectiveThreshold.__new__(ObjectiveThreshold)
         ot._expression_str = self._expression_str
         ot._metric_name_to_signature = self._metric_name_to_signature
+        ot.__dict__["_parsed"] = self._parsed
         return ot
 
     def __repr__(self) -> str:

--- a/ax/core/tests/test_objective.py
+++ b/ax/core/tests/test_objective.py
@@ -11,6 +11,7 @@ import warnings
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective, ScalarizedObjective
 from ax.exceptions.core import UserInputError
+from ax.utils.common.sympy import parse_objective_expression
 from ax.utils.common.testutils import TestCase
 
 
@@ -364,6 +365,52 @@ class ObjectiveTest(TestCase):
         self.assertIsInstance(mo, MultiObjective)
         self.assertIsInstance(so, Objective)
         self.assertIsInstance(so, ScalarizedObjective)
+
+    def test_SpecialCharMetricNames(self) -> None:
+        """Metric names with commas, parentheses, and hyphens are preserved
+        when SymPy parsing is bypassed via the metric= kwarg or _parsed."""
+        names = [
+            "metric_one (excl group_a, group_b, and group_c)",
+            "metric-two-with-hyphens",
+            "metric_three (sub-group)",
+        ]
+
+        with self.subTest("metric_kwarg"):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                obj = Objective(metric=Metric(name=names[0]), minimize=True)
+            self.assertEqual(obj.metric_names, [names[0]])
+            self.assertEqual(obj.metric_weights, [(names[0], -1.0)])
+            self.assertTrue(obj.minimize)
+            cloned = obj.clone()
+            self.assertEqual(cloned.metric_names, [names[0]])
+            self.assertEqual(cloned.metric_weights, [(names[0], -1.0)])
+
+        with self.subTest("parsed_bypass"):
+            obj = Objective(
+                expression=names[1],
+                metric_name_to_signature={names[1]: names[1]},
+                _parsed=([names[1]], [[(names[1], -1.0)]]),
+            )
+            self.assertEqual(obj.metric_names, [names[1]])
+            self.assertTrue(obj.minimize)
+
+        with self.subTest("multi_objective"):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                multi = MultiObjective(
+                    objectives=[
+                        Objective(metric=Metric(name=names[0]), minimize=True),
+                        Objective(metric=Metric(name=names[2]), minimize=False),
+                    ]
+                )
+            self.assertEqual(multi.metric_names, [names[0], names[2]])
+            self.assertTrue(multi.is_multi_objective)
+            self.assertFalse(multi.is_scalarized_objective)
+
+        with self.subTest("sympy_lossiness"):
+            parsed = parse_objective_expression(names[0])
+            self.assertNotEqual(str(parsed), names[0])
 
     def test_UniqueId(self) -> None:
         """Test _unique_id used for sorting."""

--- a/ax/service/tests/test_report_utils.py
+++ b/ax/service/tests/test_report_utils.py
@@ -402,9 +402,14 @@ class ReportUtilsTest(TestCase):
         exp = get_branin_experiment_with_multi_objective(with_batch=True)
         # Flip the minimize direction for the multi-objective:
         # first objective to maximize, second to minimize
-        obj = none_throws(exp.optimization_config).objective
+        opt_config = none_throws(exp.optimization_config)
+        obj = opt_config.objective
         names = obj.metric_names
-        obj._expression_str = f"{names[0]}, -{names[1]}"
+        mapping = dict(obj._metric_name_to_signature)
+        opt_config._objective = Objective(
+            expression=f"{names[0]}, -{names[1]}",
+            metric_name_to_signature=mapping,
+        )
         assert_is_instance(
             exp.optimization_config, MultiObjectiveOptimizationConfig
         )._objective_thresholds = [
@@ -720,12 +725,18 @@ class ReportUtilsTest(TestCase):
         exp.fetch_data()
         arm_names = list(exp.arms_by_name.keys())
 
-        # Use a different metric name in optimization config that doesn't exist in data
-        exp._optimization_config.objective._expression_str = "nonexistent_metric"
+        # Use a different metric name in optimization config that doesn't
+        # exist in data.
+        opt_config = OptimizationConfig(
+            objective=Objective(
+                expression="nonexistent_metric",
+                metric_name_to_signature={"nonexistent_metric": "nonexistent_metric"},
+            ),
+        )
 
         result = maybe_extract_baseline_comparison_values(
             experiment=exp,
-            optimization_config=exp.optimization_config,
+            optimization_config=opt_config,
             comparison_arm_names=[arm_names[1]],
             baseline_arm_name=arm_names[0],
         )
@@ -738,17 +749,21 @@ class ReportUtilsTest(TestCase):
         exp.fetch_data()
         arm_names = list(exp.arms_by_name.keys())
 
-        # Replace one objective metric with a nonexistent one
+        # Replace one objective metric with a nonexistent one.
         moo = none_throws(exp.optimization_config).objective
         names = list(moo.metric_names)
-        moo._expression_str = f"-nonexistent_metric, -{names[1]}"
-        new_mapping = dict(moo._metric_name_to_signature)
-        new_mapping["nonexistent_metric"] = "nonexistent_metric"
-        moo._metric_name_to_signature = new_mapping
+        mapping = dict(moo._metric_name_to_signature)
+        mapping["nonexistent_metric"] = "nonexistent_metric"
+        opt_config = MultiObjectiveOptimizationConfig(
+            objective=Objective(
+                expression=f"-nonexistent_metric, -{names[1]}",
+                metric_name_to_signature=mapping,
+            ),
+        )
 
         result = maybe_extract_baseline_comparison_values(
             experiment=exp,
-            optimization_config=exp.optimization_config,
+            optimization_config=opt_config,
             comparison_arm_names=[arm_names[1]],
             baseline_arm_name=arm_names[0],
         )

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -9,6 +9,8 @@
 import copy
 import datetime
 import json
+import re
+import warnings
 from collections import OrderedDict
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -1480,6 +1482,14 @@ def objective_from_json(
         expr = input_args["expression"]
         mapping = input_args.get("metric_name_to_signature")
         if mapping is None:
+            if re.search(r"[()]", expr):
+                warnings.warn(
+                    f"Objective expression {expr!r} contains characters that "
+                    "SymPy may misinterpret (parentheses, commas). Metric "
+                    "names with special characters may not round-trip "
+                    "correctly through this deserialization path.",
+                    stacklevel=2,
+                )
             parsed = parse_objective_expression(expr)
             sub_exprs = parsed if isinstance(parsed, tuple) else (parsed,)
             names: list[str] = []

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -6,6 +6,8 @@
 
 # pyre-strict
 
+import re
+import warnings
 from collections import defaultdict
 from collections.abc import Callable
 from copy import deepcopy
@@ -1336,6 +1338,14 @@ class Decoder:
                 parse_objective_expression,
             )
 
+            if re.search(r"[()]", expr):
+                warnings.warn(
+                    f"Objective expression {expr!r} contains characters that "
+                    "SymPy may misinterpret (parentheses, commas). Metric "
+                    "names with special characters may not round-trip "
+                    "correctly through this deserialization path.",
+                    stacklevel=2,
+                )
             parsed = parse_objective_expression(expr)
             sub_exprs = parsed if isinstance(parsed, tuple) else (parsed,)
             names: list[str] = []


### PR DESCRIPTION
Summary:
A recent refactor made `metric_names`, `metric_weights`, and `is_multi_objective` re-parse the expression through SymPy on every access. This is lossy for metric names containing characters SymPy interprets as operators (commas, parentheses, hyphens) -- e.g. "Messaging Conversations (excl Stories, Notes, FB Reshares, Transactional, and AI-only)". SymPy fragments the name into individual symbols, causing `KeyError` on the `metric_name_to_signature` lookup and crashing experiment loading, data fetching, and candidate generation.

The fix follows `OutcomeConstraint`'s established `cached_property _parsed` pattern: parse once, cache, read from the cache in all properties. For deprecated constructor paths where SymPy parsing would fail, the cache is pre-set directly in `__dict__`, bypassing the `cached_property` descriptor.

**`objective.py`:**

- Add `cached_property _parsed` returning `(metric_names, sub_objective_name_weights)` via SymPy.
- For the deprecated `metric` kwarg and for callers that provide pre-computed results (via private `_parsed` parameter), pre-set `__dict__["_parsed"]` so the `cached_property` never fires.
- `metric_names`, `metric_weights`, `is_multi_objective` read from `_parsed` instead of re-parsing.
- `clone()` on all three classes forwards `_parsed`.
- `MultiObjective.__init__` collects `_parsed` from children, validates no duplicate metric names.
- Add `_build_objective_expression` helper to reconstruct expression strings from name-weight pairs.

**`outcome_constraint.py`:**

- Pre-set `__dict__["_parsed"]` in `OutcomeConstraint.__init__` (deprecated `metric` kwarg) and `ObjectiveThreshold.__init__` (before `super().__init__()`) to bypass SymPy parsing of constraint expressions with special-char metric names.
- `ObjectiveThreshold.clone()` carries `_parsed`.

**`optimization_config.py`:**

- Replace `expression.split(",")` (which breaks for metric names with commas) with iteration over `objective._parsed[1]`. Sub-objectives use `_build_objective_expression` for correct expression strings and fail-fast signature lookup.

**`adapter_utils.py`:**

- `extract_objective_weight_matrix`: pass `_parsed` when constructing per-metric sub-objectives during MOBO candidate generation.

**`test_report_utils.py`:**

- Fix two tests that mutated `_expression_str` directly. With `cached_property`, this does not invalidate the cache. Construct new Objective instances instead.

Reviewed By: mgarrard

Differential Revision: D101930060


