### PR TITLE
Remove fully_bayesian re-exports from botorch.models.__init__ (#5190)

### DIFF
--- a/ax/generators/torch/tests/test_surrogate.py
+++ b/ax/generators/torch/tests/test_surrogate.py
@@ -51,8 +51,9 @@ from ax.utils.testing.mock import mock_botorch_optimize
 from ax.utils.testing.torch_stubs import get_torch_test_data
 from ax.utils.testing.utils import generic_equals
 from botorch.exceptions.errors import ModelFittingError
-from botorch.models import ModelListGP, SaasFullyBayesianSingleTaskGP, SingleTaskGP
+from botorch.models import ModelListGP, SingleTaskGP
 from botorch.models.deterministic import GenericDeterministicModel
+from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
 from botorch.models.fully_bayesian_multitask import SaasFullyBayesianMultiTaskGP
 from botorch.models.gp_regression_mixed import MixedSingleTaskGP
 from botorch.models.model import Model, ModelList  # noqa: F401 -- used in Mocks.

--- a/ax/utils/testing/tests/test_mock.py
+++ b/ax/utils/testing/tests/test_mock.py
@@ -56,7 +56,7 @@ class TestMock(TestCase):
             "kernel_tausq": jnp.ones(num_mcmc_samples),
             "_kernel_inv_length_sq": jnp.ones((num_mcmc_samples, dim)),
         }
-        with patch("botorch.fit.MCMC") as mock_mcmc:
+        with patch("numpyro.infer.MCMC") as mock_mcmc:
             mock_mcmc.return_value.get_samples.return_value = mock_samples
             with mock_botorch_optimize_context_manager():
                 Generators.SAASBO(experiment=experiment, data=experiment.lookup_data())


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/botorch/pull/3291


Reviewed By: saitcakmak

Differential Revision: D102367257


