### PR TITLE
docs: fix typo in automating.ipynb

### DIFF
--- a/tutorials/automating/automating.ipynb
+++ b/tutorials/automating/automating.ipynb
@@ -14,7 +14,7 @@
         "# Automating Orchestration\n",
         "Previously, we've demonstrated [using Ax for ask-tell optimization](../getting_started), a paradigm in which we \"ask\" Ax for candidate configurations and \"tell\" Ax our observations.\n",
         "This can be effective in many scenerios, and it can be automated through use of flow control statements like `for` and `while` loops.\n",
-        "However there are some situations where it would be beneficial to allow Ax to orchestrate the entire optimization: deploying trials to external systems, polling their status, and reading reading their results.\n",
+        "However there are some situations where it would be beneficial to allow Ax to orchestrate the entire optimization: deploying trials to external systems, polling their status, and reading their results.\n",
         "This can be common in a number of real world engineering tasks, including:\n",
         "* **Large scale machine learning experiments** running workloads on high-performance computing clusters\n",
         "* **A/B tests** conducted using an external experimentation platform\n",
@@ -165,7 +165,7 @@
         "`poll_trial` queries the external system to see if the trial has completed, failed, or if it's still running.\n",
         "In this mock example, we will check to see how many seconds have elapsed since the `run_trial` was called and only report a trial as completed once 5 seconds have elapsed.\n",
         "\n",
-        "Runner's may also optionally implement a `stop_trial` method to terminate a trial's execution before it has completed.\n",
+        "Runners may also optionally implement a `stop_trial` method to terminate a trial's execution before it has completed.\n",
         "This is necessary for using [early stopping](../early_stopping) in closed-loop experimentation, but we will skip this for now."
       ]
     },

--- a/tutorials/automating/automating.ipynb
+++ b/tutorials/automating/automating.ipynb
@@ -13,7 +13,7 @@
       "source": [
         "# Automating Orchestration\n",
         "Previously, we've demonstrated [using Ax for ask-tell optimization](../getting_started), a paradigm in which we \"ask\" Ax for candidate configurations and \"tell\" Ax our observations.\n",
-        "This can be effective in many scenerios, and it can be automated through use of flow control statements like `for` and `while` loops.\n",
+        "This can be effective in many scenarios, and it can be automated through use of flow control statements like `for` and `while` loops.\n",
         "However there are some situations where it would be beneficial to allow Ax to orchestrate the entire optimization: deploying trials to external systems, polling their status, and reading their results.\n",
         "This can be common in a number of real world engineering tasks, including:\n",
         "* **Large scale machine learning experiments** running workloads on high-performance computing clusters\n",


### PR DESCRIPTION
FIx typo in https://ax.dev/docs/tutorials/automating/