### PR TITLE
Expose `digits` on `RangeParameterConfig`

### DIFF
--- a/ax/api/configs.py
+++ b/ax/api/configs.py
@@ -18,6 +18,23 @@ class RangeParameterConfig:
     """
     Allows specifying a continuous dimension of an experiment's search space
     and internally validates the inputs.
+
+    ``step_size`` and ``digits`` are two distinct ways to express limited
+    resolution and are mutually exclusive:
+
+    - ``step_size`` materializes an ordered ``ChoiceParameter`` over the
+      explicit grid ``[lower, lower + step, ..., upper]``. The optimizer
+      treats the parameter as discrete (with nearest-neighbor acquisition
+      optimization for low-cardinality grids). Use this when the domain
+      *is* the grid -- e.g. a small set of hardware settings. Requires
+      linear scaling and ``(upper - lower) % step_size == 0``.
+    - ``digits`` keeps the parameter as a continuous ``RangeParameter``
+      and rounds suggested values to ``digits`` decimal places at output
+      time. The optimizer treats the parameter as continuous. Use this
+      when the underlying quantity is continuous but the
+      measurement/control resolution is limited -- e.g. a laser intensity
+      dialed in 0.1 W increments. Float-only; works with log/logit
+      scaling and has no cardinality cap.
     """
 
     name: str
@@ -26,6 +43,7 @@ class RangeParameterConfig:
     parameter_type: Literal["float", "int"]
     step_size: float | None = None
     scaling: Literal["linear", "log"] | None = None
+    digits: int | None = None
 
 
 @dataclass

--- a/ax/api/configs.py
+++ b/ax/api/configs.py
@@ -27,7 +27,9 @@ class RangeParameterConfig:
       treats the parameter as discrete (with nearest-neighbor acquisition
       optimization for low-cardinality grids). Use this when the domain
       *is* the grid -- e.g. a small set of hardware settings. Requires
-      linear scaling and ``(upper - lower) % step_size == 0``.
+      linear scaling and ``(upper - lower) % step_size == 0``. Capped at
+      1000 grid points (``MAX_VALUES_CHOICE_PARAM``); use ``digits`` for
+      finer resolutions.
     - ``digits`` keeps the parameter as a continuous ``RangeParameter``
       and rounds suggested values to ``digits`` decimal places at output
       time. The optimizer treats the parameter as continuous. Use this

--- a/ax/api/configs.py
+++ b/ax/api/configs.py
@@ -28,8 +28,7 @@ class RangeParameterConfig:
       optimization for low-cardinality grids). Use this when the domain
       *is* the grid -- e.g. a small set of hardware settings. Requires
       linear scaling and ``(upper - lower) % step_size == 0``. Capped at
-      1000 grid points (``MAX_VALUES_CHOICE_PARAM``); use ``digits`` for
-      finer resolutions.
+      1000 grid points; use ``digits`` for finer resolutions.
     - ``digits`` keeps the parameter as a continuous ``RangeParameter``
       and rounds suggested values to ``digits`` decimal places at output
       time. The optimizer treats the parameter as continuous. Use this

--- a/ax/api/utils/instantiation/from_config.py
+++ b/ax/api/utils/instantiation/from_config.py
@@ -37,6 +37,18 @@ def parameter_from_config(
     if isinstance(config, RangeParameterConfig):
         lower, upper = config.bounds
 
+        if config.step_size is not None and config.digits is not None:
+            raise UserInputError(
+                "`step_size` and `digits` are mutually exclusive on "
+                "`RangeParameterConfig`; set at most one."
+            )
+
+        if config.digits is not None and config.parameter_type != "float":
+            raise UserInputError(
+                "`digits` is only supported for `float` parameters; "
+                f"got parameter_type={config.parameter_type!r}."
+            )
+
         # TODO[mpolson64] Add support for RangeParameterConfig.step_size native to
         # RangeParameter instead of converting to ChoiceParameter
         if (step_size := config.step_size) is not None:
@@ -67,6 +79,7 @@ def parameter_from_config(
             lower=lower,
             upper=upper,
             log_scale=config.scaling == "log",
+            digits=config.digits,
         )
     elif isinstance(config, DerivedParameterConfig):
         return DerivedParameter(

--- a/ax/api/utils/instantiation/tests/test_from_config.py
+++ b/ax/api/utils/instantiation/tests/test_from_config.py
@@ -153,6 +153,69 @@ class TestFromConfig(TestCase):
                 )
             )
 
+        digits_config = RangeParameterConfig(
+            name="digits_param",
+            parameter_type="float",
+            bounds=(0, 1),
+            digits=3,
+        )
+        self.assertEqual(
+            parameter_from_config(config=digits_config),
+            RangeParameter(
+                name="digits_param",
+                parameter_type=CoreParameterType.FLOAT,
+                lower=0,
+                upper=1,
+                digits=3,
+            ),
+        )
+
+        digits_config_with_log_scaling = RangeParameterConfig(
+            name="digits_param_with_log_scaling",
+            parameter_type="float",
+            bounds=(1e-3, 1),
+            scaling="log",
+            digits=4,
+        )
+        self.assertEqual(
+            parameter_from_config(config=digits_config_with_log_scaling),
+            RangeParameter(
+                name="digits_param_with_log_scaling",
+                parameter_type=CoreParameterType.FLOAT,
+                lower=1e-3,
+                upper=1,
+                log_scale=True,
+                digits=4,
+            ),
+        )
+
+        with self.assertRaisesRegex(
+            UserInputError,
+            "`step_size` and `digits` are mutually exclusive",
+        ):
+            parameter_from_config(
+                config=RangeParameterConfig(
+                    name="both_set",
+                    parameter_type="float",
+                    bounds=(0, 1),
+                    step_size=0.1,
+                    digits=3,
+                )
+            )
+
+        with self.assertRaisesRegex(
+            UserInputError,
+            "`digits` is only supported for `float` parameters",
+        ):
+            parameter_from_config(
+                config=RangeParameterConfig(
+                    name="int_with_digits",
+                    parameter_type="int",
+                    bounds=(0, 10),
+                    digits=2,
+                )
+            )
+
     def test_create_choice_parameter(self) -> None:
         es = ExitStack()
         ws = es.enter_context(warnings.catch_warnings(record=True))


### PR DESCRIPTION
## Summary
- Adds `digits: int | None = None` to `RangeParameterConfig`, plumbed through `parameter_from_config` to `RangeParameter`. Gives client-API users a first-class way to limit the resolution of a float range parameter without the `client._experiment.search_space.parameters[name].digits = N` workaround discussed in #5108.
- `digits` and `step_size` are mutually exclusive and serve different intents:
  - `step_size` materializes an ordered `ChoiceParameter` over an explicit grid; optimizer treats the parameter as discrete. Capped at 1000 grid points.
  - `digits` keeps the parameter as a continuous `RangeParameter` and rounds suggested values to N decimals at output time; optimizer treats it as continuous. Float-only, works with log/logit scaling, no cardinality cap.
- Both restrictions (`step_size` ∧ `digits` set; `digits` on non-float) raise `UserInputError` in `parameter_from_config`. Docstring on `RangeParameterConfig` documents the distinction.

Closes #5108.

## Test plan
- [x] New unit tests in `test_from_config.py` cover: float happy-path, log-scale happy-path, mutual-exclusion error, int+digits error.
- [x] `python -m pytest ax/api/utils/instantiation/tests/test_from_config.py -xvs` → 4 passed.
- [x] `ufmt` and `python -m flake8 -j 1` clean on all 3 changed files.