### PR TITLE
Bump pinned botorch version to 0.18.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "botorch[pymoo]>=0.17.2,<0.17.3dev9999",
+    "botorch[pymoo]>=0.18.0,<0.18.1dev9999",
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",


### PR DESCRIPTION
Summary: Bumps the pinned botorch version from 0.17.2 to 0.18.0 in the Ax GitHub `pyproject.toml`, in preparation for the BoTorch 0.18.0 release.

Reviewed By: dme65

Differential Revision: D107301386


