### PR TITLE
Preference-aware cross-validation

### DIFF
--- a/ax/adapter/cross_validation.py
+++ b/ax/adapter/cross_validation.py
@@ -656,6 +656,145 @@ def _kfold_train_test_split(
         )
 
 
+def _pairwise_kfold_train_test_split(
+    folds: int,
+    training_data: ExperimentData,
+    preference_metric_name: str | None = None,
+) -> Iterable[CVData]:
+    """Return train/test CV splits based on trial indices.
+
+    For pairwise/preference data, each comparison trial contains exactly two
+    arms forming a pair. Splitting by trial_index (instead of arm_name) keeps
+    comparison pairs intact -- both arms of a pair are always together in
+    the same fold.
+
+    When ``preference_metric_name`` is provided, only trials with observations
+    for that metric are used as fold boundaries. This prevents holding out
+    trials that have no pairwise data (e.g., a BO trial with only tracking
+    metrics), which would remove all data for those metrics and cause
+    downstream model-fitting failures.
+
+    Args:
+        folds: Number of folds. Use -1 for leave-one-out CV (one trial per fold).
+        training_data: Training data to split.
+        preference_metric_name: If provided, only split on trials that have
+            non-NaN observations for this metric.
+
+    Returns:
+        Yields CVData with train/test splits.
+    """
+    if preference_metric_name is not None:
+        obs_mean = training_data.observation_data["mean"]
+        if preference_metric_name in obs_mean.columns:
+            non_null = obs_mean[preference_metric_name].dropna()
+            trial_indices = sorted(set(non_null.index.get_level_values("trial_index")))
+        else:
+            trial_indices = sorted(
+                set(training_data.arm_data.index.get_level_values("trial_index"))
+            )
+    else:
+        trial_indices = sorted(
+            set(training_data.arm_data.index.get_level_values("trial_index"))
+        )
+    n = len(trial_indices)
+    if n < 2:
+        raise UnsupportedError(
+            "Pairwise cross validation requires at least two trials in the "
+            f"training data. Only {n} trials were found."
+        )
+    elif folds > n:
+        raise ValueError(
+            f"Training data only has {n} trials, which is less than {folds} folds."
+        )
+    elif folds < 2 and folds != -1:
+        raise ValueError("Folds must be -1 for LOO, or > 1.")
+    elif folds == -1:
+        folds = n
+
+    trial_arr = np.array(trial_indices)
+    if folds != n:
+        np.random.shuffle(trial_arr)
+    test_size = n // folds
+    final_size = test_size + (n - folds * test_size)
+    for fold in range(folds):
+        trial_arr = np.roll(trial_arr, test_size)
+        n_test = test_size if fold < folds - 1 else final_size
+        train_trials = set(trial_arr[:-n_test].tolist())
+        test_trials_set = set(trial_arr[-n_test:].tolist())
+        # Non-split trials (e.g., BO trials with only tracking metrics)
+        # must stay in every training fold so the full ModelList can be
+        # refitted (all metrics need data).
+        # TODO(D94970662): Once Experiment._trial_type_to_metric_names
+        # lands, use experiment.trials_for_type() instead of data-driven
+        # inference to determine split-eligible vs always-train trials.
+        all_trials = set(training_data.arm_data.index.get_level_values("trial_index"))
+        train_trials = train_trials | (all_trials - set(trial_indices))
+        yield CVData(
+            training_data=training_data.filter_by_trial_index(
+                trial_indices=train_trials
+            ),
+            test_data=training_data.filter_by_trial_index(
+                trial_indices=test_trials_set
+            ),
+        )
+
+
+def compute_pairwise_accuracy(
+    cv_results: list[CVResult],
+    metric_name: str,
+) -> float:
+    """Compute classification accuracy for pairwise preference CV.
+
+    For each held-out comparison pair (two arms from the same trial), checks
+    whether the model correctly predicts which arm is preferred (i.e., the arm
+    with higher predicted utility matches the arm with observed label = 1).
+
+    Args:
+        cv_results: Cross-validation results from cross_validate().
+        metric_name: The preference metric name to evaluate.
+
+    Returns:
+        Fraction of correctly predicted comparisons (random baseline = 0.5).
+    """
+    # Group CV results by trial_index to find comparison pairs.
+    trial_groups: dict[int | None, list[CVResult]] = defaultdict(list)
+    for result in cv_results:
+        trial_groups[result.observed.features.trial_index].append(result)
+
+    correct = 0
+    total = 0
+    for _trial_idx, results in trial_groups.items():
+        if len(results) != 2:
+            continue
+        r0, r1 = results
+
+        # Find the metric index in the observation data.
+        try:
+            idx0 = list(r0.observed.data.metric_signatures).index(metric_name)
+            idx1 = list(r1.observed.data.metric_signatures).index(metric_name)
+            pred_idx0 = list(r0.predicted.metric_signatures).index(metric_name)
+            pred_idx1 = list(r1.predicted.metric_signatures).index(metric_name)
+        except ValueError:
+            continue
+
+        obs0 = r0.observed.data.means[idx0]
+        obs1 = r1.observed.data.means[idx1]
+        pred0 = r0.predicted.means[pred_idx0]
+        pred1 = r1.predicted.means[pred_idx1]
+
+        # The arm with observed label = 1 is preferred. Check if the model
+        # predicts higher utility for the preferred arm.
+        if obs0 == obs1:
+            continue  # Skip ties in observed labels
+        preferred_is_0 = obs0 > obs1
+        model_predicts_0 = pred0 > pred1
+        if preferred_is_0 == model_predicts_0:
+            correct += 1
+        total += 1
+
+    return correct / total if total > 0 else 0.0
+
+
 def gen_trial_split(
     training_data: ExperimentData,
     test_trials: list[int],

--- a/ax/adapter/tests/test_cross_validation.py
+++ b/ax/adapter/tests/test_cross_validation.py
@@ -8,17 +8,21 @@
 
 import warnings
 from collections.abc import Iterable
+from functools import partial
 from itertools import product
 from typing import cast
 from unittest import mock
 
 import numpy as np
+import pandas as pd
 import torch
 from ax.adapter.cross_validation import (
     _efficient_loo_cross_validate,
     _fold_cross_validate,
+    _pairwise_kfold_train_test_split,
     assess_model_fit,
     compute_diagnostics,
+    compute_pairwise_accuracy,
     cross_validate,
     CVData,
     CVDiagnostics,
@@ -51,6 +55,8 @@ from ax.exceptions.model import CrossValidationError
 from ax.generators.torch.botorch_modular.generator import BoTorchGenerator
 from ax.generators.torch.botorch_modular.surrogate import Surrogate, SurrogateSpec
 from ax.generators.torch.botorch_modular.utils import ModelConfig
+from ax.generators.torch.utils import predict_from_model
+from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.core_stubs import (
     get_branin_experiment,
@@ -61,13 +67,19 @@ from ax.utils.testing.mock import (
     mock_botorch_optimize,
     mock_botorch_optimize_context_manager,
 )
+from ax.utils.testing.preference_stubs import get_pbo_experiment
 from botorch.cross_validation import CVResults, efficient_loo_cv, ensemble_loo_cv
 from botorch.exceptions.warnings import InputDataWarning
 from botorch.models.fully_bayesian import SaasFullyBayesianSingleTaskGP
+from botorch.models.model import ModelList
+from botorch.models.pairwise_gp import PairwiseGP, PairwiseLaplaceMarginalLogLikelihood
 from botorch.models.robust_relevance_pursuit_model import (
     RobustRelevancePursuitSingleTaskGP,
 )
+from botorch.models.transforms.input import Normalize
+from botorch.models.transforms.outcome import Standardize
 from botorch.posteriors.gpytorch import GPyTorchPosterior
+from botorch.posteriors.posterior_list import PosteriorList
 from gpytorch.distributions import MultivariateNormal
 from linear_operator.operators import DiagLinearOperator
 from pandas import DataFrame
@@ -1105,3 +1117,277 @@ def _create_adapter_with_out_of_design_points() -> TorchAdapter:
         transforms=[UnitX, StandardizeY],
         expand_model_space=False,
     )
+
+
+class PairwiseCVTest(TestCase):
+    """Tests for pairwise/preference cross-validation utilities."""
+
+    def _make_pairwise_experiment_data(
+        self,
+        n_pairwise_trials: int = 4,
+        include_tracking_trial: bool = False,
+    ) -> ExperimentData:
+        """Create ExperimentData with pairwise observations and optionally
+        a non-pairwise trial with tracking metrics only."""
+        arm_rows = []
+        obs_rows = []
+
+        start_trial = 0
+        if include_tracking_trial:
+            # Trial 0: tracking-only (no pairwise data)
+            for arm_idx in range(3):
+                arm_rows.append(
+                    {
+                        "trial_index": 0,
+                        "arm_name": f"0_{arm_idx}",
+                        "x1": float(arm_idx) * 0.5,
+                        "x2": float(arm_idx) * 0.3,
+                    }
+                )
+                obs_rows.append(
+                    {
+                        "trial_index": 0,
+                        "arm_name": f"0_{arm_idx}",
+                        "tracking_m": float(arm_idx) + 1.0,
+                        "pairwise_pref_query": float("nan"),
+                    }
+                )
+            start_trial = 1
+
+        # Pairwise trials: 2 arms each with binary preference labels
+        for t in range(start_trial, start_trial + n_pairwise_trials):
+            for arm_idx in range(2):
+                arm_rows.append(
+                    {
+                        "trial_index": t,
+                        "arm_name": f"{t}_{arm_idx}",
+                        "x1": float(t) * 0.1 + arm_idx * 0.5,
+                        "x2": float(t) * 0.2 + arm_idx * 0.3,
+                    }
+                )
+                obs_rows.append(
+                    {
+                        "trial_index": t,
+                        "arm_name": f"{t}_{arm_idx}",
+                        "tracking_m": float("nan") if include_tracking_trial else 0.0,
+                        "pairwise_pref_query": float(arm_idx),
+                    }
+                )
+
+        arm_df = DataFrame(arm_rows).set_index(["trial_index", "arm_name"])
+        obs_df = DataFrame(obs_rows).set_index(["trial_index", "arm_name"])
+        # Build multi-level columns for observation_data
+        mean_df = obs_df.copy()
+        sem_df = obs_df.copy()
+        sem_df[:] = 0.0
+        mean_df.columns = pd.MultiIndex.from_product([["mean"], mean_df.columns])
+        sem_df.columns = pd.MultiIndex.from_product([["sem"], sem_df.columns])
+        observation_data = pd.concat([mean_df, sem_df], axis=1)
+
+        return ExperimentData(arm_data=arm_df, observation_data=observation_data)
+
+    def test_pairwise_kfold_split_basic(self) -> None:
+        """Basic trial-based splitting produces correct folds."""
+        td = self._make_pairwise_experiment_data(n_pairwise_trials=4)
+        folds = list(_pairwise_kfold_train_test_split(folds=-1, training_data=td))
+        self.assertEqual(len(folds), 4)  # LOO: one fold per trial
+        for fold in folds:
+            train_trials = set(
+                fold.training_data.arm_data.index.get_level_values("trial_index")
+            )
+            test_trials = set(
+                fold.test_data.arm_data.index.get_level_values("trial_index")
+            )
+            self.assertEqual(len(test_trials), 1)
+            self.assertEqual(len(train_trials), 3)
+            self.assertTrue(train_trials.isdisjoint(test_trials))
+
+    def test_pairwise_kfold_split_filters_non_pairwise_trials(self) -> None:
+        """When preference_metric_name is set, non-pairwise trials are excluded
+        from fold boundaries."""
+        td = self._make_pairwise_experiment_data(
+            n_pairwise_trials=4, include_tracking_trial=True
+        )
+        # Without filter: 5 trials (0-4), including tracking-only trial 0
+        all_trials = set(td.arm_data.index.get_level_values("trial_index"))
+        self.assertEqual(len(all_trials), 5)
+
+        # With filter: only 4 pairwise trials used as fold boundaries
+        folds = list(
+            _pairwise_kfold_train_test_split(
+                folds=-1,
+                training_data=td,
+                preference_metric_name="pairwise_pref_query",
+            )
+        )
+        self.assertEqual(len(folds), 4)  # Trial 0 excluded from splitting
+        for fold in folds:
+            test_trials = set(
+                fold.test_data.arm_data.index.get_level_values("trial_index")
+            )
+            # Trial 0 (tracking-only) should never be in the test set
+            self.assertNotIn(0, test_trials)
+            # Test set should only contain pairwise trials
+            self.assertTrue(all(t >= 1 for t in test_trials))
+            # Trial 0 must be in every training fold so tracking metrics
+            # have data for the full ModelList refit
+            train_trials = set(
+                fold.training_data.arm_data.index.get_level_values("trial_index")
+            )
+            self.assertIn(0, train_trials)
+
+    def test_compute_pairwise_accuracy(self) -> None:
+        """Accuracy correctly identifies whether the model predicts the
+        preferred arm in each comparison pair."""
+        metric = "pref"
+        # Two comparison pairs from trial 1 and trial 2
+        results = [
+            # Trial 1: arm A (obs=1, pred=0.8) vs arm B (obs=0, pred=0.2)
+            # Model correctly predicts A > B -> correct
+            CVResult(
+                observed=Observation(
+                    features=ObservationFeatures(parameters={"x": 0}, trial_index=1),
+                    data=ObservationData(
+                        means=np.array([1.0]),
+                        covariance=np.array([[0.0]]),
+                        metric_signatures=[metric],
+                    ),
+                ),
+                predicted=ObservationData(
+                    means=np.array([0.8]),
+                    covariance=np.array([[0.1]]),
+                    metric_signatures=[metric],
+                ),
+            ),
+            CVResult(
+                observed=Observation(
+                    features=ObservationFeatures(parameters={"x": 1}, trial_index=1),
+                    data=ObservationData(
+                        means=np.array([0.0]),
+                        covariance=np.array([[0.0]]),
+                        metric_signatures=[metric],
+                    ),
+                ),
+                predicted=ObservationData(
+                    means=np.array([0.2]),
+                    covariance=np.array([[0.1]]),
+                    metric_signatures=[metric],
+                ),
+            ),
+            # Trial 2: arm C (obs=0, pred=0.9) vs arm D (obs=1, pred=0.1)
+            # Model incorrectly predicts C > D -> wrong
+            CVResult(
+                observed=Observation(
+                    features=ObservationFeatures(parameters={"x": 2}, trial_index=2),
+                    data=ObservationData(
+                        means=np.array([0.0]),
+                        covariance=np.array([[0.0]]),
+                        metric_signatures=[metric],
+                    ),
+                ),
+                predicted=ObservationData(
+                    means=np.array([0.9]),
+                    covariance=np.array([[0.1]]),
+                    metric_signatures=[metric],
+                ),
+            ),
+            CVResult(
+                observed=Observation(
+                    features=ObservationFeatures(parameters={"x": 3}, trial_index=2),
+                    data=ObservationData(
+                        means=np.array([1.0]),
+                        covariance=np.array([[0.0]]),
+                        metric_signatures=[metric],
+                    ),
+                ),
+                predicted=ObservationData(
+                    means=np.array([0.1]),
+                    covariance=np.array([[0.1]]),
+                    metric_signatures=[metric],
+                ),
+            ),
+        ]
+        accuracy = compute_pairwise_accuracy(cv_results=results, metric_name=metric)
+        self.assertEqual(accuracy, 0.5)  # 1 correct out of 2 pairs
+
+    def test_compute_pairwise_accuracy_empty(self) -> None:
+        """Empty CV results return 0.0 accuracy."""
+        self.assertEqual(compute_pairwise_accuracy(cv_results=[], metric_name="m"), 0.0)
+
+    @mock_botorch_optimize
+    def test_pairwise_cv_with_saas_pairwise_modellist(self) -> None:
+        """End-to-end preference-aware CV of a ModelList that combines a
+        fully-Bayesian SAAS GP (regular metric) and a PairwiseGP (preference
+        metric). The SAAS ensemble adds a leading MCMC batch dimension to the
+        ModelList posterior; ``predict_from_model`` must average it out so that
+        ``array_to_observation_data`` receives ``(n, num_outcomes)`` predictions.
+        Without that reduction, CV of a SAAS + PairwiseGP model would produce
+        malformed predictions. This is the only test that exercises the full
+        SAAS + PairwiseGP CV path."""
+        pref = Keys.PAIRWISE_PREFERENCE_QUERY.value
+        experiment = get_pbo_experiment(
+            num_parameters=2,
+            num_experimental_metrics=1,
+            num_experimental_trials=4,
+            num_preference_trials=4,
+            num_preference_trials_w_repeated_arm=0,
+        )
+        # Route the regular metric to a fully-Bayesian SAAS GP and the
+        # preference metric to a PairwiseGP, yielding a mixed ModelList.
+        surrogate_spec = SurrogateSpec(
+            model_configs=[
+                ModelConfig(
+                    botorch_model_class=SaasFullyBayesianSingleTaskGP,
+                    outcome_transform_classes=[Standardize],
+                )
+            ],
+            metric_to_model_configs={
+                pref: [
+                    ModelConfig(
+                        botorch_model_class=PairwiseGP,
+                        mll_class=PairwiseLaplaceMarginalLogLikelihood,
+                        input_transform_classes=[Normalize],
+                    )
+                ]
+            },
+        )
+        adapter = TorchAdapter(
+            experiment=experiment,
+            data=experiment.lookup_data(),
+            generator=BoTorchGenerator(surrogate_spec=surrogate_spec),
+            fit_tracking_metrics=True,
+        )
+        generator = assert_is_instance(adapter.generator, BoTorchGenerator)
+        model = assert_is_instance(generator.surrogate.model, ModelList)
+        submodels = list(model.models)
+
+        with self.subTest("ModelList combines SAAS and PairwiseGP submodels"):
+            self.assertTrue(
+                any(isinstance(m, SaasFullyBayesianSingleTaskGP) for m in submodels)
+            )
+            self.assertTrue(any(isinstance(m, PairwiseGP) for m in submodels))
+
+        with self.subTest("predict_from_model averages out the SAAS batch dim"):
+            test_x = torch.rand(5, 2, dtype=torch.double) * 20.0 + 10.0
+            # The raw ModelList posterior carries a leading MCMC-sample dim...
+            raw_posterior = assert_is_instance(model.posterior(test_x), PosteriorList)
+            self.assertGreater(raw_posterior.mean.ndim, 2)
+            # ...which predict_from_model reduces to (n, num_outcomes).
+            predicted_mean, _ = predict_from_model(model, test_x)
+            self.assertEqual(predicted_mean.shape, (5, len(adapter.outcomes)))
+
+        with self.subTest("preference-aware CV runs and yields valid accuracy"):
+            cv_results = cross_validate(
+                adapter=adapter,
+                fold_generator=partial(
+                    _pairwise_kfold_train_test_split,
+                    -1,
+                    preference_metric_name=pref,
+                ),
+            )
+            self.assertGreater(len(cv_results), 0)
+            accuracy = compute_pairwise_accuracy(
+                cv_results=cv_results, metric_name=pref
+            )
+            self.assertGreaterEqual(accuracy, 0.0)
+            self.assertLessEqual(accuracy, 1.0)

--- a/ax/analysis/diagnostics.py
+++ b/ax/analysis/diagnostics.py
@@ -83,11 +83,11 @@ class DiagnosticAnalysis(Analysis):
             # Extract all metric names from the OptimizationConfig.
             metric_names = [*none_throws(experiment.optimization_config).metric_names]
 
-        # Preference metrics (e.g., pairwise_pref_query) use comparison-pair data
-        # and latent utility models. Standard regression CV (predicted vs. observed
-        # scatter, R²) is meaningless for them — observed values are binary 0/1
-        # while predictions are latent utilities on an incommensurate scale.
-        metric_names = [m for m in metric_names if not is_preference_metric(m)]
+        # Identify preference metrics so CrossValidationPlot can switch to
+        # pair-aware accuracy evaluation (instead of scatter + R^2). If CV
+        # fails for a preference model (e.g., PairwiseGP NotPSDError), it
+        # surfaces as an ErrorAnalysisCard -- same as any other model failure.
+        preference_metrics = {m for m in metric_names if is_preference_metric(m)}
 
         is_bandit = generation_strategy and is_bandit_experiment(
             generation_strategy_name=generation_strategy.name
@@ -109,7 +109,11 @@ class DiagnosticAnalysis(Analysis):
         cross_validation_plots = (
             [
                 CrossValidationPlot(
-                    metric_names=metric_names, test_trial_index=self.test_trial_index
+                    metric_names=metric_names,
+                    test_trial_index=self.test_trial_index,
+                    preference_metrics=preference_metrics
+                    if preference_metrics
+                    else None,
                 ).compute_or_error_card(
                     experiment=experiment,
                     generation_strategy=generation_strategy,

--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -7,11 +7,17 @@
 
 
 from collections.abc import Mapping, Sequence
+from functools import partial
 from typing import final
 
 import pandas as pd
 from ax.adapter.base import Adapter
-from ax.adapter.cross_validation import cross_validate, CVResult
+from ax.adapter.cross_validation import (
+    _pairwise_kfold_train_test_split,
+    compute_pairwise_accuracy,
+    cross_validate,
+    CVResult,
+)
 from ax.analysis.analysis import Analysis
 from ax.analysis.healthcheck.predictable_metrics import DEFAULT_MODEL_FIT_THRESHOLD
 from ax.analysis.plotly.color_constants import AX_BLUE
@@ -66,8 +72,10 @@ class CrossValidationPlot(Analysis):
         - predicted_sem: The SEM of the predicted mean of the metric specified
 
 
-    The card title includes the R² (coefficient of determination) score for
-    the metric.
+    For regression metrics the card title includes the R^2 (coefficient of
+    determination) score for the metric. For preference metrics (see
+    ``preference_metrics``) the card instead reports the pairwise classification
+    accuracy.
     """
 
     def __init__(
@@ -78,6 +86,7 @@ class CrossValidationPlot(Analysis):
         trial_index: int | None = None,
         labels: Mapping[str, str] | None = None,
         test_trial_index: int | None = None,
+        preference_metrics: set[str] | None = None,
     ) -> None:
         """
         Args:
@@ -105,6 +114,10 @@ class CrossValidationPlot(Analysis):
                 predictions for observations from this trial. Other trials'
                 observations will still be used for training but will not
                 appear as test points.
+            preference_metrics: Set of metric names that use preference/comparison-pair
+                semantics (e.g., pairwise_pref_query). For these metrics, CV uses
+                pair-aware fold splitting (by trial) and renders classification
+                accuracy instead of scatter + R^2.
         """
 
         self.metric_names = metric_names
@@ -113,6 +126,7 @@ class CrossValidationPlot(Analysis):
         self.trial_index = trial_index
         self.labels: dict[str, str] = {**labels} if labels is not None else {}
         self.test_trial_index = test_trial_index
+        self.preference_metrics: set[str] = preference_metrics or set()
         self._r2s: dict[str, float] = {}
 
     @override
@@ -151,11 +165,29 @@ class CrossValidationPlot(Analysis):
             if self.test_trial_index is not None
             else None
         )
+        # Use pair-aware fold splitting when preference metrics are present.
+        # Pairwise trials have 2 arms each; splitting by trial keeps pairs
+        # intact. Only split on trials with preference data -- holding out
+        # a non-preference trial (e.g., BO trial with only tracking metrics)
+        # would remove all data for those metrics.
+        if self.preference_metrics:
+            # TODO: If multiple preference metrics exist, each may need its
+            # own fold splitting strategy. Currently assumes a single metric.
+            pref_metric_name = next(iter(self.preference_metrics))
+            fold_generator = partial(
+                _pairwise_kfold_train_test_split,
+                self.folds,
+                preference_metric_name=pref_metric_name,
+            )
+        else:
+            fold_generator = None
+
         cv_results = cross_validate(
             adapter=relevant_adapter,
             folds=self.folds,
             untransform=self.untransform,
             test_selector=test_selector,
+            fold_generator=fold_generator,
         )
         relevant_adapter_metric_names = [
             relevant_adapter._experiment.signature_to_metric[signature].name
@@ -163,61 +195,94 @@ class CrossValidationPlot(Analysis):
         ]
         self._r2s = {}
         for metric_name in self.metric_names or relevant_adapter_metric_names:
-            df = _prepare_data(
-                metric_name=metric_name, cv_results=cv_results, adapter=relevant_adapter
-            )
-
-            fig = _prepare_plot(df=df)
-
-            k_folds_substring = (
-                f"{self.folds}-fold" if self.folds > 0 else "leave-one-out"
-            )
-
             # If a human readable metric name is provided, use it in the title
             metric_title = self.labels.get(metric_name, metric_name)
 
-            r_squared = coefficient_of_determination(
-                y_obs=df["observed"].to_numpy(),
-                y_pred=df["predicted"].to_numpy(),
-            )
-            self._r2s[metric_title] = r_squared
+            is_preference = metric_name in self.preference_metrics
 
-            # Define the cross-validation description based on the number of folds
-            cv_description = (
-                (
-                    f"the data is split into {self.folds} subsets and the model is "
-                    f"trained on {self.folds - 1} subsets while the remaining subset "
-                    "is used for validation"
+            if is_preference:
+                # Preference metrics: compute classification accuracy and
+                # render a bar chart instead of scatter + R^2.
+                accuracy = compute_pairwise_accuracy(
+                    cv_results=cv_results,
+                    metric_name=metric_name,
                 )
-                if self.folds > 0
-                else (
-                    "the model is trained on all data except one sample, which is "
-                    "used for validation"
+                fig = _prepare_preference_cv_plot(
+                    accuracy=accuracy, metric_title=metric_title
                 )
-            )
 
-            card = create_plotly_analysis_card(
-                name=self.__class__.__name__,
-                title=(
-                    f"Cross Validation for {metric_title} (R\u00b2 = {r_squared:.2f})"
-                ),
-                subtitle=(
-                    "The cross-validation plot displays the model fit for each "
-                    f"metric in the experiment. It employs a {k_folds_substring} "
-                    f"approach, where {cv_description}. The plot shows the "
-                    "predicted outcome for the validation set on the y-axis against "
-                    "its actual value on the x-axis. Points that align closely with "
-                    "the dotted diagonal line indicate a strong model fit, signifying "
-                    "accurate predictions. Additionally, the plot includes 95% "
-                    "confidence intervals that provide insight into the noise in "
-                    "observations and the uncertainty in model predictions. A "
-                    "horizontal, flat line of predictions indicates that the model "
-                    "has not picked up on sufficient signal in the data, and instead "
-                    "is just predicting the mean."
-                ),
-                df=df,
-                fig=fig,
-            )
+                card = create_plotly_analysis_card(
+                    name=self.__class__.__name__,
+                    title=(
+                        f"Preference CV for {metric_title} (Accuracy = {accuracy:.0%})"
+                    ),
+                    subtitle=(
+                        "Classification accuracy of the preference model on "
+                        "held-out comparison pairs. For each held-out pair, "
+                        "checks if the model correctly predicts which arm is "
+                        "preferred. Random baseline = 50%."
+                    ),
+                    df=pd.DataFrame({"metric": [metric_name], "accuracy": [accuracy]}),
+                    fig=fig,
+                )
+            else:
+                # Standard regression metrics: scatter + R^2 (unchanged).
+                df = _prepare_data(
+                    metric_name=metric_name,
+                    cv_results=cv_results,
+                    adapter=relevant_adapter,
+                )
+
+                fig = _prepare_plot(df=df)
+
+                k_folds_substring = (
+                    f"{self.folds}-fold" if self.folds > 0 else "leave-one-out"
+                )
+
+                r_squared = coefficient_of_determination(
+                    y_obs=df["observed"].to_numpy(),
+                    y_pred=df["predicted"].to_numpy(),
+                )
+                self._r2s[metric_title] = r_squared
+
+                cv_description = (
+                    (
+                        f"the data is split into {self.folds} subsets and the "
+                        f"model is trained on {self.folds - 1} subsets while "
+                        "the remaining subset is used for validation"
+                    )
+                    if self.folds > 0
+                    else (
+                        "the model is trained on all data except one sample, "
+                        "which is used for validation"
+                    )
+                )
+
+                card = create_plotly_analysis_card(
+                    name=self.__class__.__name__,
+                    title=(
+                        f"Cross Validation for {metric_title}"
+                        f" (R\u00b2 = {r_squared:.2f})"
+                    ),
+                    subtitle=(
+                        "The cross-validation plot displays the model fit for "
+                        "each metric in the experiment. It employs a "
+                        f"{k_folds_substring} approach, where {cv_description}."
+                        " The plot shows the predicted outcome for the "
+                        "validation set on the y-axis against its actual value "
+                        "on the x-axis. Points that align closely with the "
+                        "dotted diagonal line indicate a strong model fit, "
+                        "signifying accurate predictions. Additionally, the "
+                        "plot includes 95% confidence intervals that provide "
+                        "insight into the noise in observations and the "
+                        "uncertainty in model predictions. A horizontal, flat "
+                        "line of predictions indicates that the model has not "
+                        "picked up on sufficient signal in the data, and "
+                        "instead is just predicting the mean."
+                    ),
+                    df=df,
+                    fig=fig,
+                )
 
             cards.append(card)
 
@@ -459,4 +524,43 @@ def _prepare_plot(
         scaleratio=1,
         title="Predicted Outcome",
     )
+    return fig
+
+
+def _prepare_preference_cv_plot(
+    accuracy: float,
+    metric_title: str,
+) -> go.Figure:
+    """Build a preference CV accuracy bar chart.
+
+    For preference metrics, the predicted-vs-observed scatter is meaningless
+    (observed = binary 0/1, predicted = latent utility). Instead, show a
+    single accuracy bar -- the fraction of held-out comparison pairs where
+    the model correctly predicts which arm is preferred (random = 50%).
+    """
+    fig = go.Figure(
+        data=[
+            go.Bar(
+                x=["Accuracy"],
+                y=[accuracy],
+                marker={
+                    "color": "rgb(40, 160, 100)"
+                    if accuracy > 0.5
+                    else "rgb(220, 80, 60)"
+                },
+                text=[f"{accuracy:.0%}"],
+                textposition="outside",
+                showlegend=False,
+            )
+        ]
+    )
+    fig.add_hline(
+        y=0.5,
+        line_dash="dash",
+        line_color="gray",
+        annotation_text="Random (50%)",
+    )
+    fig.update_yaxes(range=[0, 1.1], title="Pairwise Classification Accuracy")
+    fig.update_xaxes(title=metric_title)
+    fig.update_layout(margin={"l": 60, "r": 40, "t": 40, "b": 60})
     return fig

--- a/ax/analysis/summary.py
+++ b/ax/analysis/summary.py
@@ -84,20 +84,43 @@ class Summary(Analysis):
         # (3) experiment data does not have has_step_column=True (data with a
         # progression doesn't support relativization due to time-series step
         # alignment complexities.)
-        # (4) no preference metric objectives -- preference metrics (e.g.,
-        # pairwise_pref_query) have binary 0/1 labels with SQ mean near zero,
-        # causing relativization to crash with "mean_control too small."
         data = experiment.lookup_data(trial_indices=self.trial_indices)
-        has_preference_objective = experiment.optimization_config is not None and any(
-            is_preference_metric(n)
-            for n in experiment.optimization_config.objective.metric_names
-        )
         should_relativize = (
             len(experiment.metrics) > 0
             and experiment.status_quo is not None
             and not data.has_step_column
-            and not has_preference_objective
         )
+
+        # When relativizing, scope to non-preference metrics only. Preference
+        # metrics (e.g., pairwise_pref_query) have binary 0/1 labels with SQ
+        # mean near zero, causing relativization to crash with "mean_control
+        # too small." Non-preference tracking metrics are relativized normally.
+        non_preference_metric_names: list[str] | None = None
+        if should_relativize:
+            non_preference_metric_names = [
+                name for name in experiment.metrics if not is_preference_metric(name)
+            ]
+
+        df = experiment.to_df(
+            trial_indices=self.trial_indices,
+            omit_empty_columns=self.omit_empty_columns,
+            trial_statuses=self.trial_statuses,
+            relativize=should_relativize,
+            metric_names_to_relativize=non_preference_metric_names,
+        )
+
+        # Drop preference metric columns (e.g., pairwise_pref_query) -- their
+        # binary 0/1 values are not informative in a summary table. Then drop
+        # rows where all remaining metric columns are empty, which removes
+        # labeling-only trials that have no tracking metric data.
+        preference_cols = [col for col in df.columns if is_preference_metric(col)]
+        if preference_cols:
+            df = df.drop(columns=preference_cols)
+            remaining_metric_cols = [
+                col for col in df.columns if col in experiment.metrics
+            ]
+            if remaining_metric_cols:
+                df = df.dropna(subset=remaining_metric_cols, how="all")
 
         return self._create_analysis_card(
             title=(
@@ -112,10 +135,5 @@ class Summary(Analysis):
                     "Metric results are relativized against status quo."
                 )
             ),
-            df=experiment.to_df(
-                trial_indices=self.trial_indices,
-                omit_empty_columns=self.omit_empty_columns,
-                trial_statuses=self.trial_statuses,
-                relativize=should_relativize,
-            ),
+            df=df,
         )

--- a/ax/analysis/tests/test_diagnostics.py
+++ b/ax/analysis/tests/test_diagnostics.py
@@ -36,7 +36,7 @@ from ax.generation_strategy.transition_criterion import MinTrials
 from ax.utils.common.constants import Keys
 from ax.utils.common.testutils import TestCase
 from ax.utils.testing.mock import mock_botorch_optimize
-from pyre_extensions import none_throws
+from pyre_extensions import assert_is_instance, none_throws
 
 
 class DiagnosticAnalysisTest(TestCase):
@@ -258,12 +258,15 @@ class DiagnosticAnalysisTest(TestCase):
         self.assertEqual(card_group.title, DIAGNOSTICS_CARDGROUP_TITLE)
         self.assertEqual(card_group.subtitle, DIAGNOSTICS_CARDGROUP_SUBTITLE)
 
-    def test_compute_filters_preference_metrics(self) -> None:
-        """Preference metrics should be excluded from cross-validation since
-        regression CV (binary 0/1 vs. latent utilities) is meaningless.
+    def test_compute_passes_preference_metrics_to_cv(self) -> None:
+        """Preference metrics should be included in CrossValidationPlot with
+        the preference_metrics flag set, so CV uses pair-aware accuracy
+        evaluation. If the model fails (e.g., NotPSDError), it surfaces as
+        an ErrorAnalysisCard -- same as any other model failure.
 
         Uses include_tracking_metrics=True so that pairwise_pref_query (added
-        as a tracking metric) appears in the metric list and gets filtered.
+        as a tracking metric) appears in the metric list and is forwarded to
+        CrossValidationPlot via the preference_metrics flag (not filtered out).
         """
         client = Client()
         client.configure_experiment(
@@ -289,23 +292,27 @@ class DiagnosticAnalysisTest(TestCase):
                 },
             )
 
-        # Verify pairwise metric is filtered from CrossValidationPlot
+        # Capture what CrossValidationPlot receives
         original_cv_init: Callable[..., None] = CrossValidationPlot.__init__
-        captured_metric_names: list[Sequence[str] | None] = []
+        captured_kwargs: list[dict[str, object]] = []
 
         def capturing_init(self: CrossValidationPlot, **kwargs: object) -> None:
-            # pyre-ignore[6]: metric_names is Sequence[str] | None
-            captured_metric_names.append(kwargs.get("metric_names"))
+            captured_kwargs.append(kwargs)
             original_cv_init(self, **kwargs)
 
-        # include_tracking_metrics=True pulls pairwise into the metric list
         with patch.object(CrossValidationPlot, "__init__", capturing_init):
             DiagnosticAnalysis(include_tracking_metrics=True).compute(
                 experiment=client._experiment,
                 generation_strategy=client._generation_strategy,
             )
 
-        self.assertEqual(len(captured_metric_names), 1)
-        cv_metrics = none_throws(captured_metric_names[0])
+        self.assertEqual(len(captured_kwargs), 1)
+        cv_metrics = assert_is_instance(captured_kwargs[0].get("metric_names"), list)
+        # Both metrics should be included
         self.assertIn("booth", cv_metrics)
-        self.assertNotIn(pairwise_name, cv_metrics)
+        self.assertIn(pairwise_name, cv_metrics)
+        # preference_metrics flag should identify pairwise
+        pref_metrics = assert_is_instance(
+            captured_kwargs[0].get("preference_metrics"), set
+        )
+        self.assertIn(pairwise_name, pref_metrics)

--- a/ax/analysis/tests/test_summary.py
+++ b/ax/analysis/tests/test_summary.py
@@ -10,9 +10,9 @@ import pandas as pd
 from ax.analysis.summary import Summary
 from ax.api.client import Client
 from ax.api.configs import RangeParameterConfig
-from ax.core.arm import Arm
 from ax.core.base_trial import TrialStatus
 from ax.core.data import Data
+from ax.core.experiment import Experiment
 from ax.core.metric import Metric
 from ax.core.objective import MultiObjective, Objective
 from ax.core.optimization_config import MultiObjectiveOptimizationConfig
@@ -224,35 +224,97 @@ class TestSummary(TestCase):
         self.assertIn(0, card.df["trial_index"].values)
         self.assertIn(1, card.df["trial_index"].values)
 
-    def test_compute_with_preference_objective_skips_relativization(self) -> None:
-        """Summary should skip relativization when a preference metric is an
-        objective, since binary 0/1 labels have SQ mean near zero which causes
-        'mean_control too small' errors."""
+    def _attach_binary_pairwise_data(
+        self, experiment: Experiment, pairwise_name: str
+    ) -> None:
+        """Attach binary 0/1 pairwise data to every trial, with the status-quo
+        (control) arm set to 0. A near-zero control mean is exactly what makes
+        relativizing this metric crash with 'mean_control too small', so this
+        deterministically reproduces the crash unless the preference metric is
+        scoped out of relativization."""
+        status_quo_name = none_throws(experiment.status_quo).name
+        for trial in experiment.trials.values():
+            arm_names = [arm.name for arm in trial.arms]
+            # Control arm gets 0.0 so |mean_control| is below the relativization
+            # epsilon; all other arms get 1.0.
+            means = [0.0 if name == status_quo_name else 1.0 for name in arm_names]
+            experiment.attach_data(
+                Data(
+                    df=pd.DataFrame(
+                        {
+                            "arm_name": arm_names,
+                            "metric_name": [pairwise_name] * len(arm_names),
+                            "mean": means,
+                            "sem": [0.0] * len(arm_names),
+                            "trial_index": [trial.index] * len(arm_names),
+                            "metric_signature": [pairwise_name] * len(arm_names),
+                        }
+                    )
+                )
+            )
+
+    def test_compute_with_preference_objective_per_metric_relativization(
+        self,
+    ) -> None:
+        """Summary with a preference metric objective should relativize only
+        non-preference metrics. The preference metric (pairwise_pref_query)
+        has binary 0/1 labels with SQ mean near zero -- relativizing it would
+        crash with 'mean_control too small'. Non-preference metrics should
+        be relativized normally."""
         pairwise_name = Keys.PAIRWISE_PREFERENCE_QUERY.value
 
-        # Use Client to set up experiment with SQ and data
-        client = self.client
-        client.configure_optimization(objective="foo")
-        experiment = client._experiment
-        experiment.status_quo = Arm(parameters={"x1": 0.5, "x2": 0.5})
+        # Use an experiment with BatchTrials and SQ data, which triggers
+        # relativization in the Summary. get_branin_experiment_with_status_quo_trials
+        # creates BatchTrials with a SQ arm, so data.relativize() has SQ data.
+        experiment = get_branin_experiment_with_status_quo_trials()
 
-        # Add pairwise_pref_query as an additional objective
+        # Add pairwise_pref_query as an additional objective alongside branin.
         experiment.add_tracking_metric(Metric(name=pairwise_name))
         experiment.optimization_config = MultiObjectiveOptimizationConfig(
             objective=MultiObjective(
                 objectives=[
-                    Objective(metric=Metric(name="foo"), minimize=True),
+                    Objective(metric=experiment.metrics["branin"], minimize=True),
                     Objective(metric=Metric(name=pairwise_name), minimize=False),
                 ]
             )
         )
 
-        client.get_next_trials(max_trials=1)
-        client.complete_trial(trial_index=0, raw_data={"foo": 1.0, pairwise_name: 0.0})
+        self._attach_binary_pairwise_data(experiment, pairwise_name)
 
-        # Should succeed without "mean_control too small" error
+        # Should succeed without "mean_control too small" crash
         card = Summary().compute(experiment=experiment)
-        self.assertNotIn("relativized", card.subtitle)
+
+        # Subtitle should indicate relativization (non-preference metrics)
+        self.assertIn("relativized", card.subtitle)
+
+        # Preference metric column should be dropped from the summary
+        self.assertNotIn(pairwise_name, card.df.columns)
+
+    def test_compute_with_preference_tracking_metric_and_no_optimization_config(
+        self,
+    ) -> None:
+        """A preference metric attached as a tracking metric (with a status quo
+        but no optimization_config) must still be scoped out of relativization.
+        Relativization is gated only on metrics/status_quo/step data, not on the
+        optimization_config, so without scoping the binary 0/1 preference metric
+        (SQ mean ~0) would crash with 'mean_control too small'."""
+        pairwise_name = Keys.PAIRWISE_PREFERENCE_QUERY.value
+
+        experiment = get_branin_experiment_with_status_quo_trials()
+        # Preference metric is tracking-only; there is no optimization_config.
+        experiment.add_tracking_metric(Metric(name=pairwise_name))
+        experiment._optimization_config = None
+
+        self._attach_binary_pairwise_data(experiment, pairwise_name)
+
+        # Should succeed without "mean_control too small" crash even though
+        # there is no optimization_config.
+        card = Summary().compute(experiment=experiment)
+
+        # branin is still relativized (non-preference metric).
+        self.assertIn("relativized", card.subtitle)
+        # Preference metric column should be dropped from the summary.
+        self.assertNotIn(pairwise_name, card.df.columns)
 
     def test_default_excludes_stale_trials(self) -> None:
         """Test that Summary defaults to excluding STALE trials."""

--- a/ax/analysis/tests/test_utils.py
+++ b/ax/analysis/tests/test_utils.py
@@ -721,6 +721,59 @@ class TestUtils(TestCase):
             decimal=1,
         )
 
+    def test_relativize_df_with_sq_skips_metrics_missing_from_sq(self) -> None:
+        """When model predictions include metrics not in the status quo df
+        (e.g., pairwise_pref_query from a preference model), relativization
+        should skip those metrics and leave their columns untouched."""
+        df = pd.DataFrame(
+            {
+                "trial_index": [0, 0],
+                "arm_name": ["status_quo", "arm1"],
+                "foo_mean": [10.0, 12.0],
+                "foo_sem": [1.0, 1.2],
+                "pairwise_pref_query_mean": [0.5, 0.8],
+                "pairwise_pref_query_sem": [0.1, 0.2],
+            }
+        )
+        # Status quo df only has foo, not pairwise_pref_query
+        status_quo_df = pd.DataFrame(
+            {
+                "trial_index": [0],
+                "arm_name": ["status_quo"],
+                "foo_mean": [10.0],
+                "foo_sem": [1.0],
+            }
+        )
+
+        rel_df = _relativize_df_with_sq(
+            df=df,
+            status_quo_df=status_quo_df,
+            status_quo_name="status_quo",
+        )
+
+        with self.subTest("foo is relativized"):
+            np.testing.assert_almost_equal(
+                rel_df.loc[rel_df["arm_name"] == "arm1", "foo_mean"].iloc[0],
+                0.2,
+                decimal=1,
+            )
+
+        with self.subTest("pairwise_pref_query is untouched"):
+            np.testing.assert_almost_equal(
+                rel_df.loc[
+                    rel_df["arm_name"] == "arm1", "pairwise_pref_query_mean"
+                ].iloc[0],
+                0.8,
+                decimal=5,
+            )
+            np.testing.assert_almost_equal(
+                rel_df.loc[
+                    rel_df["arm_name"] == "arm1", "pairwise_pref_query_sem"
+                ].iloc[0],
+                0.2,
+                decimal=5,
+            )
+
     def test_is_preference_metric(self) -> None:
         self.assertTrue(is_preference_metric("pairwise_pref_query"))
         self.assertFalse(is_preference_metric("branin"))

--- a/ax/analysis/utils.py
+++ b/ax/analysis/utils.py
@@ -845,7 +845,14 @@ def _relativize_df_with_sq(
         and 'METRIC_NAME_sem' columns relativized to the status quo arm for each metric
         within each trial.
     """
-    metric_names = [name[:-5] for name in df.columns if name.endswith("_mean")]
+    # Only relativize metrics present in both the data df and the status quo
+    # df. Model predictions may include metrics (e.g., pairwise_pref_query)
+    # that the status quo df doesn't have columns for.
+    metric_names = [
+        name[:-5]
+        for name in df.columns
+        if name.endswith("_mean") and name in status_quo_df.columns
+    ]
 
     rel_df = df.copy()
 

--- a/ax/core/data.py
+++ b/ax/core/data.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import itertools
 import math
 from bisect import bisect_right
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from copy import deepcopy
 from functools import cached_property
 from io import StringIO
@@ -439,6 +439,7 @@ class Data(Base, SerializationMixin):
         include_sq: bool = False,
         bias_correction: bool = True,
         control_as_constant: bool = False,
+        metric_names: Sequence[str] | None = None,
     ) -> Data:
         """Relativize a data object w.r.t. a status_quo arm.
 
@@ -453,6 +454,9 @@ class Data(Base, SerializationMixin):
                 ax.utils.stats.math_utils.relativize for more details.
             control_as_constant: If true, control is treated as a constant.
                 bias_correction is ignored when this is true.
+            metric_names: If provided, only relativize these metrics. Other
+                metrics are passed through with raw values. If None, all
+                metrics are relativized.
 
         Returns:
             The new data object with the relativized metrics (excluding the
@@ -471,6 +475,7 @@ class Data(Base, SerializationMixin):
             include_sq=include_sq,
             bias_correction=bias_correction,
             control_as_constant=control_as_constant,
+            metric_names=metric_names,
         )
         return self.__class__(df=df_rel)
 
@@ -698,6 +703,7 @@ def relativize_dataframe(
     include_sq: bool = False,
     bias_correction: bool = True,
     control_as_constant: bool = False,
+    metric_names: Sequence[str] | None = None,
 ) -> pd.DataFrame:
     """Relativize a dataframe w.r.t. a status_quo arm.
 
@@ -712,6 +718,9 @@ def relativize_dataframe(
             ax.utils.stats.math_utils.relativize for more details.
         control_as_constant: If true, control is treated as a constant.
             bias_correction is ignored when this is true.
+        metric_names: If provided, only relativize these metrics. Other
+            metrics are passed through with raw values. If None, all
+            metrics are relativized.
 
     Returns:
         The new dataframe with the relativized metrics (excluding the
@@ -721,11 +730,26 @@ def relativize_dataframe(
     grp_cols = list(
         {"trial_index", "metric_name", "random_split"}.intersection(df.columns.values)
     )
+    metric_names_set = set(metric_names) if metric_names is not None else None
 
     grouped_df = df.groupby(grp_cols)
     dfs = []
     for grp in grouped_df.groups.keys():
         subgroup_df = grouped_df.get_group(grp)
+
+        # If metric scoping is requested, skip relativization for excluded
+        # metrics and pass through raw data (with or without SQ row).
+        if metric_names_set is not None and "metric_name" in grp_cols:
+            grp_metric = (
+                grp if isinstance(grp, str) else grp[grp_cols.index("metric_name")]
+            )
+            if grp_metric not in metric_names_set:
+                if include_sq:
+                    dfs.append(subgroup_df)
+                else:
+                    dfs.append(subgroup_df[subgroup_df["arm_name"] != status_quo_name])
+                continue
+
         is_sq = subgroup_df["arm_name"] == status_quo_name
 
         # Check if status quo exists in this subgroup (trial)
@@ -758,7 +782,13 @@ def relativize_dataframe(
         dfs.append(subgroup_df.assign(mean=means_rel, sem=sems_rel))
     df_rel = pd.concat(dfs, axis=0)
     if include_sq:
-        df_rel.loc[df_rel["arm_name"] == status_quo_name, "sem"] = 0.0
+        # Zero SEM only for metrics that were actually relativized.
+        # Non-relativized metrics (excluded via metric_names scoping)
+        # should retain their original SEM values.
+        sq_mask = df_rel["arm_name"] == status_quo_name
+        if metric_names_set is not None and "metric_name" in df_rel.columns:
+            sq_mask = sq_mask & df_rel["metric_name"].isin(metric_names_set)
+        df_rel.loc[sq_mask, "sem"] = 0.0
     df_rel.reset_index(inplace=True, drop=True)
     # Reorder columns to match expected order (reuses Data class logic)
     df_rel = Data._get_df_with_cols_in_expected_order(df_rel)

--- a/ax/core/experiment.py
+++ b/ax/core/experiment.py
@@ -2303,6 +2303,7 @@ class Experiment(Base):
         trial_statuses: Sequence[TrialStatus] | None = None,
         omit_empty_columns: bool = True,
         relativize: bool = False,
+        metric_names_to_relativize: Sequence[str] | None = None,
     ) -> pd.DataFrame:
         """
         High-level summary of the Experiment with one row per arm. Any values missing at
@@ -2329,6 +2330,9 @@ class Experiment(Base):
                 * experiment has a status quo on all of its ``BatchTrial``-s
                 * OR a status quo trial among its ``Trial``-s,
                 , relativize metrics against the status quo.
+            metric_names_to_relativize: If provided alongside ``relativize=True``,
+                only relativize these specific metrics. Other metrics are passed
+                through with raw values. If None, all metrics are relativized.
         """
 
         records = []
@@ -2347,6 +2351,7 @@ class Experiment(Base):
                 status_quo_name=self.status_quo.name,
                 as_percent=True,
                 include_sq=True,
+                metric_names=metric_names_to_relativize,
             ).df
         else:
             data_df = data.df
@@ -2410,9 +2415,14 @@ class Experiment(Base):
             df = df.loc[:, df.notnull().any()]
 
         # Format metric columns as percentages with 4 significant figures when
-        # relativized
+        # relativized. Only format metrics that were actually relativized.
         if relativize:
-            for metric_name in self.metrics.keys():
+            metrics_to_format = (
+                metric_names_to_relativize
+                if metric_names_to_relativize is not None
+                else list(self.metrics.keys())
+            )
+            for metric_name in metrics_to_format:
                 if metric_name in df.columns:
                     df[metric_name] = df[metric_name].apply(
                         lambda x: (

--- a/ax/core/tests/test_data.py
+++ b/ax/core/tests/test_data.py
@@ -837,3 +837,68 @@ class RelativizeDataTest(TestCase):
         self.assertEqual(
             expected_relativized_data_with_sq, actual_relativized_data_with_sq
         )
+
+    def test_relativize_with_metric_names_preserves_unscoped_sem(self) -> None:
+        """When metric_names scoping is used with include_sq=True,
+        non-relativized metrics should retain their original SEM values."""
+        df = pd.DataFrame(
+            [
+                {
+                    "trial_index": 0,
+                    "mean": 2.0,
+                    "sem": 0.5,
+                    "metric_name": "to_relativize",
+                    "metric_signature": "to_relativize",
+                    "arm_name": "status_quo",
+                },
+                {
+                    "trial_index": 0,
+                    "mean": 4.0,
+                    "sem": 1.0,
+                    "metric_name": "to_relativize",
+                    "metric_signature": "to_relativize",
+                    "arm_name": "0_0",
+                },
+                {
+                    "trial_index": 0,
+                    "mean": 3.0,
+                    "sem": 0.8,
+                    "metric_name": "not_relativized",
+                    "metric_signature": "not_relativized",
+                    "arm_name": "status_quo",
+                },
+                {
+                    "trial_index": 0,
+                    "mean": 6.0,
+                    "sem": 1.2,
+                    "metric_name": "not_relativized",
+                    "metric_signature": "not_relativized",
+                    "arm_name": "0_0",
+                },
+            ]
+        )
+        data = Data(df=df)
+        result = data.relativize(include_sq=True, metric_names=["to_relativize"])
+        result_df = result.df
+
+        with self.subTest("relativized metric SQ SEM is zero"):
+            sq_rel = result_df[
+                (result_df["arm_name"] == "status_quo")
+                & (result_df["metric_name"] == "to_relativize")
+            ]
+            self.assertEqual(sq_rel["sem"].iloc[0], 0.0)
+
+        with self.subTest("non-relativized metric SQ SEM is preserved"):
+            sq_raw = result_df[
+                (result_df["arm_name"] == "status_quo")
+                & (result_df["metric_name"] == "not_relativized")
+            ]
+            self.assertEqual(sq_raw["sem"].iloc[0], 0.8)
+
+        with self.subTest("non-relativized metric values are raw"):
+            raw_arm = result_df[
+                (result_df["arm_name"] == "0_0")
+                & (result_df["metric_name"] == "not_relativized")
+            ]
+            self.assertEqual(raw_arm["mean"].iloc[0], 6.0)
+            self.assertEqual(raw_arm["sem"].iloc[0], 1.2)

--- a/ax/service/utils/best_point.py
+++ b/ax/service/utils/best_point.py
@@ -9,6 +9,7 @@
 from collections import OrderedDict
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
+from functools import partial
 from logging import Logger
 
 import numpy as np
@@ -22,6 +23,7 @@ from ax.adapter.adapter_utils import (
 )
 from ax.adapter.base import Adapter
 from ax.adapter.cross_validation import (
+    _pairwise_kfold_train_test_split,
     assess_model_fit,
     compute_diagnostics,
     cross_validate,
@@ -49,7 +51,7 @@ from ax.core.utils import compute_metric_availability, MetricAvailability
 from ax.exceptions.core import DataRequiredError, UnsupportedError, UserInputError
 from ax.generation_strategy.generation_strategy import GenerationStrategy
 from ax.generators.torch_base import TorchGenerator
-from ax.utils.common.constants import Keys
+from ax.utils.common.constants import is_preference_metric, Keys
 from ax.utils.common.logger import get_logger
 from ax.utils.preference.preference_utils import get_preference_adapter
 from botorch.utils.multi_objective.box_decompositions import DominatedPartitioning
@@ -320,7 +322,20 @@ def get_best_parameters_from_model_predictions_with_trial_index(
         return _extract_best_arm_from_gr(gr=gr, trials=experiment.trials)
 
     # Check to see if the adapter is worth using.
-    cv_results = cross_validate(adapter=adapter)
+    # Use pairwise-aware fold splitting when preference metrics are present,
+    # so CV folds keep comparison pairs intact (otherwise prep_pairwise_data
+    # crashes on odd-sized folds).
+    pref_metrics = [m for m in adapter.outcomes if is_preference_metric(m)]
+    fold_generator = (
+        partial(
+            _pairwise_kfold_train_test_split,
+            -1,
+            preference_metric_name=pref_metrics[0],
+        )
+        if pref_metrics
+        else None
+    )
+    cv_results = cross_validate(adapter=adapter, fold_generator=fold_generator)
     diagnostics = compute_diagnostics(result=cv_results)
     assess_model_fit_results = assess_model_fit(diagnostics=diagnostics)
 


### PR DESCRIPTION
Summary:
## Summary

When `CrossValidationPlot` encounters preference metrics (e.g., `pairwise_pref_query` backed by PairwiseGP), it switches to a preference-appropriate model quality evaluation:

**Regression metrics** (unchanged): predicted-vs-observed scatter + R² — "are predictions accurate?"

**Preference metrics** (new): pairwise classification accuracy — "does the model correctly predict which arm is preferred?"

Both answer the same question ("is the model trustworthy?") with the appropriate methodology.

### Adapter layer: pair-aware fold splitting

`_pairwise_kfold_train_test_split` in `ax/adapter/cross_validation.py` splits by trial_index instead of arm_name. Each pairwise trial contains exactly two arms forming a comparison pair — splitting by trial keeps pairs intact.

Only trials with pairwise data are used as fold boundaries. Non-pairwise trials (e.g., the BO trial with tracking metrics) remain in every training fold so the full ModelList can be refitted — all metrics need data in every fold.

`compute_pairwise_accuracy` computes the fraction of held-out comparison pairs where the model correctly predicts which arm is preferred (random baseline = 50%).

### Analysis layer: visualization switching

`CrossValidationPlot` accepts `preference_metrics: set[str] | None`. When the current metric is in this set, it:
1. Uses `_pairwise_kfold_train_test_split` as the `fold_generator`
2. Computes classification accuracy via `compute_pairwise_accuracy`
3. Renders an accuracy bar chart (scatter + R² is meaningless when observed = binary 0/1 and predicted = latent utility on an incommensurate scale)

`DiagnosticAnalysis` no longer filters preference metrics from CV. Instead, it passes `preference_metrics` to `CrossValidationPlot` so it can switch visualization mode per metric.

### Additional fixes in this diff

- **Pairwise-aware fold splitting in `best_point.py`**: `get_best_parameters_from_model_predictions_with_trial_index` calls `cross_validate()` internally (for model fit assessment). Previously it used default arm-based fold splitting, which broke pairwise comparison pairs apart — a fold with an odd number of pairwise observations crashes `prep_pairwise_data(reshape to [-1, 2])`. Now passes `_pairwise_kfold_train_test_split` as fold generator when preference metrics are present.

### Compatibility with SAAS + PairwiseGP ModelLists

A fully-Bayesian SAAS outcome model combined with a PairwiseGP in a `ModelList` yields posteriors with an extra leading MCMC-sample batch dimension. This is already handled in `predict_from_model` (landed in D99037272), which the CV path reaches via `BoTorchGenerator.cross_validate -> Surrogate.predict`, so no change in `torch.py` is required. This diff adds an end-to-end regression test (`test_pairwise_cv_with_saas_pairwise_modellist`) that fits a real SAAS + PairwiseGP `ModelList` and runs preference-aware cross-validation — a path that previously had no coverage.

Differential Revision: D99151833


