### PR TITLE
Mock out idle sleeps in orchestration tests (~9x faster)

### DIFF
--- a/ax/orchestration/tests/test_orchestrator.py
+++ b/ax/orchestration/tests/test_orchestrator.py
@@ -234,6 +234,36 @@ class TestAxOrchestrator(TestCase):
             ]
         )
         self.orchestrator_options_kwargs = {}
+        self._mock_orchestrator_poll_sleep()
+
+    def _mock_orchestrator_poll_sleep(self) -> None:
+        """Patch out wall-clock sleeps that only slow tests down.
+
+        Two sources of pure idle time are removed:
+
+        1. The orchestrator's polling loop (``ax.orchestration.orchestrator.sleep``).
+           Many tests leave ``init_seconds_between_polls`` / ``min_seconds_before_poll``
+           at their (non-zero) defaults, so the loop spends most of its wall-clock time
+           sleeping. Loop termination depends on ``total_seconds_elapsed`` (which
+           accumulates the configured interval regardless of actual sleeping), so
+           removing the wait is behavior-preserving.
+        2. The exponential backoff between DB-save retries in
+           ``retry_on_exception`` (``initial_wait_seconds=5`` → 5s + 10s = 15s for
+           ``test_suppress_all_storage_errors``). Only the ``sleep`` is mocked; the
+           retry count and all other ``time`` functions are untouched, so retry
+           assertions still hold. A ``wraps``-ed copy of the ``time`` module is used so
+           that tests relying on real elapsed time (e.g. trial-TTL expiry via
+           ``time.sleep``) are unaffected.
+        """
+        poll_patcher = patch("ax.orchestration.orchestrator.sleep")
+        self.addCleanup(poll_patcher.stop)
+        poll_patcher.start()
+
+        fake_time = Mock(wraps=time)
+        fake_time.sleep = Mock()
+        retry_patcher = patch("ax.utils.common.executils.time", fake_time)
+        self.addCleanup(retry_patcher.stop)
+        retry_patcher.start()
 
     @property
     def runner_registry(self) -> dict[type[Runner], int]:
@@ -3120,6 +3150,7 @@ class TestAxOrchestratorMultiTypeExperiment(TestAxOrchestrator):
         self.orchestrator_options_kwargs: dict[str, str | None] = {
             "mt_experiment_trial_type": "type1"
         }
+        self._mock_orchestrator_poll_sleep()
 
     def test_init_with_no_impl_with_runner(self) -> None:
         self.branin_experiment_no_impl_runner_or_metrics.update_runner(


### PR DESCRIPTION
## TLDR

Mocks out `sleep` in orchestrator tests, reducing the test runtime significantly.


## Summary

The `ax/orchestration` test suite was the single slowest test directory in Ax — ~400s of wall time — but it spent almost all of that **sleeping, not computing** (~20s CPU of 400s wall). This PR removes the idle waits via a shared `_mock_orchestrator_poll_sleep()` helper called from both test classes' `setUp` (the subclass `TestAxOrchestratorMultiTypeExperiment` calls `TestCase.setUp` directly rather than `super()`, so both need it).

Two sources of pure idle time are removed:

1. **Orchestrator polling loop** (`ax.orchestration.orchestrator.sleep`). Many tests leave `init_seconds_between_polls` / `min_seconds_before_poll` at their non-zero defaults (1.0s), so the polling loop just waits. Loop termination depends on `total_seconds_elapsed` — which accumulates the *configured* interval regardless of whether `sleep` actually pauses — so removing the wait is behavior-preserving.

2. **Retry backoff** in `retry_on_exception` (`initial_wait_seconds=5` → 5s + 10s = 15s for `test_suppress_all_storage_errors`). Only `sleep` is mocked, via a `wraps`-ed copy of the `time` module (`patch("ax.utils.common.executils.time", Mock(wraps=time))`), so the retry count and every other `time.*` function are untouched — and trial-TTL tests that rely on real `time.sleep` (e.g. `test_generate_candidates_can_remove_stale_candidates`) keep working against the real clock.

## Result

Single-threaded, all 164 tests still pass:

| Stage | Wall time |
|-------|----------:|
| Baseline | 401.6s |
| + poll-sleep mock | 103.5s |
| + retry-sleep mock | **42.9s** |

**~89% faster (401.6s → 42.9s).** Previously-dominant tests (`test_ignore_global_stopping` ~20s, `test_run_n_trials*` ~11s, `test_suppress_all_storage_errors` ~15s) all drop to sub-second. The TTL tests intentionally still take ~2.2s, confirming real elapsed-time behavior is preserved.

## GitHub CI results:

Before: 28m 5s https://github.com/facebook/Ax/actions/runs/26967821950/job/79575013374
After: 20m 46s https://github.com/facebook/Ax/actions/runs/26968208766/job/79576349702?pr=5223

## Test Plan

- `pytest ax/orchestration/` → 164 passed
- `ufmt` + `flake8` clean