### PR TITLE
Make JAX / fully-Bayesian (SAAS) backend an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ Extras for using Ax with MySQL storage (`mysql`), for running Ax's tutorial's
 locally (`tutorials`), and for installing all dependencies necessary for
 developing Ax (`dev`) are also available.
 
+To use fully Bayesian (SAAS) models -- e.g. `SAASBO` / `SAAS_MTGP`, or the API's
+`method="quality"` generation strategy -- install the `fully_bayesian` extra,
+which pulls in the optional JAX / NumPyro backend:
+
+```shell
+pip install "ax-platform[fully_bayesian]"
+```
+
 ## Install Ax from source
 
 You can install the latest (bleeding edge) version from GitHub using `pip`.

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -37,6 +37,14 @@ Extras for using Ax with MySQL storage (`mysql`), for running Ax's tutorial's
 locally (`tutorials`), and for installing all dependencies necessary for
 developing Ax (`dev`) are also available.
 
+To use fully Bayesian (SAAS) models -- e.g. `SAASBO` / `SAAS_MTGP`, or the API's
+`method="quality"` generation strategy -- install the `fully_bayesian` extra,
+which pulls in the optional JAX / NumPyro backend:
+
+```shell
+pip install "ax-platform[fully_bayesian]"
+```
+
 ## Install Ax from source
 
 You can install the latest (bleeding edge) version from GitHub using `pip`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-    "botorch[pymoo]>=0.18.0,<0.18.1dev9999",
+    "botorch[pymoo]>=0.18.1,<0.18.2dev9999",
     "jinja2",  # also a Plotly dep
     "pandas",
     "scipy",
@@ -56,6 +56,14 @@ notebook = [
     "jupyter",
 ]
 
+# Optional backend for fully Bayesian (SAAS) models. As of BoTorch 0.18.1 the
+# JAX / NumPyro NUTS backend is no longer a required dependency; install this
+# extra (`pip install "ax-platform[fully_bayesian]"`) to use SAASBO / SAAS_MTGP
+# or the API's `method="quality"` generation strategy.
+fully_bayesian = [
+    "botorch[fully_bayesian]",
+]
+
 unittest_minimal = [
     # For tensorboard unit tests (min req: numpy 2.0 compatibility).
     "tensorboard>=2.18.0",
@@ -67,7 +75,9 @@ unittest_minimal = [
 ]
 
 unittest = [
-    "ax-platform[dev,mysql,notebook,unittest_minimal]",
+    # `fully_bayesian` pulls in the JAX/NumPyro backend so SAAS model tests
+    # still run now that it is no longer a required dependency.
+    "ax-platform[dev,mysql,notebook,unittest_minimal,fully_bayesian]",
 ]
 
 tutorial = [

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -74,6 +74,21 @@ module.exports={
         ]
       }
     ],
+    // Workaround for webpack's RealContentHashPlugin crashing the production
+    // build with "Circular hash dependency ..." (thrown from
+    // RealContentHashPlugin.js). The cycle is sensitive to chunk-hash ordering,
+    // so it surfaces non-deterministically as docs content changes. Disabling
+    // `realContentHash` skips that optimization pass -- the only code path that
+    // raises this error -- while leaving normal content-based chunk hashing
+    // (and therefore cache busting) intact.
+    function disableRealContentHash() {
+      return {
+        name: 'disable-real-content-hash',
+        configureWebpack() {
+          return {optimization: {realContentHash: false}};
+        },
+      };
+    },
   ],
   "themeConfig": {
     prism: {


### PR DESCRIPTION
## Summary

BoTorch 0.18.1 drops `pyro-ppl` and moves its fully-Bayesian NUTS backend (JAX, jaxlib, NumPyro) to an optional `botorch[fully_bayesian]` extra. As a result those are no longer pulled into Ax's required dependency closure. This PR makes the change coherent on the Ax side so JAX/NumPyro become a clean, documented opt-in.

## Changes

- **Bump pinned BoTorch to `>=0.18.1`** (`pyproject.toml`).
- **Add a `fully_bayesian` extra** that pulls in `botorch[fully_bayesian]` — users opt into SAAS models via `pip install "ax-platform[fully_bayesian]"`.
- **Wire `fully_bayesian` into the `unittest` extra** so CI still installs the backend and keeps exercising SAAS tests. (The minimal CI job only runs an import smoke test, and SAAS classes import fine without the backend, so `unittest_minimal` is intentionally left untouched.)
- **Docs**: document the extra in `README.md` and `docs/installation.mdx`.
- **Website build**: disable webpack's `realContentHash` optimization in `website/docusaurus.config.js`. Adding content to `installation.mdx` shifted chunk hashes into a cyclic arrangement that crashed the production build with `Circular hash dependency ...` (thrown only from webpack's `RealContentHashPlugin`). Disabling that pass removes the sole code path that raises the error while leaving content-based chunk hashing intact. Verified the previously-failing "Test Website" CI job now passes.

## Why no dispatch / code changes are needed

Fully-Bayesian models are strictly **opt-in** — nothing selects them by default:
- Legacy dispatch defaults to `SingleTaskGP`/`MixedSingleTaskGP` (`use_saasbo=False`).
- Client API defaults to `method="fast"`; only `method="quality"` selects `SaasFullyBayesianSingleTaskGP`.
- The default `BOTORCH_MODULAR` registry entry carries no SAAS surrogate spec.

BoTorch 0.18.1 also made the JAX/NumPyro imports lazy: `SaasFullyBayesianSingleTaskGP`, `SaasFullyBayesianMultiTaskGP`, and `fit_fully_bayesian_model_nuts` all import fine without the backend, and `__init__`/fit raise a clear, actionable `ImportError` (`pip install "botorch[fully_bayesian]"`) if used without it. So no import guards, lazy-import refactor, or test skip-guards are required.

## Verification

With botorch 0.18.1 and **no** jax/jaxlib/numpyro installed:
- `import ax` and all top-level SAAS imports succeed; `Generators.SAASBO` / `SAAS_MTGP` defined.
- Default (`method="fast"`) flow runs end-to-end; SAAS GS construction (`method="quality"`, `use_saasbo=True`) succeeds lazily.
- Instantiating a SAAS model raises the clean install-hint `ImportError`.

After `pip install "ax-platform[fully_bayesian]"` (resolves to jax 0.9.2 / jaxlib 0.9.2 / numpyro 0.21.0):
- `pytest ax/adapter/tests/test_registry.py -k SAASBO` passes.