### PR TITLE
Gate early-stopping eligibility on curve depth, not trial COMPLETED status (#5229)

### DIFF
--- a/ax/benchmark/tests/test_benchmark.py
+++ b/ax/benchmark/tests/test_benchmark.py
@@ -1281,7 +1281,7 @@ class TestBenchmark(TestCase):
                 problem=problem, method=es_method, seed=0
             )
             new_opt_trace = get_opt_trace_by_steps(experiment=experiment)
-            self.assertEqual(list(new_opt_trace), [0.0, 0.0, 1.0, 1.0, 2.0, 3.0])
+            self.assertEqual(list(new_opt_trace), [0.0, 0.0, 1.0, 2.0, 3.0])
 
         with self.subTest("Multi-objective"):
             # Multi-objective problem with step data

--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -17,7 +17,6 @@ from ax.adapter.data_utils import _maybe_normalize_map_key
 from ax.core.batch_trial import BatchTrial
 from ax.core.data import Data, MAP_KEY
 from ax.core.experiment import Experiment
-from ax.core.trial_status import TrialStatus
 from ax.early_stopping.utils import (
     _interval_boundary,
     align_partial_results,
@@ -62,10 +61,11 @@ class BaseEarlyStoppingStrategy(ABC, Base):
                 to make a decision.
             max_progression: Do not stop trials that have passed `max_progression`.
                 Useful if we prefer finishing a trial that are already near completion.
-            min_curves: Trials will not be stopped until a number of trials
-                `min_curves` have completed with curve data attached. That is, if
-                `min_curves` trials are completed but their curve data was not
-                successfully retrieved, further trials may not be early-stopped.
+            min_curves: Trials will not be stopped until at least `min_curves`
+                trials have curve data reaching `min_progression`. Eligibility is
+                based on observed curve depth rather than trial status, so a
+                sufficiently deep curve from a still-running trial counts toward
+                `min_curves`.
             normalize_progressions: If True, normalizes the progression values
                 for each metric to the [0, 1] range using the observed minimum and
                 maximum progression values for that metric. This transformation maps
@@ -332,7 +332,8 @@ class BaseEarlyStoppingStrategy(ABC, Base):
     ) -> bool:
         """Perform a series of default checks for a set of trials `trial_indices` and
         determine if at least one of them is eligible for further stopping logic:
-            1. Check that at least `self.min_curves` trials have completed`
+            1. Check that at least `self.min_curves` trials have curve data reaching
+               `self.min_progression` (i.e. enough comparable curves exist)
             2. Check that at least one trial has reached `self.min_progression`
         Returns a boolean indicating if all checks are passed.
 
@@ -351,19 +352,26 @@ class BaseEarlyStoppingStrategy(ABC, Base):
                     "early stopping strategies."
                 )
 
-        # check that there are sufficient completed trials
-        num_completed = len(experiment.trial_indices_by_status[TrialStatus.COMPLETED])
-        if self.min_curves is not None and num_completed < self.min_curves:
+        df_with_data = df.dropna(subset=["mean"])
+        min_progression = 0.0 if self.min_progression is None else self.min_progression
+
+        # Trials whose latest progression has reached `min_progression`, i.e. trials
+        # with curve data deep enough to be comparable.
+        trials_at_min_progression = set(
+            df_with_data.loc[df_with_data[MAP_KEY] >= min_progression, "trial_index"]
+        )
+
+        # check that there are sufficiently many trials with comparable curve data
+        min_curves = self.min_curves
+        if min_curves is not None and len(trials_at_min_progression) < min_curves:
             return False
 
-        # check that at least one trial has reached `self.min_progression`
-        df_trials = df[df["trial_index"].isin(trial_indices)].dropna(subset=["mean"])
-        any_last_prog = 0
-        if not df_trials[MAP_KEY].empty:
-            any_last_prog = df_trials[MAP_KEY].max()
-
-        if self.min_progression is not None and any_last_prog < self.min_progression:
-            # No trials have reached `self.min_progression`, not stopping any trials
+        # check that at least one trial in `trial_indices` has reached
+        # `self.min_progression`
+        if self.min_progression is not None and trials_at_min_progression.isdisjoint(
+            trial_indices
+        ):
+            # No candidate trials have reached `self.min_progression`, not stopping any
             return False
 
         return True
@@ -611,10 +619,11 @@ class ModelBasedEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
                 to make a decision.
             max_progression: Do not stop trials that have passed `max_progression`.
                 Useful if we prefer finishing a trial that are already near completion.
-            min_curves: Trials will not be stopped until a number of trials
-                `min_curves` have completed with curve data attached. That is, if
-                `min_curves` trials are completed but their curve data was not
-                successfully retrieved, further trials may not be early-stopped.
+            min_curves: Trials will not be stopped until at least `min_curves`
+                trials have curve data reaching `min_progression`. Eligibility is
+                based on observed curve depth rather than trial status, so a
+                sufficiently deep curve from a still-running trial counts toward
+                `min_curves`.
             normalize_progressions: If True, normalizes the progression values
                 for each metric to the [0, 1] range using the observed minimum and
                 maximum progression values for that metric. This transformation maps

--- a/ax/early_stopping/strategies/percentile.py
+++ b/ax/early_stopping/strategies/percentile.py
@@ -58,10 +58,11 @@ class PercentileEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
                 become negative.
             max_progression: Do not stop trials that have passed `max_progression`.
                 Useful if we prefer finishing a trial that are already near completion.
-            min_curves: Trials will not be stopped until a number of trials
-                `min_curves` have completed with curve data attached. That is, if
-                `min_curves` trials are completed but their curve data was not
-                successfully retrieved, further trials may not be early-stopped.
+            min_curves: Trials will not be stopped until at least `min_curves`
+                trials have curve data reaching `min_progression`. Eligibility is
+                based on observed curve depth rather than trial status, so a
+                sufficiently deep curve from a still-running trial counts toward
+                `min_curves`.
             normalize_progressions: If True, normalizes the progression values
                 for each metric to the [0, 1] range using the observed minimum and
                 maximum progression values for that metric. This transformation maps

--- a/ax/early_stopping/strategies/threshold.py
+++ b/ax/early_stopping/strategies/threshold.py
@@ -48,16 +48,17 @@ class ThresholdEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
                 to make a decision.
             max_progression: Do not stop trials that have passed `max_progression`.
                 Useful if we prefer finishing a trial that are already near completion.
-            min_curves: Trials will not be stopped until a number of trials
-                `min_curves` have completed with curve data attached. That is, if
-                `min_curves` trials are completed but their curve data was not
-                successfully retrieved, further trials may not be early-stopped.
+            min_curves: Trials will not be stopped until at least `min_curves`
+                trials have curve data reaching `min_progression`. Eligibility is
+                based on observed curve depth rather than trial status, so a
+                sufficiently deep curve from a still-running trial counts toward
+                `min_curves`.
             normalize_progressions: Normalizes the progression column of the Data df
                 by dividing by the max. If the values were originally in [0, `prog_max`]
                 (as we would expect), the transformed values will be in [0, 1]. Useful
                 for inferring the max progression and allows `min_progression` to be
                 specified in the transformed space. IMPORTANT: Typically, `min_curves`
-                should be > 0 to ensure that at least one trial has completed and that
+                should be > 0 to ensure that at least one trial has curve data and that
                 we have a reliable approximation for `prog_max`.
             check_safe: If True, applies the relevant safety checks to gate
                 early-stopping when it is likely to be harmful. If False (default),

--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -934,12 +934,45 @@ class TestPercentileEarlyStoppingStrategy(TestCase):
         )
         self.assertEqual(set(should_stop), {0, 3, 1})
 
-        # not enough completed trials
+        # Not enough comparable curves: all 5 trials have curve data reaching
+        # `min_progression`, but `min_curves=6` exceeds the number of available
+        # curves. Eligibility is based on observed curve depth (not COMPLETED
+        # status), so even though 4 trials are completed, no trial is stopped.
+        early_stopping_strategy = PercentileEarlyStoppingStrategy(
+            metric_signatures=metric_signatures,
+            percentile_threshold=75,
+            min_curves=6,
+            min_progression=0.1,
+        )
+        should_stop = early_stopping_strategy.should_stop_trials_early(
+            trial_indices=idcs, experiment=exp
+        )
+        self.assertEqual(should_stop, {})
+
+        # Curve depth, not trial status, drives the `min_curves` gate: with
+        # `min_curves=5` and all 5 trials reporting curve data reaching
+        # `min_progression`, the gate is satisfied even though only 4 trials are
+        # in the COMPLETED status, so the worst trial is stopped.
         early_stopping_strategy = PercentileEarlyStoppingStrategy(
             metric_signatures=metric_signatures,
             percentile_threshold=75,
             min_curves=5,
             min_progression=0.1,
+        )
+        should_stop = early_stopping_strategy.should_stop_trials_early(
+            trial_indices=idcs, experiment=exp
+        )
+        self.assertEqual(set(should_stop), {0, 3, 1})
+
+        # Curves that have not reached `min_progression` do not count toward
+        # `min_curves`. With `min_progression=2`, only the trials whose latest
+        # progression is >= 2 are comparable; requiring `min_curves=6` then
+        # exceeds the available curves and no trial is stopped.
+        early_stopping_strategy = PercentileEarlyStoppingStrategy(
+            metric_signatures=metric_signatures,
+            percentile_threshold=75,
+            min_curves=6,
+            min_progression=2,
         )
         should_stop = early_stopping_strategy.should_stop_trials_early(
             trial_indices=idcs, experiment=exp


### PR DESCRIPTION
Summary:

See: https://docs.google.com/document/d/1KqxZoQFMwFaYwmW461grF6-roOKFsk6Ga6zMgB1v_f4/edit?tab=t.0#heading=h.i4svtgc6d68h

`BaseEarlyStoppingStrategy.is_eligible_any` previously required at least `min_curves` trials to be in the `COMPLETED` status before any trial could be early-stopped. This coupled eligibility to trial status rather than to the actual signal we care about — whether enough comparable learning curves exist.

This changes the `min_curves` check to count trials whose latest observed progression has reached `min_progression`, i.e. trials with sufficient curve data to be comparable, regardless of status. A sufficiently deep curve from a still-running trial now counts toward `min_curves`, which is what the docstrings already described ("trials have completed with curve data attached"). For `PercentileEarlyStoppingStrategy`, the per-candidate per-progression comparability check in `_should_stop_trial_early` already enforces that `min_curves` trials have data at the decision step, so this makes the global gate consistent with the per-candidate one.

Motivation: in offline early-stopping benchmark replay, peer trials carry curve data but are not necessarily marked `COMPLETED`, so the status-based gate suppressed all stopping and diverged from what production sees at decision time. Counting by curve depth makes replay faithful.

Notes:
- `normalize_progressions` is unaffected: normalization is computed from observed progression values, never from trial status, so the no-completed-trials case now proceeds on deep running curves instead of dead-ending.
- The `check_safe=True` harm-simulation (`best_trial_vulnerable`) still seeds its protected startup set from `COMPLETED` trials; this is a distinct set-selection mechanism (not the removed count gate) and is left as-is. `check_safe` defaults to `False`.

Differential Revision: D108908764


