### PR TITLE
Fix R^2 display corruption in cross-validation cards

### DIFF
--- a/ax/analysis/plotly/cross_validation.py
+++ b/ax/analysis/plotly/cross_validation.py
@@ -261,8 +261,7 @@ class CrossValidationPlot(Analysis):
                 card = create_plotly_analysis_card(
                     name=self.__class__.__name__,
                     title=(
-                        f"Cross Validation for {metric_title}"
-                        f" (R\u00b2 = {r_squared:.2f})"
+                        f"Cross Validation for {metric_title} (R^2 = {r_squared:.2f})"
                     ),
                     subtitle=(
                         "The cross-validation plot displays the model fit for "
@@ -300,7 +299,7 @@ class CrossValidationPlot(Analysis):
                     go.Table(
                         columnwidth=[4, 1],
                         header={
-                            "values": ["Metric", "R\u00b2"],
+                            "values": ["Metric", "R<sup>2</sup>"],
                             "align": "left",
                         },
                         cells={
@@ -315,15 +314,15 @@ class CrossValidationPlot(Analysis):
                 name=self.__class__.__name__,
                 title="Summary of model fits",
                 subtitle=(
-                    "R\u00b2 (coefficient of determination) measures how well"
-                    " the model predicts each metric. Higher values indicate"
-                    " better model fit. Metrics with R\u00b2 >="
+                    "R<sup>2</sup> (coefficient of determination) measures how"
+                    " well the model predicts each metric. Higher values"
+                    " indicate better model fit. Metrics with R<sup>2</sup> >="
                     f" {threshold} are highlighted in green."
                 ),
                 df=pd.DataFrame(
                     {
                         "Metric": metric_names_list,
-                        "R\u00b2": list(self._r2s.values()),
+                        "R^2": list(self._r2s.values()),
                     }
                 ),
                 fig=r2_fig,

--- a/ax/analysis/plotly/tests/test_cross_validation.py
+++ b/ax/analysis/plotly/tests/test_cross_validation.py
@@ -77,7 +77,7 @@ class TestCrossValidationPlot(TestCase):
         )
         self.assertEqual(
             card.title,
-            "Cross Validation for bar (R\u00b2 = 0.85)",
+            "Cross Validation for bar (R^2 = 0.85)",
         )
         self.assertEqual(
             card.subtitle,
@@ -190,8 +190,8 @@ class TestCrossValidationPlot(TestCase):
         ).flatten()
         self.assertEqual(len(cards), 3)
         titles = {
-            "Cross Validation for spunky (R\u00b2 = 0.85)",
-            "Cross Validation for foo2 (R\u00b2 = 0.85)",
+            "Cross Validation for spunky (R^2 = 0.85)",
+            "Cross Validation for foo2 (R^2 = 0.85)",
         }
         for card in cards[:2]:
             self.assertEqual(card.name, "CrossValidationPlot")
@@ -230,9 +230,11 @@ class TestCrossValidationPlot(TestCase):
                         else None,
                     )
 
-                    _ = analysis.compute(
+                    cards = analysis.compute(
                         experiment=experiment, generation_strategy=generation_strategy
-                    )
+                    ).flatten()
+                    self.assertGreater(len(cards), 0)
+                    self.assertEqual(cards[0].name, "CrossValidationPlot")
 
     @TestCase.ax_long_test(
         reason=(
@@ -264,6 +266,8 @@ class TestCrossValidationPlot(TestCase):
                         else None,
                     )
 
-                    _ = analysis.compute(
+                    cards = analysis.compute(
                         experiment=experiment, generation_strategy=generation_strategy
-                    )
+                    ).flatten()
+                    self.assertGreater(len(cards), 0)
+                    self.assertEqual(cards[0].name, "CrossValidationPlot")


### PR DESCRIPTION
Summary:
The cross-validation plot card titles displayed "R?" instead of "R^2"
because the Unicode superscript character (U+00B2) was corrupted when
stored/retrieved from the latin-1 MySQL database.

Replace non-ASCII R-squared symbols with rendering-context-appropriate
ASCII alternatives:
- Card titles (plain text in React): R^2
- Card subtitles (HTML via DOMPurify): R<sup>2</sup>
- Plotly table headers (HTML in Plotly): R<sup>2</sup>
- DataFrame column names (plain text): R^2

Also add missing assertions to test_online and test_offline smoke tests.

Reviewed By: rpanchal1996, saitcakmak

Differential Revision: D109032270


