### PR TITLE
Security: Potential XSS via markdown.markdown in MarkdownAnalysisCard

### DIFF
--- a/ax/analysis/markdown/markdown_analysis.py
+++ b/ax/analysis/markdown/markdown_analysis.py
@@ -17,7 +17,7 @@ class MarkdownAnalysisCard(AnalysisCard):
         return self.blob
 
     def _body_html(self, depth: int) -> str:
-        return f"<div class='content'>{markdown.markdown(self.get_markdown())}<div>"
+        return f"<div class='content'>{markdown.markdown(self.get_markdown(), safe_mode='escape')}<div>"
 
     def _body_papermill(self) -> Markdown:
         return Markdown(self.get_markdown())


### PR DESCRIPTION
## Summary

Security: Potential XSS via markdown.markdown in MarkdownAnalysisCard

## Problem

**Severity**: `Medium` | **File**: `ax/analysis/markdown/markdown_analysis.py:L22`

The `MarkdownAnalysisCard._body_html()` method passes `self.get_markdown()` directly to `markdown.markdown()` without sanitization, then embeds the result in HTML. While the `markdown` library by default escapes raw HTML, if `safe_mode` is not enabled or if extensions are used that allow raw HTML, this could lead to Cross-Site Scripting (XSS) if the markdown content comes from an untrusted source. The `blob` field containing the markdown could be populated from user-controlled data in experiment configurations or analysis results.

## Solution

Enable safe_mode in markdown.markdown() or sanitize the output with bleach or similar HTML sanitizer before embedding in HTML. Example: `markdown.markdown(self.get_markdown(), safe_mode='escape')` or use `bleach.clean()` on the output.

## Changes

- `ax/analysis/markdown/markdown_analysis.py` (modified)