### PR TITLE
Allow outcome constraints on objective metrics in MOO (#5234)

### DIFF
--- a/ax/core/objective.py
+++ b/ax/core/objective.py
@@ -267,7 +267,15 @@ class Objective(SortableBase):
 
     def get_unconstrainable_metric_names(self) -> list[str]:
         """Return metric names that are incompatible with
-        OutcomeConstraints."""
+        OutcomeConstraints.
+
+        For multi-objective problems, all objective metrics are
+        constrainable because outcome constraints on objectives are
+        useful for bounding objectives against their optimization
+        direction (e.g., FLOPs >= threshold while minimizing FLOPs).
+        """
+        if self.is_multi_objective:
+            return []
         return self.metric_names
 
     def clone(self) -> Self:

--- a/ax/core/tests/test_objective.py
+++ b/ax/core/tests/test_objective.py
@@ -182,7 +182,7 @@ class ObjectiveTest(TestCase):
         self.assertEqual(self.objective.get_unconstrainable_metric_names(), ["m1"])
         self.assertEqual(
             self.multi_objective.get_unconstrainable_metric_names(),
-            ["m1", "m2", "m3"],
+            [],
         )
 
     def test_DeprecatedProperties(self) -> None:

--- a/ax/core/tests/test_optimization_config.py
+++ b/ax/core/tests/test_optimization_config.py
@@ -164,10 +164,14 @@ class OptimizationConfigTest(TestCase):
         # Three outcome_constraints on the same metric should raise.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
+            opposite_op = (
+                ComparisonOp.LEQ
+                if self.outcome_constraint.op == ComparisonOp.GEQ
+                else ComparisonOp.GEQ
+            )
             opposing_constraint = OutcomeConstraint(
                 metric=self.metrics["m3"],
-                # pyre-fixme[6]: For 2nd param expected `ComparisonOp` but got `bool`.
-                op=not self.outcome_constraint.op,
+                op=opposite_op,
                 bound=self.outcome_constraint.bound,
             )
         with self.assertRaises(ValueError):
@@ -181,10 +185,14 @@ class OptimizationConfigTest(TestCase):
         add_bound = 1 if self.outcome_constraint.op == ComparisonOp.LEQ else -1
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
+            opposite_op = (
+                ComparisonOp.LEQ
+                if self.outcome_constraint.op == ComparisonOp.GEQ
+                else ComparisonOp.GEQ
+            )
             opposing_constraint = OutcomeConstraint(
                 metric=self.metrics["m3"],
-                # pyre-fixme[6]: For 2nd param expected `ComparisonOp` but got `bool`.
-                op=not self.outcome_constraint.op,
+                op=opposite_op,
                 bound=self.outcome_constraint.bound + add_bound,
             )
         with self.assertRaises(ValueError):
@@ -197,10 +205,14 @@ class OptimizationConfigTest(TestCase):
         # bounds should not raise.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
+            opposite_op = (
+                ComparisonOp.LEQ
+                if self.outcome_constraint.op == ComparisonOp.GEQ
+                else ComparisonOp.GEQ
+            )
             opposing_constraint = OutcomeConstraint(
                 metric=self.metrics["m3"],
-                # pyre-fixme[6]: For 2nd param expected `ComparisonOp` but got `bool`.
-                op=not self.outcome_constraint.op,
+                op=opposite_op,
                 bound=self.outcome_constraint.bound + 1,
             )
         config = OptimizationConfig(
@@ -343,7 +355,7 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
             "`MultiObjectiveOptimizationConfig` requires an objective of type "
             "`MultiObjective` or `ScalarizedObjective`.",
         ):
-            # pyre-fixme [8]: Incompatible attribute type
+            # pyre-ignore[8]: Intentionally testing wrong type for error path.
             config1.objective = self.objective  # Wrong objective type
         # updating constraints is fine.
         config1.outcome_constraints = [self.outcome_constraint]
@@ -391,9 +403,7 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
         with self.assertRaises(UserInputError):
             MultiObjectiveOptimizationConfig(
                 objective=self.multi_objective,
-                # pyre-fixme[6]: For 2nd param expected
-                #  `Optional[List[ObjectiveThreshold]]` but got
-                #  `List[OutcomeConstraint]`.
+                # pyre-ignore[6]: Intentionally testing wrong type for error path.
                 objective_thresholds=[self.additional_outcome_constraint],
             )
 
@@ -424,25 +434,9 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
             "`MultiObjectiveOptimizationConfig` requires an objective of type "
             "`MultiObjective` or `ScalarizedObjective`.",
         ):
-            # pyre-fixme [6]: Incompatible parameter type
+            # pyre-ignore[6]: Intentionally testing wrong type for error path.
             MultiObjectiveOptimizationConfig(objective=self.objective)
 
-        # Using an outcome constraint for an objective should raise
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            outcome_constraint_m1 = OutcomeConstraint(
-                metric=self.metrics["m1"],
-                op=ComparisonOp.LEQ,
-                bound=1234,
-                relative=False,
-            )
-        with self.assertRaisesRegex(
-            ValueError, "Cannot constrain on objective metric."
-        ):
-            MultiObjectiveOptimizationConfig(
-                objective=self.multi_objective,
-                outcome_constraints=[outcome_constraint_m1],
-            )
         # Two outcome_constraints on the same metric with the same op
         # should raise.
         with warnings.catch_warnings():
@@ -461,10 +455,14 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
         # Three outcome_constraints on the same metric should raise.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
+            opposite_op = (
+                ComparisonOp.LEQ
+                if self.outcome_constraint.op == ComparisonOp.GEQ
+                else ComparisonOp.GEQ
+            )
             opposing_constraint = OutcomeConstraint(
                 metric=self.metrics["m3"],
-                # pyre-fixme[6]: For 2nd param expected `ComparisonOp` but got `bool`.
-                op=not self.outcome_constraint.op,
+                op=opposite_op,
                 bound=self.outcome_constraint.bound,
             )
         with self.assertRaises(ValueError):
@@ -480,8 +478,7 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
             warnings.simplefilter("ignore", DeprecationWarning)
             opposing_constraint = OutcomeConstraint(
                 metric=self.metrics["m3"],
-                # pyre-fixme[6]: For 2nd param expected `ComparisonOp` but got `bool`.
-                op=not self.outcome_constraint.op,
+                op=opposite_op,
                 bound=self.outcome_constraint.bound + add_bound,
             )
         with self.assertRaises(ValueError):
@@ -496,8 +493,7 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
             warnings.simplefilter("ignore", DeprecationWarning)
             opposing_constraint = OutcomeConstraint(
                 metric=self.metrics["m3"],
-                # pyre-fixme[6]: For 2nd param expected `ComparisonOp` but got `bool`.
-                op=not self.outcome_constraint.op,
+                op=opposite_op,
                 bound=self.outcome_constraint.bound + 1,
             )
         config = MultiObjectiveOptimizationConfig(
@@ -524,8 +520,8 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
         )
         self.assertEqual(len(config_with_scalarized.outcome_constraints), 1)
 
-        # Can't constrain on metric in ScalarizedOutcomeConstraint
-        # that overlaps with objective
+        # ScalarizedOutcomeConstraint that overlaps with objective is also
+        # allowed in MOO.
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             scalarized_with_objective_metric = ScalarizedOutcomeConstraint(
@@ -537,13 +533,41 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
                 op=ComparisonOp.GEQ,
                 bound=0.0,
             )
-        with self.assertRaisesRegex(
-            ValueError, "Cannot constrain on objective metric."
-        ):
-            MultiObjectiveOptimizationConfig(
-                objective=self.multi_objective,
-                outcome_constraints=[scalarized_with_objective_metric],
+        config_scalarized_obj = MultiObjectiveOptimizationConfig(
+            objective=self.multi_objective,
+            outcome_constraints=[scalarized_with_objective_metric],
+        )
+        self.assertEqual(
+            config_scalarized_obj.outcome_constraints,
+            [scalarized_with_objective_metric],
+        )
+
+    def test_ConstraintAgainstOptimizationDirection(self) -> None:
+        """Verify that an objective can be constrained against its optimization
+        direction, e.g. FLOPs >= threshold while minimizing FLOPs. This is
+        useful in MOO to prevent the acquisition function from exploring
+        regions of the objective space that are known to be uninteresting.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            # m1 is minimized, m2 is maximized in self.multi_objective
+            # Constraint m1 from below (against minimize direction)
+            lower_bound_on_m1 = OutcomeConstraint(
+                metric=self.metrics["m1"],
+                op=ComparisonOp.GEQ,
+                bound=100.0,
+                relative=False,
             )
+        config = MultiObjectiveOptimizationConfig(
+            objective=self.multi_objective,
+            outcome_constraints=[lower_bound_on_m1],
+            objective_thresholds=self.objective_thresholds,
+        )
+        self.assertEqual(config.outcome_constraints, [lower_bound_on_m1])
+        self.assertEqual(config.objective_thresholds, self.objective_thresholds)
+        self.assertEqual(
+            config.all_constraints, [lower_bound_on_m1] + self.objective_thresholds
+        )
 
     def test_Clone(self) -> None:
         config1 = MultiObjectiveOptimizationConfig(


### PR DESCRIPTION
Summary:

In multi-objective optimization, the acquisition function can exploit
asymmetric model uncertainty by proposing points that are extreme in
easy-to-predict objectives (e.g., very small model size) while hoping for
favorable outcomes on uncertain objectives (e.g., model accuracy). Users want to
add constraints against the optimization direction (e.g., model size >=
threshold while minimizing model size) to prevent exploring regions that
are known to be uninteresting.

Previously, Ax prevented any outcome constraint on an objective metric
via `get_unconstrainable_metric_names()`. This restriction made sense
for single-objective optimization (where constraining the sole objective
is reducible to a constrained problem) but was overly restrictive for
MOO. The downstream BoTorch acquisition functions (e.g.,
`qLogNoisyExpectedHypervolumeImprovement`) already support constraints
on objective outputs via their `constraints` parameter, which applies
a sigmoid-based feasibility indicator independently of the hypervolume
objective.

This diff relaxes the validation in
`MultiObjectiveOptimizationConfig._validate_transformed_optimization_config()`
to allow outcome constraints on objective metrics for multi-objective
problems, while preserving the restriction for single-objective and
scalarized-objective cases.

Note: objective thresholds are insufficient for this use case because
(1) they only serve as the hypervolume reference point (soft boundary,
not hard constraint), and (2) they only support bounding from the
direction of optimization -- you cannot set a lower bound on a
minimized objective via thresholds.

Reviewed By: saitcakmak

Differential Revision: D109061377


