### PR TITLE
Add log_scale option to ChoiceParameterConfig

### DIFF
--- a/ax/api/configs.py
+++ b/ax/api/configs.py
@@ -40,6 +40,7 @@ class ChoiceParameterConfig:
     values: list[float] | list[int] | list[str] | list[bool]
     parameter_type: Literal["float", "int", "str", "bool"]
     is_ordered: bool | None = None
+    log_scale: bool | None = None
     dependent_parameters: Mapping[TParameterValue, Sequence[str]] | None = None
 
 

--- a/ax/api/utils/instantiation/from_config.py
+++ b/ax/api/utils/instantiation/from_config.py
@@ -93,6 +93,7 @@ def parameter_from_config(
             parameter_type=_parameter_type_converter(config.parameter_type),
             values=cast(list[TParamValue], config.values),
             is_ordered=config.is_ordered,
+            log_scale=config.log_scale,
             dependents=cast(
                 dict[TParamValue, list[str]] | None,
                 config.dependent_parameters,

--- a/ax/api/utils/instantiation/tests/test_from_config.py
+++ b/ax/api/utils/instantiation/tests/test_from_config.py
@@ -26,6 +26,7 @@ from ax.core.parameter_constraint import ParameterConstraint
 from ax.core.search_space import SearchSpace
 from ax.exceptions.core import UserInputError
 from ax.utils.common.testutils import TestCase
+from pyre_extensions import assert_is_instance
 
 
 class TestFromConfig(TestCase):
@@ -222,6 +223,46 @@ class TestFromConfig(TestCase):
                 value="a",
             ),
         )
+
+        choice_config_with_log_scale = ChoiceParameterConfig(
+            name="choice_param_with_log_scale",
+            parameter_type="float",
+            values=[1.0, 2.0, 3.0],
+            log_scale=True,
+        )
+        self.assertEqual(
+            parameter_from_config(config=choice_config_with_log_scale),
+            ChoiceParameter(
+                name="choice_param_with_log_scale",
+                parameter_type=CoreParameterType.FLOAT,
+                values=[1.0, 2.0, 3.0],
+                log_scale=True,
+            ),
+        )
+
+        # log_scale=False should override the auto-detection default.
+        choice_config_without_log_scale = ChoiceParameterConfig(
+            name="choice_param_without_log_scale",
+            parameter_type="int",
+            values=[1, 10, 100],
+            log_scale=False,
+        )
+        parameter = parameter_from_config(config=choice_config_without_log_scale)
+        self.assertFalse(assert_is_instance(parameter, ChoiceParameter).log_scale)
+
+        # log_scale is only supported for numeric parameters.
+        with self.assertRaisesRegex(
+            UserInputError, "log_scale is only supported for numerical parameters"
+        ):
+            parameter_from_config(
+                config=ChoiceParameterConfig(
+                    name="str_choice_param_with_log_scale",
+                    parameter_type="str",
+                    values=["a", "b", "c"],
+                    log_scale=True,
+                )
+            )
+
         self.assertFalse(any("sort_values" in str(w.message) for w in ws))
 
     def test_experiment_from_config(self) -> None:


### PR DESCRIPTION
Summary:
## Summary

Adds a `log_scale: bool | None = None` field to `ChoiceParameterConfig` and pipes it through `parameter_from_config` to the underlying `ChoiceParameter`.

This is the Ax-side change for T276435081, which adds end-to-end support for declaring numeric (int/float) `Choice` parameters as log-scaled so that GAIN's log-log / log-linear modeling can flow through to Ax. The corresponding GAIN-side changes will stack on top of this diff.

`ChoiceParameter` already supports `log_scale` with validation that values are numeric, positive, and ordered. Passing `log_scale=None` preserves Ax's existing auto-detection behavior, while an explicit `True`/`False` overrides the default — matching the existing `ChoiceParameter.__init__` semantics.

Differential Revision: D109078978


