### PR TITLE
Fix typo in failure-rate error message

### DIFF
--- a/ax/orchestration/orchestrator.py
+++ b/ax/orchestration/orchestrator.py
@@ -2193,7 +2193,7 @@ class Orchestrator(WithDBSettingsBase, BestPointMixin):
                 if self._num_trials_bad_due_to_err > num_bad_in_orchestrator / 2
                 else ""
             )
-            + " Orignal error message: "
+            + " Original error message: "
             + FAILURE_EXCEEDED_MSG.format(
                 f_rate=self.options.tolerated_trial_failure_rate,
                 n_failed=num_bad_in_orchestrator,


### PR DESCRIPTION
Summary:
What Changed:
Correct `Orignal` to `Original` in the failure-rate exceeded error prefix.

The typo was observed in FBLearner pipeline run `f1113246350`, where it appeared in the user-visible `FailureRateExceededError`.

___

Differential Revision: D112559211


