### PR TITLE
Support discrete choices in random generators (#5257)

### DIFF
--- a/ax/adapter/registry.py
+++ b/ax/adapter/registry.py
@@ -106,6 +106,9 @@ MBM_X_trans_base: list[type[Transform]] = [
 ]
 MBM_X_trans: list[type[Transform]] = [MapKeyToFloat, *MBM_X_trans_base]
 
+# Random adapters now support discrete parameters natively, so they can use the
+# same set of transforms as MBM.
+Random_X_trans: list[type[Transform]] = MBM_X_trans_base
 
 Discrete_X_trans: list[type[Transform]] = [IntRangeToChoice]
 
@@ -210,12 +213,12 @@ GENERATOR_KEY_TO_GENERATOR_SETUP: dict[str, GeneratorSetup] = {
     "Sobol": GeneratorSetup(
         adapter_class=RandomAdapter,
         generator_class=SobolGenerator,
-        transforms=Cont_X_trans,
+        transforms=Random_X_trans,
     ),
     "Uniform": GeneratorSetup(
         adapter_class=RandomAdapter,
         generator_class=UniformGenerator,
-        transforms=Cont_X_trans,
+        transforms=Random_X_trans,
     ),
     # In-sample generators only select existing arms -- they do not need
     # arithmetic transforms (Log, Logit, UnitX) whose forward/reverse

--- a/ax/adapter/tests/test_registry.py
+++ b/ax/adapter/tests/test_registry.py
@@ -11,9 +11,9 @@ from ax.adapter.random import RandomAdapter
 from ax.adapter.registry import (
     _extract_generator_state_after_gen,
     _raise_on_callables,
-    Cont_X_trans,
     GENERATOR_KEY_TO_GENERATOR_SETUP,
     Generators,
+    Random_X_trans,
 )
 from ax.adapter.torch import TorchAdapter
 from ax.core.observation import ObservationFeatures
@@ -182,7 +182,7 @@ class ModelRegistryTest(TestCase):
                 },
                 {
                     "optimization_config": None,
-                    "transforms": Cont_X_trans,
+                    "transforms": Random_X_trans,
                     "transform_configs": None,
                     "data_loader_config": None,
                     "fit_tracking_metrics": True,

--- a/ax/api/tests/test_client.py
+++ b/ax/api/tests/test_client.py
@@ -545,6 +545,56 @@ class TestClient(TestCase):
         # Check that GS is not saved to the DB.
         mock_save.assert_not_called()
 
+    def test_get_next_trials_with_constrained_discrete_parameter(self) -> None:
+        client = Client(random_seed=0)
+        choices = [0.01, 0.26, 0.72, 0.96]
+        client.configure_experiment(
+            parameters=[
+                RangeParameterConfig(
+                    name="p1", parameter_type="float", bounds=(0.0, 1.0)
+                ),
+                ChoiceParameterConfig(
+                    name="p2",
+                    parameter_type="float",
+                    values=choices,
+                    is_ordered=True,
+                ),
+            ],
+            parameter_constraints=["p1 <= p2"],
+        )
+        client.configure_optimization(objective="score")
+        client.configure_generation_strategy(initialize_with_center=False)
+
+        trials = client.get_next_trials(max_trials=10)
+
+        for trial in trials.values():
+            p1 = assert_is_instance(trial["p1"], float)
+            p2 = assert_is_instance(trial["p2"], float)
+            self.assertIn(p2, choices)
+            self.assertLessEqual(p1, p2)
+
+    def test_get_next_trials_with_integer_range(self) -> None:
+        client = Client(random_seed=0)
+        client.configure_experiment(
+            parameters=[
+                RangeParameterConfig(
+                    name="p1", parameter_type="float", bounds=(0.0, 2.0)
+                ),
+                RangeParameterConfig(name="p2", parameter_type="int", bounds=(0, 2)),
+            ],
+            parameter_constraints=["p1 <= p2"],
+        )
+        client.configure_optimization(objective="score")
+        client.configure_generation_strategy(initialize_with_center=False)
+
+        trials = client.get_next_trials(max_trials=10)
+
+        for trial in trials.values():
+            p1 = assert_is_instance(trial["p1"], float)
+            p2 = assert_is_instance(trial["p2"], int)
+            self.assertIn(p2, [0, 1, 2])
+            self.assertLessEqual(p1, p2)
+
     def test_get_next_trials_with_db(self) -> None:
         init_test_engine_and_session_factory(force_init=True)
         client = Client(storage_config=StorageConfig())

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -16,10 +16,10 @@ from ax.adapter.factory import get_sobol
 from ax.adapter.random import RandomAdapter
 from ax.adapter.registry import (
     _extract_generator_state_after_gen,
-    Cont_X_trans,
     GENERATOR_KEY_TO_GENERATOR_SETUP,
     Generators,
     MBM_MTGP_trans,
+    Random_X_trans,
 )
 from ax.adapter.torch import TorchAdapter
 from ax.core.arm import Arm
@@ -680,7 +680,7 @@ class TestGenerationStrategy(TestCase):
                     {
                         "optimization_config": None,
                         "transform_configs": None,
-                        "transforms": Cont_X_trans,
+                        "transforms": Random_X_trans,
                         "data_loader_config": None,
                         "fit_tracking_metrics": True,
                         "fit_on_init": True,
@@ -1637,7 +1637,7 @@ class TestGenerationStrategy(TestCase):
                     {
                         "optimization_config": None,
                         "transform_configs": None,
-                        "transforms": Cont_X_trans,
+                        "transforms": Random_X_trans,
                         "data_loader_config": None,
                         "fit_tracking_metrics": True,
                         "fit_on_init": True,

--- a/ax/generators/random/base.py
+++ b/ax/generators/random/base.py
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from logging import Logger
 from typing import Any
 
@@ -80,6 +80,7 @@ class RandomGenerator(Generator):
         self.fallback_to_sample_polytope = fallback_to_sample_polytope
         self.polytope_sampler_kwargs: dict[str, Any] = polytope_sampler_kwargs or {}
         self._bounds: npt.NDArray = np.empty((0, 2))
+        self._discrete_choices: Mapping[int, Sequence[int | float]] = {}
         self.attempted_draws: int = 0
 
     @property
@@ -137,6 +138,7 @@ class RandomGenerator(Generator):
             bounds=search_space_digest.bounds, fixed_features=fixed_features
         )
         self._bounds = np.array(search_space_digest.bounds)  # (d, 2)
+        self._discrete_choices = search_space_digest.discrete_choices
 
         max_draws = DEFAULT_MAX_RS_DRAWS
         discrete_indices = set(search_space_digest.discrete_choices.keys())
@@ -155,10 +157,11 @@ class RandomGenerator(Generator):
             # pyrefly: ignore [bad-argument-type]
             max_draws = int(assert_is_instance_of_tuple(max_draws, (int, float)))
         try:
-            # With equality constraints, unconstrained sampling has probability
-            # zero of producing feasible points, so skip straight to polytope
-            # sampling.
-            if equality_constraints is not None:
+            # Equalities involving tunable continuous parameters have probability
+            # zero under unconstrained sampling. Purely discrete equalities do not.
+            if equality_constraints is not None and any(
+                np.any(equality_constraints[0][:, i] != 0) for i in continuous_indices
+            ):
                 raise SearchSpaceExhausted(
                     "Equality constraints require polytope sampling."
                 )
@@ -176,6 +179,7 @@ class RandomGenerator(Generator):
                 fixed_features=fixed_features,
                 rounding_func=rounding_func,
                 existing_points=generated_points,
+                equality_constraints=equality_constraints,
             )
         except SearchSpaceExhausted as e:
             if has_continuous_parameters or self.fallback_to_sample_polytope:
@@ -226,7 +230,8 @@ class RandomGenerator(Generator):
                 ) -> npt.NDArray:
                     # Note: the fixed features are applied as equality constraints
                     # in the polytope sampler, so we don't need to apply them here.
-                    return polytope_sampler.draw(n=n).numpy()
+                    points = polytope_sampler.draw(n=n).numpy()
+                    return self._snap_to_discrete_choices(points=points)
 
                 # we call rejection_sample here to reuse all the deduplication
                 # logic
@@ -280,17 +285,45 @@ class RandomGenerator(Generator):
 
         """
         tunable_bounds = self._bounds[tunable_feature_indices]
+        sampling_bounds = tunable_bounds.copy()
+        for local_index, parameter_index in enumerate(tunable_feature_indices):
+            choices = self._discrete_choices.get(int(parameter_index))
+            if choices is not None:
+                sampling_bounds[local_index] = (0, len(choices))
         tunable_points = self._gen_samples(
             n=n,
             tunable_d=len(tunable_feature_indices),
-            bounds=tunable_bounds,
+            bounds=sampling_bounds,
         )
+        for local_index, parameter_index in enumerate(tunable_feature_indices):
+            choices = self._discrete_choices.get(int(parameter_index))
+            if choices is not None:
+                choice_indices = np.minimum(
+                    tunable_points[:, local_index].astype(int), len(choices) - 1
+                )
+                tunable_points[:, local_index] = np.asarray(choices)[choice_indices]
         return add_fixed_features(
             tunable_points=tunable_points,
             d=d,
             tunable_feature_indices=tunable_feature_indices,
             fixed_features=fixed_features,
         )
+
+    def _snap_to_discrete_choices(self, points: npt.NDArray) -> npt.NDArray:
+        """Project discrete dimensions onto their nearest supported values.
+
+        The polytope sampler must operate in the parameters' value space because
+        mapping irregularly spaced choices to indices is nonlinear and would not
+        preserve the linear constraints that define the polytope.
+        """
+        points = points.copy()
+        for parameter_index, choices in self._discrete_choices.items():
+            choice_values = np.asarray(choices)
+            distances = np.abs(
+                points[:, parameter_index, np.newaxis] - choice_values[np.newaxis, :]
+            )
+            points[:, parameter_index] = choice_values[np.argmin(distances, axis=1)]
+        return points
 
     def _gen_samples(self, n: int, tunable_d: int, bounds: npt.NDArray) -> npt.NDArray:
         """Generate n samples within the given bounds.

--- a/ax/generators/tests/test_sobol.py
+++ b/ax/generators/tests/test_sobol.py
@@ -113,6 +113,39 @@ class SobolGeneratorTest(TestCase):
         self.assertTrue(np.all(generated_points >= np_bounds[:, 0]))
         self.assertTrue(np.all(generated_points <= np_bounds[:, 1]))
 
+    def test_SobolGeneratorWithDiscreteChoices(self) -> None:
+        choices = [0.01, 0.26, 0.72, 0.96]
+        ssd = SearchSpaceDigest(
+            feature_names=["continuous", "discrete"],
+            bounds=[(0.0, 1.0), (min(choices), max(choices))],
+            discrete_choices={1: choices},
+        )
+        generated_points, _ = SobolGenerator(seed=0).gen(
+            n=10,
+            search_space_digest=ssd,
+            linear_constraints=(np.array([[1.0, -1.0]]), np.array([[0.0]])),
+            rounding_func=lambda x: x,
+        )
+
+        self.assertTrue(set(generated_points[:, 1]).issubset(choices))
+        self.assertTrue(np.all(generated_points[:, 0] <= generated_points[:, 1]))
+
+    def test_SobolGeneratorWithDiscreteEqualityConstraint(self) -> None:
+        choices = [1.0, 10.0, 100.0]
+        ssd = SearchSpaceDigest(
+            feature_names=["discrete"],
+            bounds=[(min(choices), max(choices))],
+            discrete_choices={0: choices},
+        )
+        generated_points, _ = SobolGenerator(seed=0).gen(
+            n=1,
+            search_space_digest=ssd,
+            equality_constraints=(np.array([[1.0]]), np.array([[10.0]])),
+            rounding_func=lambda x: x,
+        )
+
+        self.assertEqual(generated_points[0, 0], 10.0)
+
     def test_SobolGeneratorOnline(self) -> None:
         # Verify that the generator will return the expected arms if called
         # one at a time.

--- a/ax/generators/tests/test_uniform.py
+++ b/ax/generators/tests/test_uniform.py
@@ -182,3 +182,18 @@ class UniformGeneratorTest(TestCase):
         self.assertTrue(np.all(generated_points >= np_bounds[:, 0]))
         self.assertTrue(np.all(generated_points <= np_bounds[:, 1]))
         self.assertTrue(np.all(weights == 1.0))
+
+    def test_with_discrete_choices(self) -> None:
+        choices = [1.0, 10.0, 100.0]
+        ssd = SearchSpaceDigest(
+            feature_names=["discrete"],
+            bounds=[(min(choices), max(choices))],
+            discrete_choices={0: choices},
+        )
+        generated_points, _ = UniformGenerator(seed=self.seed).gen(
+            n=len(choices),
+            search_space_digest=ssd,
+            rounding_func=lambda x: x,
+        )
+
+        self.assertEqual(set(generated_points[:, 0]), set(choices))


### PR DESCRIPTION
Summary:

Problem:
Random generation previously used `OrderedChoiceToIntegerRange`, which encoded ordered numeric choices as integer indices while leaving parameter constraints in the original value space. Constraints could therefore be checked against indices and produce candidates that violated the user-defined constraint after transforming back. This also prevented correct handling of irregularly spaced choices.

What Changed:
- Add a choice-preserving transform base shared by random generators and MBM, using `ChoiceToNumericChoice` without `IntToFloat` or model-side `UnitX` for random generation.
- Preserve numeric `ChoiceParameter` values and integer ranges in `SearchSpaceDigest.discrete_choices`.
- Teach `RandomGenerator`, and therefore Sobol and Uniform generators, to sample every discrete dimension uniformly by rank and decode it to the actual choice value before constraint checks, rounding, and deduplication.
- Handle purely discrete equality constraints with rejection sampling.
- In the polytope fallback, sample the continuous relaxation in the original value space, project each discrete coordinate to its nearest supported value, and recheck feasibility. Irregular value-to-index mappings are nonlinear, so transforming the polytope to index space would not preserve its linear constraints.
- Avoid calling PyTorch `SobolEngine.fast_forward(0)`: the fresh-engine implementation converts zero to `-1`, while advancing by zero should be a no-op.
- Cover irregular choices, discrete equality constraints, and integer ranges through generator, adapter, generation strategy, and public `Client` tests.

Differential Revision: D113627036


