### PR TITLE
Fix SobolEngine.fast_forward with n=0 (#5262)

### DIFF
--- a/ax/analysis/plotly/tests/test_sensitivity.py
+++ b/ax/analysis/plotly/tests/test_sensitivity.py
@@ -5,7 +5,6 @@
 
 # pyre-strict
 
-from itertools import product
 from unittest.mock import patch
 
 from ax.adapter.registry import Generators

--- a/ax/generators/random/sobol.py
+++ b/ax/generators/random/sobol.py
@@ -66,7 +66,9 @@ class SobolGenerator(RandomGenerator):
         if not self._engine:
             self._engine = SobolEngine(
                 dimension=n_tunable_features, scramble=self.scramble, seed=self.seed
-            ).fast_forward(self.init_position)
+            )
+            if self.init_position > 0:
+                self._engine.fast_forward(self.init_position)
         return self._engine
 
     @property


### PR DESCRIPTION
Summary:

A recent torch change made it so that n=0 is not a valid input to SobolEngine.fast_forward. This diff should fix the resulting failures (in internal CI).

___

Differential Revision: D113989171


