### PR TITLE
Suppress type errors for Pyre upgrade - ax

### DIFF
--- a/ax/adapter/tests/test_cross_validation.py
+++ b/ax/adapter/tests/test_cross_validation.py
@@ -958,6 +958,7 @@ class CrossValidationTest(TestCase):
         model = assert_is_instance(surrogate.model, SaasFullyBayesianSingleTaskGP)
 
         # Get training data shape info
+        # pyrefly: ignore [unsupported-operation]
         train_X = model.train_inputs[0]
         d = train_X.shape[-1]
         num_models = 4  # Number of MCMC samples

--- a/ax/adapter/transforms/bilog_y.py
+++ b/ax/adapter/transforms/bilog_y.py
@@ -109,6 +109,7 @@ class BilogY(Transform):
                         mean=obsd.means[i],
                         sem=None,
                         variance=obsd.covariance[i, i],
+                        # pyrefly: ignore [bad-argument-type]
                         transform=lambda y, bound=bound: transform(y, bound),
                     )
         return observation_data

--- a/ax/generators/torch/tests/test_generator.py
+++ b/ax/generators/torch/tests/test_generator.py
@@ -194,8 +194,10 @@ class BoTorchGeneratorTest(TestCase):
             outcome_constraints=self.moo_outcome_constraints,
             # pyrefly: ignore [bad-argument-type]
             model_gen_options={
+                # pyrefly: ignore [bad-assignment]
                 Keys.OPTIMIZER_KWARGS: self.optimizer_options,
                 Keys.ACQF_KWARGS: {"eta": 3.0},
+                # pyrefly: ignore [bad-assignment]
                 Keys.AX_ACQUISITION_KWARGS: {Keys.SUBSET_MODEL: True},
             },
         )

--- a/ax/service/tests/test_interactive_loop.py
+++ b/ax/service/tests/test_interactive_loop.py
@@ -72,6 +72,7 @@ class TestInteractiveLoop(TestCase):
         return (
             trial_index,
             {
+                # pyrefly: ignore [bad-assignment]
                 "hartmann6": (hartmann6(x), 0.0),
                 "l2norm": (np.sqrt((x**2).sum()), 0.0),
             },
@@ -145,6 +146,7 @@ class TestInteractiveLoop(TestCase):
             return (
                 trial_index,
                 {
+                    # pyrefly: ignore [bad-assignment]
                     "hartmann6": (hartmann6(x), 0.0),
                     "l2norm": (np.sqrt((x**2).sum()), 0.0),
                 },

--- a/ax/storage/sqa_store/sqa_config.py
+++ b/ax/storage/sqa_store/sqa_config.py
@@ -68,6 +68,7 @@ class SQAConfig:
 
     EXPERIMENT_TYPES_WITH_NO_DATA_STORAGE: set[str] = field(default_factory=set)
 
+    # pyrefly: ignore [bad-function-definition]
     def _default_class_to_sqa_class(self=None) -> dict[type[Base], type[SQABase]]:
         ax_cls_to_sqa_cls = {
             AbandonedArm: SQAAbandonedArm,


### PR DESCRIPTION
Summary:
This diff was automatically generated by the Pyre per-target upgrade tool.

It adds `# pyre-fixme` or `pyrefly: ignore` comments to suppress type errors that will be introduced by an upcoming Pyre or Pyrefly release. These suppressions allow the upgrade to proceed without breaking existing code.

#pyreupgrade

Differential Revision: D113945639


