### PR TITLE
Fix prep_pairwise_data to filter out invalid group indices (#5266)

### DIFF
--- a/ax/adapter/adapter_utils.py
+++ b/ax/adapter/adapter_utils.py
@@ -1420,17 +1420,60 @@ def prep_pairwise_data(
             the number of features.
         Y: Tensor of shape `(n, 1)` with binary 0 or 1 outcomes with 1 indicating
             that is the preferred arm in the trial.
-        group_indices: Indices of groups of each observation. We have exactly two
-            arms per group with exactly one 0 and one 1 in Y.
+        group_indices: Indices of groups of each observation. A valid comparison
+            group has exactly two arms with exactly one 0 and one 1 in Y. Groups
+            that do not satisfy this (e.g. a single arm, or two arms with the same
+            label) are dropped with a warning before pairing, so callers are not
+            required to guarantee this invariant.
         outcome: Name of the outcome.
         parameters: Names of the features.
 
     Returns:
         A `RankingDataset` for pairwise preference modeling.
+
+    Raises:
+        UserInputError: If no valid comparison group remains after dropping
+            incomplete groups.
     """
     sorted_indices = torch.argsort(group_indices)
     X = X[sorted_indices]
     Y = Y[sorted_indices]
+    group_indices = group_indices[sorted_indices]
+
+    # Each comparison group must contain exactly two arms with exactly one
+    # preferred (`1`) and one not (`0`) to form a valid pair. Upstream filtering
+    # -- e.g. dropping arms whose outcome is NaN or removing stale LILO labels --
+    # can leave a group with a single arm (yielding an odd number of observations
+    # that cannot be reshaped into pairs and would otherwise crash with a cryptic
+    # `shape '[-1, 2]' is invalid` error) or with two identically-labeled arms
+    # (which would be silently mispaired). Drop any such invalid group.
+    unique_groups, inverse, counts = torch.unique(
+        group_indices, return_inverse=True, return_counts=True
+    )
+    label_sums = torch.zeros(
+        unique_groups.shape[0], dtype=Y.dtype, device=Y.device
+    ).scatter_add_(0, inverse, Y.view(-1))
+    invalid_groups = unique_groups[(counts != 2) | (label_sums != 1)]
+    if invalid_groups.numel() > 0:
+        keep_mask = ~torch.isin(group_indices, invalid_groups)
+        logger.warning(
+            f"Dropping {int((~keep_mask).sum())} pairwise preference "
+            f"observation(s) from {int(invalid_groups.numel())} comparison "
+            "group(s) that do not contain exactly two arms with exactly one "
+            "preferred (1) and one not-preferred (0) label. Each pairwise "
+            "comparison requires exactly two such arms."
+        )
+        X = X[keep_mask]
+        Y = Y[keep_mask]
+        group_indices = group_indices[keep_mask]
+
+    if Y.numel() == 0:
+        raise UserInputError(
+            "No valid pairwise comparison groups remain for outcome "
+            f"'{outcome}' after dropping incomplete groups. Each pairwise "
+            "comparison requires exactly two arms with exactly one preferred "
+            "(1) and one not-preferred (0) label."
+        )
 
     # Update Xs and Ys shapes for PairwiseGP
     Y = _binary_pref_to_comp_pair(Y=Y)

--- a/ax/adapter/tests/test_adapter_utils.py
+++ b/ax/adapter/tests/test_adapter_utils.py
@@ -21,6 +21,7 @@ from ax.adapter.adapter_utils import (
     extract_search_space_digest,
     feasible_hypervolume,
     is_unordered_choice,
+    prep_pairwise_data,
     process_contextual_datasets,
     transform_search_space,
     validate_and_apply_final_transform,
@@ -657,6 +658,100 @@ class TestAdapterUtils(TestCase):
             self.assertNotIn(0, result)
             self.assertNotIn(1, result)
             self.assertIn(2, result)
+
+    def test_prep_pairwise_data_drops_incomplete_groups(self) -> None:
+        """Comparison groups without exactly two arms are dropped so that an odd
+        number of pairwise observations does not crash the reshape into pairs."""
+        parameters = ["x1", "x2"]
+        # Groups 0 and 1 are complete pairs; group 2 has a single arm, so the
+        # total count is odd (5) -- this used to crash `.reshape(-1, 2)` with
+        # `shape '[-1, 2]' is invalid for input of size 5`.
+        X = torch.tensor(
+            [[0.0, 0.0], [1.0, 1.0], [2.0, 2.0], [3.0, 3.0], [4.0, 4.0]],
+            dtype=torch.double,
+        )
+        Y = torch.tensor([[0], [1], [1], [0], [1]], dtype=torch.long)
+        group_indices = torch.tensor([0, 0, 1, 1, 2])
+
+        with self.assertLogs("ax", level="WARNING") as logs:
+            dataset = prep_pairwise_data(
+                X=X,
+                Y=Y,
+                group_indices=group_indices,
+                outcome=Keys.PAIRWISE_PREFERENCE_QUERY.value,
+                parameters=parameters,
+            )
+        self.assertIn("do not contain exactly two arms", "\n".join(logs.output))
+        # Only the two complete comparison pairs remain.
+        self.assertEqual(dataset.Y.shape[0], 2)
+
+    def test_prep_pairwise_data_drops_degenerate_groups(self) -> None:
+        """Groups with two arms but identical labels (both 0 or both 1) are
+        dropped rather than being silently mispaired."""
+        parameters = ["x1", "x2"]
+        # Group 0 is a valid pair; group 1 has two arms both labeled 1.
+        X = torch.tensor(
+            [[0.0, 0.0], [1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+            dtype=torch.double,
+        )
+        Y = torch.tensor([[0], [1], [1], [1]], dtype=torch.long)
+        group_indices = torch.tensor([0, 0, 1, 1])
+
+        with self.assertLogs("ax", level="WARNING") as logs:
+            dataset = prep_pairwise_data(
+                X=X,
+                Y=Y,
+                group_indices=group_indices,
+                outcome=Keys.PAIRWISE_PREFERENCE_QUERY.value,
+                parameters=parameters,
+            )
+        self.assertIn(
+            "one preferred (1) and one not-preferred (0)", "\n".join(logs.output)
+        )
+        # Only the single valid comparison pair remains.
+        self.assertEqual(dataset.Y.shape[0], 1)
+
+    def test_prep_pairwise_data_all_groups_invalid_raises(self) -> None:
+        """When no valid comparison group remains, a descriptive error is raised
+        instead of failing cryptically downstream on empty inputs."""
+        parameters = ["x1", "x2"]
+        X = torch.tensor([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]], dtype=torch.double)
+        Y = torch.tensor([[0], [1], [1]], dtype=torch.long)
+        # Every group has a single arm -- all groups are incomplete.
+        group_indices = torch.tensor([0, 1, 2])
+
+        with self.assertRaisesRegex(
+            UserInputError, "No valid pairwise comparison groups remain"
+        ):
+            with self.assertLogs("ax", level="WARNING"):
+                prep_pairwise_data(
+                    X=X,
+                    Y=Y,
+                    group_indices=group_indices,
+                    outcome=Keys.PAIRWISE_PREFERENCE_QUERY.value,
+                    parameters=parameters,
+                )
+
+    def test_prep_pairwise_data_all_complete_groups(self) -> None:
+        """When every group is a complete pair, no observations are dropped and
+        no warning is logged."""
+        parameters = ["x1", "x2"]
+        X = torch.tensor(
+            [[0.0, 0.0], [1.0, 1.0], [2.0, 2.0], [3.0, 3.0]],
+            dtype=torch.double,
+        )
+        Y = torch.tensor([[0], [1], [1], [0]], dtype=torch.long)
+        group_indices = torch.tensor([0, 0, 1, 1])
+
+        with self.assertNoLogs("ax", level="WARNING"):
+            dataset = prep_pairwise_data(
+                X=X,
+                Y=Y,
+                group_indices=group_indices,
+                outcome=Keys.PAIRWISE_PREFERENCE_QUERY.value,
+                parameters=parameters,
+            )
+        self.assertEqual(dataset.Y.shape[0], 2)
 
     def test_extract_inequality_constraints(self) -> None:
         param_names = ["x", "y"]


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/facebook/Ax/pull/5266

Differential Revision: D113421765


