### PR TITLE
Support baseline-referenced SGES for single-trial experiments

### DIFF
--- a/ax/early_stopping/strategies/base.py
+++ b/ax/early_stopping/strategies/base.py
@@ -249,6 +249,9 @@ class BaseEarlyStoppingStrategy(ABC, Base):
 
         full_df = data.full_df
         full_df = full_df[full_df["metric_signature"].isin(metric_signatures)]
+        full_df = self._augment_early_stopping_data(
+            df=full_df, metric_signatures=metric_signatures
+        )
 
         # Drop rows with NaN values in MAP_KEY column to prevent issues in
         # align_partial_results which uses MAP_KEY as the pivot index
@@ -265,6 +268,12 @@ class BaseEarlyStoppingStrategy(ABC, Base):
         if self.normalize_progressions:
             full_df = _maybe_normalize_map_key(df=full_df)
         return Data(df=full_df)
+
+    def _augment_early_stopping_data(
+        self, df: pd.DataFrame, metric_signatures: list[str]
+    ) -> pd.DataFrame:
+        """Allow strategies to add reference observations before normalization."""
+        return df
 
     @staticmethod
     def _log_and_return_no_data(

--- a/ax/early_stopping/strategies/stability_gated.py
+++ b/ax/early_stopping/strategies/stability_gated.py
@@ -14,6 +14,7 @@ from typing import cast
 
 import numpy as np
 import pandas as pd
+from ax.core.data import MAP_KEY
 from ax.core.experiment import Experiment
 from ax.early_stopping.strategies.base import BaseEarlyStoppingStrategy
 from ax.exceptions.core import UnsupportedError, UserInputError
@@ -22,6 +23,9 @@ from ax.utils.common.logger import get_logger
 from pyre_extensions import override as overrides
 
 logger: Logger = get_logger(__name__)
+
+_BASELINE_REFERENCE_TRIAL_INDEX = -1
+_BASELINE_REFERENCE_ARM_NAME = "sges_baseline_reference"
 
 
 @dataclass(frozen=True)
@@ -192,6 +196,69 @@ class StabilityGatedEarlyStoppingStrategy(BaseEarlyStoppingStrategy):
         self.top_k_fraction = top_k_fraction
         self.min_top_k = min_top_k
         self.recent_best_lookback = recent_best_lookback
+        self._baseline_reference_curve: list[tuple[float, float]] | None = None
+
+    def set_baseline_reference_curve(
+        self, curve: list[tuple[float, float]] | None
+    ) -> None:
+        """Set the baseline progression and mean values for single-trial decisions."""
+        self._baseline_reference_curve = curve
+
+    def is_baseline_reference_curve_needed(self, experiment: Experiment) -> bool:
+        """Return whether attached data has one candidate and no cached reference."""
+        if self._baseline_reference_curve is not None:
+            return False
+
+        metric_signature, _ = self._default_objective_and_direction(
+            experiment=experiment
+        )
+        data = experiment.lookup_data()
+        if data.df.empty:
+            return False
+        metric_rows = data.full_df[data.full_df["metric_signature"] == metric_signature]
+        return self._has_single_candidate_curve(metric_rows)
+
+    @staticmethod
+    def _has_single_candidate_curve(df: pd.DataFrame) -> bool:
+        return df["trial_index"].nunique() == 1
+
+    @overrides
+    def _augment_early_stopping_data(
+        self, df: pd.DataFrame, metric_signatures: list[str]
+    ) -> pd.DataFrame:
+        """Inject baseline as a pseudo-trial when no peer candidate curve exists."""
+        if (
+            self._baseline_reference_curve is None
+            or not metric_signatures
+            or not self._has_single_candidate_curve(df)
+        ):
+            return df
+
+        metric_signature = metric_signatures[0]
+        metric_rows = df[df["metric_signature"] == metric_signature]
+        if metric_rows.empty:
+            return df
+
+        baseline_df = (
+            pd.DataFrame(
+                self._baseline_reference_curve,
+                columns=[MAP_KEY, "mean"],
+            )
+            .dropna()
+            .drop_duplicates(subset=MAP_KEY, keep="last")
+            .sort_values(MAP_KEY)
+        )
+        if len(baseline_df) < 2:
+            return df
+
+        reference_df = baseline_df.assign(
+            arm_name=_BASELINE_REFERENCE_ARM_NAME,
+            metric_name=metric_rows["metric_name"].iloc[0],
+            metric_signature=metric_signature,
+            sem=np.nan,
+            trial_index=_BASELINE_REFERENCE_TRIAL_INDEX,
+        )
+        return pd.concat([df, reference_df], ignore_index=True)
 
     @overrides
     def _is_harmful(

--- a/ax/early_stopping/tests/test_strategies.py
+++ b/ax/early_stopping/tests/test_strategies.py
@@ -1797,6 +1797,104 @@ class TestStabilityGatedEarlyStoppingStrategy(TestCase):
         self.assertEqual(set(should_stop), {1})
         self.assertIn("SGES count", none_throws(should_stop[1]))
 
+    def test_stability_gated_compares_single_trial_to_baseline_curve(self) -> None:
+        experiment, metric_signature = self._get_experiment_with_sges_data(
+            {
+                0: [
+                    (1e9, 0.1010),
+                    (2e9, 0.1011),
+                    (3e9, 0.1010),
+                    (4e9, 0.1011),
+                    (5e9, 0.1010),
+                ],
+            }
+        )
+        strategy = StabilityGatedEarlyStoppingStrategy(
+            metric_signatures=[metric_signature],
+            min_progression=1e9,
+            min_curves=2,
+            normalize_progressions=False,
+            check_interval=1e9,
+            window_size=2,
+            variance_threshold=1e-5,
+            gap_threshold=4e-4,
+            stability_count=2,
+            top_k_fraction=0.0,
+            min_top_k=1,
+            recent_best_lookback=0,
+        )
+
+        self.assertEqual(
+            strategy.should_stop_trials_early(trial_indices={0}, experiment=experiment),
+            {},
+        )
+        self.assertTrue(strategy.is_baseline_reference_curve_needed(experiment))
+
+        strategy.set_baseline_reference_curve(
+            [
+                (0.5e9, 0.10005),
+                (2.5e9, 0.09985),
+                (4.5e9, 0.09965),
+                (5.5e9, 0.09955),
+            ]
+        )
+        self.assertFalse(strategy.is_baseline_reference_curve_needed(experiment))
+        should_stop = strategy.should_stop_trials_early(
+            trial_indices={0}, experiment=experiment
+        )
+
+        self.assertEqual(set(should_stop), {0})
+        self.assertIn("leader_trial=-1", none_throws(should_stop[0]))
+
+    def test_stability_gated_preserves_baseline_sampling_and_unknown_sem(self) -> None:
+        experiment, metric_signature = self._get_experiment_with_sges_data(
+            {
+                0: [
+                    (2.0, 0.1010),
+                    (5.0, 0.1011),
+                    (8.0, 0.1010),
+                ],
+            }
+        )
+        strategy = StabilityGatedEarlyStoppingStrategy(
+            metric_signatures=[metric_signature],
+            normalize_progressions=False,
+        )
+        strategy.set_baseline_reference_curve(
+            [
+                (float(progression), 0.100 - progression / 1000)
+                for progression in range(11)
+            ]
+        )
+
+        data = none_throws(
+            strategy._lookup_and_validate_data(
+                experiment=experiment,
+                metric_signatures=[metric_signature],
+            )
+        )
+        baseline_rows = data.full_df[data.full_df["trial_index"] == -1]
+
+        self.assertEqual(baseline_rows[MAP_KEY].tolist(), list(range(11)))
+        self.assertEqual(
+            baseline_rows["mean"].tolist(),
+            [0.100 - progression / 1000 for progression in range(11)],
+        )
+        self.assertTrue(baseline_rows["sem"].isna().all())
+
+    def test_stability_gated_does_not_need_baseline_with_peer_curve(self) -> None:
+        experiment, metric_signature = self._get_experiment_with_sges_data(
+            {
+                0: [(1.0, 0.1), (2.0, 0.09)],
+                1: [(1.0, 0.11), (2.0, 0.10)],
+            }
+        )
+        strategy = StabilityGatedEarlyStoppingStrategy(
+            metric_signatures=[metric_signature]
+        )
+
+        self.assertFalse(strategy.is_baseline_reference_curve_needed(experiment))
+
     def test_stability_gated_does_not_stop_volatile_trial(self) -> None:
         experiment, metric_signature = self._get_experiment_with_sges_data(
             {


### PR DESCRIPTION
Summary:
Stability-gated early stopping requires at least two comparable curves. Add an explicit baseline-reference hook so integrations can provide a comparison curve when an experiment has one candidate.

Inject the cleaned raw baseline as a pseudo-trial before progression normalization. Ax already aligns curves sampled at different progressions and SGES interpolates them at decision checkpoints, so no integration-specific resampling is needed. Preserve unknown baseline uncertainty as NaN. Existing multi-candidate behavior remains unchanged.

Expose a reference-needed query based on the same attached-data condition used for injection. It returns true only when the selected metric has exactly one candidate curve and no reference is cached, allowing integrations to avoid unused and repeated baseline fetches.

Context:
A one-candidate experiment has no peer curve, so SGES cannot satisfy its comparison requirements even when GAIN has a completed baseline. The reference hook supplies only the missing comparator. Restricting injection and fetching to exactly one attached candidate curve avoids changing leader selection, top-k protection, and inferred stability thresholds for existing multi-candidate experiments.

Reviewed By: saitcakmak

Differential Revision: D114376941


