### PR TITLE
Remove Pyre mode headers (1/3)

### DIFF
--- a/ax/adapter/transforms/tests/test_bilog_y.py
+++ b/ax/adapter/transforms/tests/test_bilog_y.py
@@ -4,7 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-strict
 
 from __future__ import annotations
 

--- a/ax/core/data_utils.py
+++ b/ax/core/data_utils.py
@@ -4,8 +4,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# pyre-strict
-
 
 """
 Utilities for working with data for an Ax experiment.


### PR DESCRIPTION
Summary: Remove standalone `# pyre-strict` and `# pyre-unsafe` mode headers from migrated Python files. Pyrefly runs in one consistent mode, and other Pyre directives are left untouched.

Differential Revision: D115746276


