### PR TITLE
Mock BoTorch optimization in p-feasible online test

### DIFF
--- a/ax/analysis/plotly/tests/test_p_feasible.py
+++ b/ax/analysis/plotly/tests/test_p_feasible.py
@@ -215,6 +215,7 @@ class TestPFeasiblePlot(TestCase):
                             generation_strategy=generation_strategy,
                         )
 
+    @mock_botorch_optimize
     def test_online(self) -> None:
         for experiment in get_online_experiments():
             # Skip if no outcome constraints


### PR DESCRIPTION
Summary:
Apply `mock_botorch_optimize` to `test_online` so the online p-feasible analysis cases avoid expensive BoTorch fitting and acquisition optimization. This reduces warm test runtime from 68.49 seconds to about 25 seconds.

___

Differential Revision: D116466152


