### PR TITLE
Propagate generator kwargs to transfer-learning fallback (#5277)

### DIFF
--- a/ax/adapter/transfer_learning/adapter.py
+++ b/ax/adapter/transfer_learning/adapter.py
@@ -788,8 +788,10 @@ def transfer_learning_generator_specs_constructor(
             model's input constructor.
         fit_tracking_metrics: Whether to fit the generator on tracking metrics. Passed
             to the `TransferLearningAdapter`.
-        additional_generator_kwargs: Additional kwargs to be passed
-            to the BoTorchGenerator
+        additional_generator_kwargs: Additional kwargs to be passed to each
+            BoTorchGenerator. When model selection is enabled, these kwargs must be
+            compatible with both the transfer learning model and the single-task
+            fallback.
 
     Returns:
         A tuple containing BOTL generator specs in case model selection is not enabled,
@@ -839,7 +841,10 @@ def transfer_learning_generator_specs_constructor(
     ]
     if use_model_selection:
         botl_specs.append(
-            GeneratorSpec(generator_enum=Generators.BOTORCH_MODULAR),
+            GeneratorSpec(
+                generator_enum=Generators.BOTORCH_MODULAR,
+                generator_kwargs=additional_generator_kwargs,
+            ),
         )
         best_model_selector = SingleDiagnosticBestModelSelector(
             diagnostic="Rank correlation",

--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -384,9 +384,9 @@ def _prepare_plot(
 
     fig = go.Figure(
         data=go.Contour(
-            z=z_values,
-            x=z_grid.columns.values,
-            y=z_grid.index.values,
+            z=z_values.tolist(),
+            x=z_grid.columns.tolist(),
+            y=z_grid.index.tolist(),
             colorscale=METRIC_CONTINUOUS_COLOR_SCALE,
             showscale=True,
             colorbar={


### PR DESCRIPTION
Summary:

Pass `additional_generator_kwargs` to the single-task fallback so shared acquisition behavior such as BONSAI pruning applies regardless of model selection. Document that the kwargs must be compatible with both generators and add constructor coverage.

Differential Revision: D116468995


