### PR TITLE
Preserve numeric contour arrays through Plotly serialization

### DIFF
--- a/ax/analysis/plotly/surface/contour.py
+++ b/ax/analysis/plotly/surface/contour.py
@@ -384,9 +384,9 @@ def _prepare_plot(
 
     fig = go.Figure(
         data=go.Contour(
-            z=z_values,
-            x=z_grid.columns.values,
-            y=z_grid.index.values,
+            z=z_values.tolist(),
+            x=z_grid.columns.tolist(),
+            y=z_grid.index.tolist(),
             colorscale=METRIC_CONTINUOUS_COLOR_SCALE,
             showscale=True,
             colorbar={


### PR DESCRIPTION
Summary: Convert the contour trace `x`, `y`, and `z` values to plain Python lists before Plotly serialization. This prevents Plotly 6 from preserving NumPy-backed values as base64 typed-array dictionaries when `PlotlyAnalysisCard.get_figure()` reconstructs the figure.

Differential Revision: D116474354


