### PR TITLE
Remove unused type error suppressions - ax

### DIFF
--- a/ax/adapter/base.py
+++ b/ax/adapter/base.py
@@ -89,7 +89,6 @@ class Adapter:
     specification.
     """
 
-    # pyre-ignore[13]: Initialized in _set_and_filter_training_data, called
     # from __init__. Pyre can't trace through method calls.
     _training_data: ExperimentData
 

--- a/ax/adapter/tests/test_cross_validation.py
+++ b/ax/adapter/tests/test_cross_validation.py
@@ -563,7 +563,6 @@ class CrossValidationTest(TestCase):
 
         # Test conditions that should prevent efficient LOO CV from being used
         # Each tuple: (kwargs_override, adapter_override, description)
-        # pyre-ignore[9]: Type is correct for cross_validate kwargs
         conditions_preventing_efficient_loo: list[
             tuple[dict[str, object], TorchAdapter | None, str]
         ] = [
@@ -1044,7 +1043,6 @@ def _create_adapter_with_all_in_design_points() -> TorchAdapter:
     Returns:
         A TorchAdapter with all points in-design.
     """
-    # pyre-ignore [9]: Pyre is too picky with union types.
     parameterizations: list[TParameterization] = [
         {"x": x} for x in [1.0, 2.0, 3.0, 4.0]
     ]

--- a/ax/adapter/tests/test_torch_moo_adapter.py
+++ b/ax/adapter/tests/test_torch_moo_adapter.py
@@ -333,7 +333,6 @@ class MultiObjectiveTorchAdapterTest(TestCase):
             )
             for trial in exp.trials.values():
                 trial.mark_running(no_runner_required=True).mark_completed()
-            # pyre-fixme[16]: Optional type has no attribute `metrics`.
             metrics_dict = exp.metrics
             # Objective thresholds and synthetic observations chosen to have closed-form
             # hypervolumes to test.

--- a/ax/adapter/transfer_learning/tests/test_utils_torch.py
+++ b/ax/adapter/transfer_learning/tests/test_utils_torch.py
@@ -99,7 +99,7 @@ class TestUtilsTorch(TestCase):
         mapped_names = get_mapped_parameter_names(
             self.auxsrc4,
             target_search_space=self.target_ss,
-            transforms={  # pyre-ignore[6]
+            transforms={
                 "OneHot": OneHot(search_space=joint_ss),
                 "RemoveFixed": RemoveFixed(search_space=joint_ss),
             },

--- a/ax/adapter/transfer_learning/utils.py
+++ b/ax/adapter/transfer_learning/utils.py
@@ -166,9 +166,7 @@ def merge_parameters(
             target_value=choice_param.target_value,
             sort_values=choice_param.sort_values,
             dependents=merge_dependents(
-                # pyre-ignore[6]: p1/p2 are FixedParameter | ChoiceParameter here.
                 p1=p1,
-                # pyre-ignore[6]: p1/p2 are FixedParameter | ChoiceParameter here.
                 p2=p2,
                 reverse_param_config=reverse_param_config,
             ),

--- a/ax/adapter/transforms/power_transform_y.py
+++ b/ax/adapter/transforms/power_transform_y.py
@@ -348,7 +348,6 @@ def _compute_inverse_bounds(
     inv_bounds = defaultdict()
     for k, pt in power_transforms.items():
         bounds = [-np.inf, np.inf]
-        # pyre-ignore[16]: sklearn's PowerTransformer lacks type stubs for
         # _scaler (internal attr) and lambdas_ (set during fit).
         mu, sigma = pt._scaler.mean_.item(), pt._scaler.scale_.item()
         lambda_ = pt.lambdas_.item()  # pyre-ignore[16]

--- a/ax/adapter/transforms/tests/test_power_y_transform.py
+++ b/ax/adapter/transforms/tests/test_power_y_transform.py
@@ -99,7 +99,6 @@ class PowerTransformYTest(TestCase):
         Ys = {"m2": [0.9, 0.4, 0.8]}
         pt = _compute_power_transforms(Ys)["m2"]
         # lambda < 0: im(f) = (-inf, -1/lambda) without standardization
-        # pyre-fixme[16]: `PowerTransformer` has no attribute `lambdas_`.
         pt.lambdas_.fill(-2.5)
         bounds = _compute_inverse_bounds({"m2": pt})["m2"]
         self.assertEqual(bounds[0], -np.inf)

--- a/ax/adapter/transforms/tests/test_relativize_transform.py
+++ b/ax/adapter/transforms/tests/test_relativize_transform.py
@@ -563,7 +563,6 @@ class RelativizeDataOptConfigTest(TestCase):
             )
             self.assertEqual(new_config.objective, optimization_config.objective)
             self.assertEqual(
-                # pyre-fixme[16]: `OptimizationConfig` has no attribute
                 #  `objective_thresholds`.
                 new_config.objective_thresholds[0].bound,
                 optimization_config.objective_thresholds[0].bound,

--- a/ax/adapter/transforms/tests/test_transform_to_new_sq.py
+++ b/ax/adapter/transforms/tests/test_transform_to_new_sq.py
@@ -36,7 +36,6 @@ from pyre_extensions import assert_is_instance
 
 
 class TransformToNewSQTest(RelativizeDataTest):
-    # pyre-ignore [15]: `relativize_classes` overrides attribute
     # defined in `RelativizeDataTest` inconsistently. Type `List
     # [Type[TransformToNewSQ]]` is not a subtype of the
     # overridden attribute `List[Type[Transform]]`

--- a/ax/analysis/healthcheck/regression_analysis.py
+++ b/ax/analysis/healthcheck/regression_analysis.py
@@ -47,7 +47,6 @@ class RegressionAnalysis(Analysis):
         """
         self.prob_threshold = prob_threshold
 
-    # pyrefly: ignore [bad-override]
     @override
     # pyrefly: ignore [bad-override]
     def compute(

--- a/ax/analysis/healthcheck/tests/test_metric_fetching_errors.py
+++ b/ax/analysis/healthcheck/tests/test_metric_fetching_errors.py
@@ -246,7 +246,6 @@ class TestMetricFetchingErrors(TestCase):
             options=OrchestratorOptions(),
         )
         orchestrator.poll_and_process_results()
-        # pyrefly: ignore [bad-instantiation]
         self.assertEqual(len(exp._metric_fetching_errors), 2)
         # WHEN we compute MetricFetchingErrorsAnalysis
         # pyrefly: ignore [bad-instantiation]
@@ -274,7 +273,6 @@ class TestMetricFetchingErrors(TestCase):
         orchestrator.poll_and_process_results()
         original_ts = exp._metric_fetching_errors[(0, "test_metric")]["timestamp"]
         exp.trials[0].mark_running(no_runner_required=True, unsafe=True)
-        # pyrefly: ignore [bad-instantiation]
         orchestrator.poll_and_process_results()
 
         self.assertEqual(len(exp._metric_fetching_errors), 1)
@@ -342,7 +340,6 @@ class TestMetricFetchingErrors(TestCase):
         for case in cases:
             with self.subTest(case=case["label"]):
                 exp = get_branin_experiment(**case["exp_kwargs"])
-                # pyrefly: ignore [bad-instantiation]
                 for metric_name in case["error_metrics"]:
                     exp._metric_fetching_errors[(0, metric_name)] = (
                         self._make_metric_fetching_error(0, metric_name)

--- a/ax/analysis/healthcheck/tests/test_transfer_learning_analysis.py
+++ b/ax/analysis/healthcheck/tests/test_transfer_learning_analysis.py
@@ -63,7 +63,6 @@ class TestTransferLearningAnalysis(TestCase):
 
     @patch(_MOCK_TARGET, return_value={})
     def test_no_candidates_returns_pass(self, mock_identify: object) -> None:
-        # pyrefly: ignore [bad-instantiation]
         experiment = _make_experiment(["x1", "x2"], experiment_type="my_type")
         # pyrefly: ignore [bad-instantiation]
         analysis = TransferLearningAnalysis()
@@ -80,7 +79,6 @@ class TestTransferLearningAnalysis(TestCase):
         mock_identify.return_value = {  # pyre-ignore[16]
             "source_exp": TransferLearningMetadata(
                 overlap_parameters=["x1", "x2", "x3", "x4"],
-                # pyrefly: ignore [bad-instantiation]
             ),
         }
         # pyrefly: ignore [bad-instantiation]
@@ -112,7 +110,6 @@ class TestTransferLearningAnalysis(TestCase):
                 overlap_parameters=["x1", "x2", "x3"],
             ),
             "exp_low": TransferLearningMetadata(
-                # pyrefly: ignore [bad-instantiation]
                 overlap_parameters=["x1"],
             ),
         }
@@ -139,7 +136,6 @@ class TestTransferLearningAnalysis(TestCase):
     def test_percentage_calculation(self, mock_identify: object) -> None:
         experiment = _make_experiment(["x1", "x2", "x3"], experiment_type="my_type")
         mock_identify.return_value = {  # pyre-ignore[16]
-            # pyrefly: ignore [bad-instantiation]
             "exp_a": TransferLearningMetadata(
                 overlap_parameters=["x1"],
             ),
@@ -154,7 +150,6 @@ class TestTransferLearningAnalysis(TestCase):
         experiment = _make_experiment(
             ["alpha", "beta", "gamma", "delta"], experiment_type="my_type"
         )
-        # pyrefly: ignore [bad-instantiation]
         mock_identify.return_value = {  # pyre-ignore[16]
             "exp_a": TransferLearningMetadata(
                 overlap_parameters=["gamma", "alpha", "delta"],
@@ -169,7 +164,6 @@ class TestTransferLearningAnalysis(TestCase):
         # pyrefly: ignore [bad-instantiation]
         analysis = TransferLearningAnalysis()
         with self.assertRaises(UserInputError):
-            # pyrefly: ignore [bad-instantiation]
             analysis.compute(experiment=None)
 
     @patch(_MOCK_TARGET, return_value={})
@@ -190,7 +184,6 @@ class TestTransferLearningAnalysis(TestCase):
     ) -> None:
         """When create_diff_paste_callable is provided, a 'Comparison' column
         should be added alongside the existing 'Parameters' column."""
-        # pyrefly: ignore [bad-instantiation]
         experiment = _make_experiment(
             ["x1", "x2", "x3", "x4"], experiment_type="my_type"
         )
@@ -220,7 +213,6 @@ class TestTransferLearningAnalysis(TestCase):
         )
         mock_identify.return_value = {  # pyre-ignore[16]
             "source_exp": TransferLearningMetadata(
-                # pyrefly: ignore [bad-instantiation]
                 overlap_parameters=["gamma", "alpha"],
             ),
         }
@@ -251,7 +243,6 @@ class TestTransferLearningAnalysis(TestCase):
         self.assertIn("source_exp", title)
         self.assertIn("test_experiment", title)
 
-    # pyrefly: ignore [bad-instantiation]
     @patch(_MOCK_TARGET)
     def test_no_callable_has_no_comparison_column(self, mock_identify: object) -> None:
         """Without callable, the 'Parameters' column should be present

--- a/ax/analysis/plotly/surface/tests/test_surface_utils.py
+++ b/ax/analysis/plotly/surface/tests/test_surface_utils.py
@@ -152,7 +152,6 @@ class TestGetFixedValuesForSliceOrContour(TestCase):
                 )
 
             self.assertIsNotNone(result)
-            # pyre-ignore[16]: result is not None per assertion above
             parameterization, trial_index, arm_name = result
             self.assertEqual(parameterization, {"x": 0.3, "y": 0.4})
             self.assertEqual(trial_index, 0)

--- a/ax/analysis/plotly/tests/test_arm_effects.py
+++ b/ax/analysis/plotly/tests/test_arm_effects.py
@@ -183,7 +183,6 @@ class TestArmEffectsPlot(TestCase):
             "additional_arms": [Arm(parameters={"x1": 0, "x2": 0})],
             "label": "f",
         }
-        # pyre-ignore[6]: Unsafe kwargs usage on purpose
         analysis = ArmEffectsPlot(**kwargs)
 
         cards = analysis.compute(

--- a/ax/analysis/plotly/tests/test_scatter.py
+++ b/ax/analysis/plotly/tests/test_scatter.py
@@ -221,7 +221,6 @@ class TestScatterPlot(TestCase):
             "additional_arms": [Arm(parameters={"x1": 0, "x2": 0})],
             "labels": {"foo": "f"},
         }
-        # pyre-ignore[6]: Unsafe kwargs usage on purpose
         analysis = ScatterPlot(**kwargs)
 
         cards = analysis.compute(
@@ -232,7 +231,6 @@ class TestScatterPlot(TestCase):
         adhoc_cards = compute_scatter_adhoc(
             experiment=self.client._experiment,
             generation_strategy=self.client._generation_strategy,
-            # pyre-ignore[6]: Unsafe kwargs usage on purpose
             **kwargs,
         )
 

--- a/ax/benchmark/noise.py
+++ b/ax/benchmark/noise.py
@@ -185,7 +185,6 @@ class GaussianNoise(Noise):
             sem = noise_std_ser
 
         noise = np.random.normal(loc=0, scale=sem)
-        # pyrefly: ignore [bad-return]
         return noise, sem.to_numpy()
 
 

--- a/ax/benchmark/problems/surrogate/lcbench/data.py
+++ b/ax/benchmark/problems/surrogate/lcbench/data.py
@@ -102,9 +102,7 @@ class LCBenchData:
     timestamp_series: pd.Series
 
     runtime_series: pd.Series = field(init=False)
-    # pyre-ignore [16]: Pyre doesn't understand InitVars.
     runtime_fillna: InitVar[bool] = False
-    # pyre-ignore [16]: Pyre doesn't understand InitVars.
     log_scale_parameter_names: InitVar[Collection[str] | None] = None
     dtype: torch.dtype = torch.double
     device: torch.device | None = None

--- a/ax/benchmark/problems/surrogate/lcbench/early_stopping.py
+++ b/ax/benchmark/problems/surrogate/lcbench/early_stopping.py
@@ -216,9 +216,7 @@ class LearningCurveBenchmarkTestFunction(BenchmarkTestFunction):
     metric_surrogate: RegressorProtocol = field(init=False)
     runtime_surrogate: RegressorProtocol = field(init=False)
 
-    # pyre-ignore [16]: Pyre doesn't understand InitVars.
     metric_base_surrogate: InitVar[RegressorProtocol] = get_default_base_regressor()
-    # pyre-ignore [16]: Pyre doesn't understand InitVars.
     runtime_base_surrogate: InitVar[RegressorProtocol] = get_default_base_regressor()
 
     def __post_init__(

--- a/ax/benchmark/tests/problems/surrogate/lcbench/test_early_stopping.py
+++ b/ax/benchmark/tests/problems/surrogate/lcbench/test_early_stopping.py
@@ -89,7 +89,6 @@ class TestEarlyStoppingProblem(TestCase):
         test_function = assert_is_instance(
             problem.test_function, LearningCurveBenchmarkTestFunction
         )
-        # pyre-fixme[8]: Incompatible attribute type -- not a bound method
         test_function.runtime_surrogate.predict = lambda X: np.array(
             [predicted_runtime]
         )

--- a/ax/core/batch_trial.py
+++ b/ax/core/batch_trial.py
@@ -408,7 +408,6 @@ class BatchTrial(BaseTrial):
             if self.experiment.search_space.check_membership(arm.parameters)
         ]
 
-    # pyre-ignore[6]: pyre does not understand @copy_doc with @property.
     @copy_doc(BaseTrial.generator_runs)
     @property
     def generator_runs(self) -> list[GeneratorRun]:

--- a/ax/core/data_utils.py
+++ b/ax/core/data_utils.py
@@ -55,7 +55,6 @@ class DataLoaderConfig:
             in the `MAP_KEY` column for each (arm, metric) is limited by this value.
     """
 
-    # pyre-ignore[16]: Pyre doesn't support dataclass InitVar.
     fit_out_of_design: InitVar[bool | None] = None
     fit_abandoned: bool = False
     fit_only_completed_map_metrics: bool = False

--- a/ax/core/derived_metric.py
+++ b/ax/core/derived_metric.py
@@ -632,7 +632,6 @@ class ExpressionDerivedMetric(DerivedMetric):
         # _symbols are the original (unsanitized) metric names used for
         # looking up values at evaluation time.
         # Cast free_symbols to set[Symbol] since Pyre stubs use Basic
-        # pyre-fixme[16]: Pyre cannot infer that free_symbols contains Symbol
         free_syms = cast(set[Symbol], self._sympy_expr.free_symbols)
         sympy_symbols: list[str] = sorted(s.name for s in free_syms)
         self._symbols: list[str] = [unsanitize_name(s) for s in sympy_symbols]
@@ -661,7 +660,6 @@ class ExpressionDerivedMetric(DerivedMetric):
 
         # Reject undeclared variable names.
         # Cast free_symbols to set[Symbol] since Pyre stubs use Basic
-        # pyre-fixme[16]: Pyre cannot infer that free_symbols contains Symbol
         free_syms = cast(set[Symbol], self._sympy_expr.free_symbols)
         referenced_names = {unsanitize_name(s.name) for s in free_syms}
         input_metric_set = set(self._input_metric_names)

--- a/ax/core/multi_type_experiment.py
+++ b/ax/core/multi_type_experiment.py
@@ -121,7 +121,6 @@ class MultiTypeExperiment(Experiment):
 
     # pyre does not support inferring the type of property setter decorators
     # or the `.fset` attribute on properties.
-    # pyre-fixme[56]: Pyre was not able to infer the type of the decorator.
     @Experiment.optimization_config.setter
     def optimization_config(self, optimization_config: OptimizationConfig) -> None:
         # pyre-fixme[16]: `Optional` has no attribute `fset`.

--- a/ax/core/parameter.py
+++ b/ax/core/parameter.py
@@ -67,7 +67,6 @@ class ParameterType(Enum):
 
 TParameterType = Union[type[int], type[float], type[str], type[bool]]
 
-# pyre-fixme[9]: Pyre collapses individual type[] values into Type[Union[...]].
 PARAMETER_PYTHON_TYPE_MAP: dict[ParameterType, TParameterType] = {
     ParameterType.INT: int,
     ParameterType.FLOAT: float,
@@ -1458,7 +1457,7 @@ class DerivedParameter(Parameter):
                 self._parameter_names_to_weights[parameter_name]
                 * float(
                     parameters[parameter_name]  # pyrefly: ignore [bad-argument-type]
-                )  # pyrefly: ignore [bad-argument-type]
+                )
                 for parameter_name in self._parameter_names_to_weights
             )
         )

--- a/ax/core/runner.py
+++ b/ax/core/runner.py
@@ -282,7 +282,6 @@ class Runner(Base, SerializationMixin, ABC):
     def clone(self) -> Self:
         """Create a copy of this Runner."""
         cls = type(self)
-        # pyre-ignore[45]: Cannot instantiate abstract class `Runner`.
         return cls(
             **cls.deserialize_init_args(args=cls.serialize_init_args(obj=self)),
         )

--- a/ax/core/tests/test_batch_trial.py
+++ b/ax/core/tests/test_batch_trial.py
@@ -575,7 +575,6 @@ class BatchTrialTest(TestCase):
         self.batch.add_generator_run(gr_2)
         gr_2 = self.batch._generator_runs[-1]
         # gr_2 has no candidate metadata; all candidate metadata should come from gr_1
-        # pyrefly: ignore [unsupported-operation]
         cand_metadata_expected = {
             # pyrefly: ignore [unsupported-operation]
             a.name: gr_1.candidate_metadata_by_arm_signature[a.signature]
@@ -603,7 +602,6 @@ class BatchTrialTest(TestCase):
         gr_3._candidate_metadata_by_arm_signature = new_cand_metadata
         self.batch.add_generator_run(gr_3)
         gr_3 = self.batch._generator_runs[-1]
-        # pyrefly: ignore [unsupported-operation]
         cand_metadata_expected.update(
             {
                 # pyrefly: ignore [unsupported-operation]

--- a/ax/core/tests/test_experiment.py
+++ b/ax/core/tests/test_experiment.py
@@ -572,15 +572,11 @@ class ExperimentTest(TestCase):
         with self.assertRaisesRegex(ValueError, "not found on experiment"):
             self.experiment.optimization_config = new_opt_config
 
-    # pyrefly: ignore [missing-attribute]
-
     def test_status_quo_setter(self) -> None:
         # pyrefly: ignore [missing-attribute]
         sq_parameters = self.experiment.status_quo.parameters
 
-        # pyrefly: ignore [missing-attribute]
         # Verify normal update when no trials exist
-        # pyrefly: ignore [missing-attribute]
         sq_parameters["w"] = 3.5
         self.experiment.status_quo = Arm(sq_parameters)
         # pyrefly: ignore [missing-attribute]
@@ -622,12 +618,10 @@ class ExperimentTest(TestCase):
         sq_parameters["w"] = 3.7
         with self.assertRaises(UnsupportedError) as e:
             self.experiment.status_quo = Arm(sq_parameters)
-        # pyrefly: ignore [missing-attribute]
         self.assertIn(
             "Modifications of status_quo are disabled after trials have been created",
             str(e.exception),
         )
-        # pyrefly: ignore [missing-attribute]
 
         # Verify status_quo wasn't changed
         # pyrefly: ignore [missing-attribute]
@@ -1245,7 +1239,6 @@ class ExperimentTest(TestCase):
         _, trial_index = self.experiment.attach_trial(
             parameterizations=[{"w": 5.3, "x": 5, "y": "baz", "z": True, "d": 11.6}],
             arm_names=["arm1"],
-            # pyrefly: ignore [missing-attribute]
             ttl_seconds=3600,
             run_metadata={"test_metadata_field": 1},
         )
@@ -1273,7 +1266,7 @@ class ExperimentTest(TestCase):
         )
         self.assertEqual(exp._metrics_by_class(), {Metric: [m]})
 
-    @patch(  # pyre-ignore[56]: Cannot infer function type
+    @patch(
         # No-op mock just to record calls to `bulk_fetch_experiment_data`.
         f"{BraninMetric.__module__}.BraninMetric.bulk_fetch_experiment_data",
         side_effect=BraninMetric(
@@ -1299,7 +1292,6 @@ class ExperimentTest(TestCase):
             exp.fetch_data()
             # 1. No completed trials => no fetch case.
             mock_bulk_fetch_experiment_data.reset_mock()
-            # pyrefly: ignore [missing-attribute]
             dat = exp.fetch_data()
             mock_bulk_fetch_experiment_data.assert_not_called()
             # Data should be empty since there are no completed trials.
@@ -1369,7 +1361,6 @@ class ExperimentTest(TestCase):
 
         # check that all non-failed trials are copied to new_experiment
         new_experiment = get_branin_experiment()
-        # pyrefly: ignore [missing-attribute]
         # make metric noiseless for exact reproducibility
         _obj_name = none_throws(
             new_experiment.optimization_config
@@ -1382,7 +1373,6 @@ class ExperimentTest(TestCase):
         # name one arm to test name-preserving logic.
         # pyrefly: ignore [missing-attribute]
         old_experiment.trials[0].arm._name = DUMMY_ARM_NAME
-        # pyrefly: ignore [missing-attribute]
         new_experiment.warm_start_from_old_experiment(
             old_experiment=old_experiment,
         )
@@ -1397,7 +1387,6 @@ class ExperimentTest(TestCase):
                 # pyrefly: ignore [missing-attribute]
                 trial.arm.parameters,
                 old_arm.parameters,
-                # pyrefly: ignore [missing-attribute]
             )
             self.assertRegex(
                 trial._properties["source"], "Warm start.*Experiment.*trial"
@@ -1714,11 +1703,9 @@ class ExperimentTest(TestCase):
             tracking_metrics=[
                 Metric(name="metric_a", lower_is_better=False),
                 Metric(name="metric_b", lower_is_better=True),
-                # pyrefly: ignore [missing-attribute]
             ],
         )
         df = experiment.metric_config_summary_df
-        # pyrefly: ignore [missing-attribute]
         # metric_a has positive weight -> maximize
         # metric_b has negative weight -> minimize
         goal_by_name = dict(zip(df["Name"], df["Goal"]))
@@ -2372,7 +2359,6 @@ class ExperimentWithMapDataTest(TestCase):
         # check that all non-failed trials are copied to new_experiment
         new_experiment = get_branin_experiment_with_timestamp_map_metric()
         # make metric noiseless for exact reproducibility
-        # pyrefly: ignore [missing-attribute]
         _obj_name = none_throws(
             new_experiment.optimization_config
         ).objective.metric_names[0]

--- a/ax/core/tests/test_multi_type_experiment.py
+++ b/ax/core/tests/test_multi_type_experiment.py
@@ -236,17 +236,14 @@ class MultiTypeExperimentUtilsTest(TestCase):
 
     def test_filter_trials_by_type(self) -> None:
         trials = self.experiment.trials.values()
-        # pyrefly: ignore [bad-argument-type]
         self.assertEqual(len(trials), 2)
         # pyrefly: ignore [bad-argument-type]
         filtered = filter_trials_by_type(trials, trial_type="type1")
-        # pyrefly: ignore [bad-argument-type]
         self.assertEqual(len(filtered), 1)
         self.assertEqual(filtered[0].trial_type, "type1")
         # pyrefly: ignore [bad-argument-type]
         filtered = filter_trials_by_type(trials, trial_type="type2")
         self.assertEqual(len(filtered), 1)
-        # pyrefly: ignore [bad-argument-type]
         self.assertEqual(filtered[0].trial_type, "type2")
         # pyrefly: ignore [bad-argument-type]
         filtered = filter_trials_by_type(trials, trial_type="invalid")

--- a/ax/core/tests/test_observation.py
+++ b/ax/core/tests/test_observation.py
@@ -777,7 +777,6 @@ class ObservationsTest(TestCase):
             self.assertTrue(
                 np.array_equal(
                     obs.data.means,
-                    # pyre-ignore[6]: numpy stubs type mismatch.
                     assert_is_instance(obs_truth["means"][i], np.ndarray),
                 )
             )

--- a/ax/core/tests/test_optimization_config.py
+++ b/ax/core/tests/test_optimization_config.py
@@ -355,7 +355,6 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
             "`MultiObjectiveOptimizationConfig` requires an objective of type "
             "`MultiObjective` or `ScalarizedObjective`.",
         ):
-            # pyre-ignore[8]: Intentionally testing wrong type for error path.
             config1.objective = self.objective  # Wrong objective type
         # updating constraints is fine.
         config1.outcome_constraints = [self.outcome_constraint]
@@ -381,7 +380,6 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
 
         # objective_thresholds and outcome constraints together.
         config4 = MultiObjectiveOptimizationConfig(
-            # pyrefly: ignore [bad-argument-type]
             objective=self.multi_objective,
             # pyrefly: ignore [bad-argument-type]
             objective_thresholds=self.objective_thresholds,
@@ -394,7 +392,6 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
         self.assertEqual(config4.objective_thresholds, self.objective_thresholds)
 
         # verify relative_objective_thresholds works:
-        # pyrefly: ignore [bad-argument-type]
         config5 = MultiObjectiveOptimizationConfig(
             objective=self.multi_objective,
             # pyrefly: ignore [bad-argument-type]
@@ -408,7 +405,6 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
         with self.assertRaises(UserInputError):
             MultiObjectiveOptimizationConfig(
                 objective=self.multi_objective,
-                # pyre-ignore[6]: Intentionally testing wrong type for error path.
                 objective_thresholds=[self.additional_outcome_constraint],
             )
 
@@ -563,7 +559,6 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
                 bound=100.0,
                 relative=False,
             )
-        # pyrefly: ignore [bad-argument-type]
         config = MultiObjectiveOptimizationConfig(
             objective=self.multi_objective,
             outcome_constraints=[lower_bound_on_m1],
@@ -587,7 +582,6 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
         self.assertEqual(config1.outcome_constraints, cloned1.outcome_constraints)
         cloned1_moo = assert_is_instance(cloned1, MultiObjectiveOptimizationConfig)
         self.assertEqual(config1.objective_thresholds, cloned1_moo.objective_thresholds)
-        # pyrefly: ignore [bad-argument-type]
 
         config2 = MultiObjectiveOptimizationConfig(
             objective=self.multi_objective,
@@ -599,8 +593,6 @@ class MultiObjectiveOptimizationConfigTest(TestCase):
         self.assertEqual(config2.outcome_constraints, cloned2.outcome_constraints)
         cloned2_moo = assert_is_instance(cloned2, MultiObjectiveOptimizationConfig)
         self.assertEqual(config2.objective_thresholds, cloned2_moo.objective_thresholds)
-
-    # pyrefly: ignore [bad-argument-type]
 
     def test_CloneWithArgs(self) -> None:
         config1 = MultiObjectiveOptimizationConfig(

--- a/ax/core/tests/test_search_space.py
+++ b/ax/core/tests/test_search_space.py
@@ -1206,7 +1206,6 @@ class SearchSpaceDigestTest(TestCase):
         for arg in self.kwargs:
             if arg in {"feature_names", "bounds"}:
                 continue
-            # pyrefly: ignore [bad-argument-type]
             ssd = SearchSpaceDigest(
                 # pyrefly: ignore [bad-argument-type]
                 **{k: v for k, v in self.kwargs.items() if k != arg}
@@ -1449,7 +1448,6 @@ class HierarchicalSearchSpaceTest(TestCase):
         self.assertEqual(  # Check one subtree.
             hss_1_obs_feats_1_cast.parameters,
             ObservationFeatures.from_arm(arm=self.hss_1_arm_1_cast).parameters,
-            # pyrefly: ignore [missing-attribute]
         )
         self.assertEqual(  # Check one subtree.
             # pyrefly: ignore [missing-attribute]
@@ -1498,9 +1496,7 @@ class HierarchicalSearchSpaceTest(TestCase):
             )
             self.assertEqual(  # Cast-flatten roundtrip.
                 hss_1_obs_feats_1.parameters,
-                # pyrefly: ignore [missing-attribute]
                 hss_1_obs_feats_1_flattened.parameters,
-                # pyrefly: ignore [missing-attribute]
             )
             self.assertEqual(  # Check that both cast and flattened have full params.
                 # pyrefly: ignore [missing-attribute]

--- a/ax/core/tests/test_trial.py
+++ b/ax/core/tests/test_trial.py
@@ -102,7 +102,6 @@ class TrialTest(TestCase):
         self.assertEqual(self.trial.generation_method_str, MANUAL_GENERATION_METHOD_STR)
 
         # Test empty arms
-        # pyrefly: ignore [missing-attribute]
         t = self.experiment.new_trial()
         with self.assertRaises(AttributeError):
             # pyrefly: ignore [missing-attribute]
@@ -146,14 +145,12 @@ class TrialTest(TestCase):
 
     def test_add_trial_same_arm(self) -> None:
         # Check that adding new arm w/out name works correctly.
-        # pyrefly: ignore [missing-attribute]
         new_trial1 = self.experiment.new_trial(
             generator_run=GeneratorRun(arms=[self.arm.clone(clear_name=True)])
         )
         # pyrefly: ignore [missing-attribute]
         self.assertEqual(new_trial1.arm.name, self.trial.arm.name)
         self.assertFalse(new_trial1.arm is self.trial.arm)
-        # pyrefly: ignore [missing-attribute]
         # Check that adding new arm with name works correctly.
         new_trial2 = self.experiment.new_trial(
             generator_run=GeneratorRun(arms=[self.arm.clone()])
@@ -250,10 +247,8 @@ class TrialTest(TestCase):
             else:
                 status_transition_sequence = (TrialStatus.RUNNING, terminal_status)
 
-            # pyrefly: ignore [unsupported-operation]
             for status in status_transition_sequence:
                 kwargs = {}
-                # pyrefly: ignore [unsupported-operation]
                 if status == TrialStatus.RUNNING:
                     kwargs["no_runner_required"] = True
                 if status == TrialStatus.ABANDONED:
@@ -309,7 +304,6 @@ class TrialTest(TestCase):
         # test bad new status
         self.trial.mark_running(no_runner_required=True)
         with self.assertRaisesRegex(ValueError, "New status of a stopped trial must"):
-            # pyrefly: ignore [bad-override]
             self.trial.stop(new_status=TrialStatus.CANDIDATE)
 
         # dummy runner for testing stopping functionality
@@ -383,7 +377,6 @@ class TrialTest(TestCase):
     def test_update_stop_metadata(self) -> None:
         self.assertEqual(len(self.trial.stop_metadata), 1)
         old_stop_metadata = deepcopy(self.trial.stop_metadata)
-        # pyrefly: ignore [missing-attribute]
         self.trial.update_stop_metadata({"something": "new"})
         self.assertEqual(
             self.trial.stop_metadata, {**old_stop_metadata, "something": "new"}

--- a/ax/core/tests/test_utils.py
+++ b/ax/core/tests/test_utils.py
@@ -85,7 +85,6 @@ class UtilsTest(TestCase):
         )
         self.hss_trial = self.hss_exp.new_trial(self.hss_gr)
         self.hss_cand_metadata = self.hss_trial._get_candidate_metadata(
-            # pyrefly: ignore [missing-attribute]
             arm_name=self.hss_arm.name
         )
         # pyrefly: ignore [missing-attribute]
@@ -130,7 +129,6 @@ class UtilsTest(TestCase):
         # With data for metric "m2", that metric should no longer have pending
         # observation features.
         with patch.object(
-            # pyrefly: ignore [missing-attribute]
             self.experiment,
             "lookup_data",
             return_value=raw_evaluations_to_data(
@@ -152,7 +150,6 @@ class UtilsTest(TestCase):
         )
         # A completed trial with data for some metrics should be pending only
         # for metrics without data.
-        # pyrefly: ignore [missing-attribute]
         with patch.object(
             self.experiment,
             "lookup_data",
@@ -177,7 +174,6 @@ class UtilsTest(TestCase):
             {"tracking": [self.obs_feat], "m2": [self.obs_feat], "m1": [self.obs_feat]},
         )
         # Abandoned trials with data for some metrics should only be pending
-        # pyrefly: ignore [missing-attribute]
         # for metrics without data.
         with patch.object(
             self.experiment,
@@ -386,7 +382,6 @@ class UtilsTest(TestCase):
 
     def test_get_pending_observation_features_multi_trial(self) -> None:
         # With data for metric "m2", that metric should no longer have pending
-        # pyrefly: ignore [missing-attribute]
         # observation features.
         self.trial.mark_running(no_runner_required=True)
         with patch.object(
@@ -398,19 +393,16 @@ class UtilsTest(TestCase):
                 trial_index=self.trial.index,
                 metric_name_to_signature={"m2": "m2"},
             ),
-            # pyrefly: ignore [bad-argument-type]
         ):
             self.assertEqual(
                 get_pending_observation_features(self.experiment),
                 {"tracking": [self.obs_feat], "m2": [], "m1": [self.obs_feat]},
             )
-        # pyrefly: ignore [missing-attribute]
 
         # Make sure that trial_index is set correctly
         # pyrefly: ignore [bad-argument-type]
         other_obs_feat = ObservationFeatures.from_arm(arm=self.trial.arm, trial_index=1)
         other_trial = self.experiment.new_trial(GeneratorRun([self.arm]))
-        # pyrefly: ignore [missing-attribute]
         other_trial.mark_running(no_runner_required=True)
 
         trial_0_data = raw_evaluations_to_data(
@@ -490,7 +482,6 @@ class UtilsTest(TestCase):
                     none_throws(pf.metadata),
                     none_throws(self.hss_gr.candidate_metadata_by_arm_signature)[
                         self.hss_arm.signature
-                        # pyrefly: ignore [missing-attribute]
                     ],
                 )
 
@@ -528,7 +519,6 @@ class UtilsTest(TestCase):
         # Status quo of this experiment is out-of-design, so it shouldn't be
         # among the pending points.
         self.assertEqual(
-            # pyrefly: ignore [bad-argument-type]
             get_pending_observation_features(self.experiment_2),
             {
                 "tracking": [self.obs_feat],

--- a/ax/core/types.py
+++ b/ax/core/types.py
@@ -30,9 +30,7 @@ TModelPredict = tuple[TModelMean, TModelCov]
 # ( { metric -> mean }, { metric -> { other_metric -> covariance } } ).
 TModelPredictArm = tuple[dict[str, float], dict[str, dict[str, float]] | None]
 
-# pyre-fixme[24]: Generic type `np.floating` expects 1 type parameter, use
 #  `np.floating[Any]` to avoid runtime subscripting errors with isinstance().
-# pyre-fixme[24]: Generic type `np.integer` expects 1 type parameter.
 FloatLike = int | float | np.floating | np.integer
 SingleMetricData = FloatLike | tuple[FloatLike, FloatLike | None]
 # 1-arm `Trial` evaluation data: {metric_name -> (mean, standard error)}}.

--- a/ax/early_stopping/utils.py
+++ b/ax/early_stopping/utils.py
@@ -122,7 +122,6 @@ def _interval_boundary(
         The interval boundary that this progression is at or past (rounded down).
     """
     interval_num = (progression - min_progression) // interval
-    # pyre-ignore[58]: Numpy handles float + ndarray correctly at runtime
     return min_progression + interval_num * interval
 
 

--- a/ax/generation_strategy/tests/test_best_model_selector.py
+++ b/ax/generation_strategy/tests/test_best_model_selector.py
@@ -39,7 +39,6 @@ class TestBestModelSelector(TestCase):
     def test_user_input_error(self) -> None:
         with self.assertRaisesRegex(UserInputError, "ReductionCriterion"):
             SingleDiagnosticBestModelSelector(
-                # pyrefly: ignore [bad-argument-type]
                 "Fisher exact test p",
                 # pyrefly: ignore [bad-argument-type]
                 metric_aggregation=min,

--- a/ax/generation_strategy/tests/test_dispatch_utils.py
+++ b/ax/generation_strategy/tests/test_dispatch_utils.py
@@ -487,7 +487,6 @@ class TestDispatchUtils(TestCase):
 
         with self.subTest("num_initialization_trials"):
             ss = get_large_factorial_search_space()
-            # pyrefly: ignore [missing-attribute]
             for _, param in ss.parameters.items():
                 # pyrefly: ignore [missing-attribute]
                 param._is_ordered = True
@@ -579,7 +578,6 @@ class TestDispatchUtils(TestCase):
             #  Step.__new__` actually returns a `GenerationNode`.
             none_throws(bo_step.generator_spec.generator_kwargs)["transforms"],
             [LogY],
-            # pyrefly: ignore [missing-attribute]
         )
         self.assertEqual(
             # pyrefly: ignore [missing-attribute]
@@ -588,7 +586,6 @@ class TestDispatchUtils(TestCase):
         )
         # With derelativize_with_raw_status_quo.
         bo_step = _make_botorch_step(
-            # pyrefly: ignore [missing-attribute]
             generator_kwargs=generator_kwargs,
             derelativize_with_raw_status_quo=True,
         )
@@ -745,10 +742,8 @@ class TestDispatchUtils(TestCase):
         winsorized = choose_generation_strategy_legacy(
             search_space=get_branin_search_space(),
             winsorization_config=WinsorizationConfig(upper_quantile_margin=2),
-            # pyrefly: ignore [bad-argument-type]
         )
         tc = none_throws(winsorized._nodes[1].generator_specs[0].generator_kwargs).get(
-            # pyrefly: ignore [unsupported-operation]
             "transform_configs"
         )
         # pyrefly: ignore [bad-argument-type]
@@ -769,17 +764,14 @@ class TestDispatchUtils(TestCase):
         winsorized = choose_generation_strategy_legacy(
             search_space=get_branin_search_space(),
             derelativize_with_raw_status_quo=True,
-            # pyrefly: ignore [bad-argument-type]
         )
         tc = none_throws(winsorized._nodes[1].generator_specs[0].generator_kwargs).get(
             "transform_configs"
-            # pyrefly: ignore [unsupported-operation]
         )
         self.assertIn(
             "Winsorize",
             # pyrefly: ignore [bad-argument-type]
             tc,
-            # pyrefly: ignore [bad-argument-type]
         )
         self.assertDictEqual(
             # pyrefly: ignore [unsupported-operation]

--- a/ax/generation_strategy/tests/test_generation_node.py
+++ b/ax/generation_strategy/tests/test_generation_node.py
@@ -468,7 +468,6 @@ class TestGenerationStep(TestCase):
             generator_kwargs=self.generator_kwargs,
         )
         self.generator_spec = GeneratorSpec(
-            # pyre-fixme[16]: Currently, Pyre doesn't recognize that `Generation
             #  Step.__new__` actually returns a `GenerationNode`.
             generator_enum=self.sobol_generation_step.generator_spec.generator_enum,
             generator_kwargs=self.generator_kwargs,
@@ -476,7 +475,6 @@ class TestGenerationStep(TestCase):
 
     def test_init(self) -> None:
         self.assertEqual(
-            # pyre-fixme[16]: Currently, Pyre doesn't recognize that `Generation
             #  Step.__new__` actually returns a `GenerationNode`.
             self.sobol_generation_step.generator_specs,
             [self.generator_spec],
@@ -488,7 +486,6 @@ class TestGenerationStep(TestCase):
             "Sobol",
         )
         self.assertEqual(
-            # pyre-fixme[16]: Currently, Pyre doesn't recognize that `Generation
             #  Step.__new__` actually returns a `GenerationNode`.
             self.sobol_generation_step.transition_criteria,
             [
@@ -553,11 +550,9 @@ class TestGenerationStep(TestCase):
 
     def test_properties(self) -> None:
         step = self.sobol_generation_step
-        # pyre-fixme[16]: Currently, Pyre doesn't recognize that `Generation
         #  Step.__new__` actually returns a `GenerationNode`.
         spec = step.generator_spec
         self.assertEqual(spec, self.generator_spec)
-        # pyre-fixme[16]: Currently, Pyre doesn't recognize that `Generation
         #  Step.__new__` actually returns a `GenerationNode`.
         self.assertEqual(step._unique_id, "GenerationStep_-1_Sobol")
         # Make sure that generator_kwargs and generator_gen_kwargs are synchronized

--- a/ax/generation_strategy/tests/test_generation_strategy.py
+++ b/ax/generation_strategy/tests/test_generation_strategy.py
@@ -723,7 +723,6 @@ class TestGenerationStrategy(TestCase):
             sobol_generation_strategy.gen_single_trial(exp, n=1)
             self.assertEqual(len(sobol_generation_strategy._generator_runs), i)
 
-    # pyre-fixme[56]: Pyre was not able to infer the type of argument
     # `ax.utils.testing.core_stubs.get_data()` to decorator `unittest.mock.patch`.
     @patch(f"{Experiment.__module__}.Experiment.fetch_data", return_value=get_data())
     def test_factorial_thompson_strategy(self, _: MagicMock) -> None:

--- a/ax/generators/random/uniform.py
+++ b/ax/generators/random/uniform.py
@@ -34,7 +34,6 @@ class UniformGenerator(RandomGenerator):
             init_position=init_position,
             fallback_to_sample_polytope=fallback_to_sample_polytope,
         )
-        # pyrefly: ignore [bad-argument-type]
         self._rs = np.random.RandomState(seed=self.seed)
         if self.init_position > 0:
             # Fast-forward the random state by generating & discarding samples.

--- a/ax/generators/tests/test_botorch_moo_utils.py
+++ b/ax/generators/tests/test_botorch_moo_utils.py
@@ -219,13 +219,13 @@ class BotorchMOOUtilsTest(TestCase):
         weighted_obj = get_weighted_mc_objective(
             objective_weights=objective_weights,
         )
-        # pyrefly: ignore [bad-argument-type, not-callable]
+        # pyrefly: ignore [bad-argument-type]
         self.assertTrue(torch.equal(weighted_obj.weights, torch.tensor([1.0, 1.0])))
         # pyrefly: ignore [not-callable]
         self.assertEqual(weighted_obj.outcomes.tolist(), [1, 3])
 
     # test infer objective thresholds alone
-    @mock.patch(  # pyre-ignore
+    @mock.patch(
         "ax.generators.torch.botorch_moo_utils._check_posterior_type",
         wraps=lambda y: y,
     )

--- a/ax/generators/tests/test_thompson.py
+++ b/ax/generators/tests/test_thompson.py
@@ -105,7 +105,6 @@ class ThompsonSamplerTest(TestCase):
             )
 
     def test_TopTwo_alters_weights_vs_TopOne(self) -> None:
-        # pyrefly: ignore [bad-argument-type]
         np.random.seed(0)
 
         # Compare TTTS results to the vanilla TS
@@ -158,7 +157,6 @@ class ThompsonSamplerTest(TestCase):
         self.assertTrue(full_w2[3] > full_w2[2] > full_w2[1] > full_w2[0])
 
     def test_ThompsonSamplerMinWeight(self) -> None:
-        # pyrefly: ignore [bad-argument-type]
         np.random.seed(0)
         generator = ThompsonSampler(min_weight=0.01)
         generator.fit(

--- a/ax/generators/tests/test_torch_model_utils.py
+++ b/ax/generators/tests/test_torch_model_utils.py
@@ -160,7 +160,6 @@ class SubsetModelTestMultiTask(TestCase):
         # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIsInstance(models[1], SingleTaskGP)
         # check that second model is the second output of m2
-        # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertTrue(torch.equal(models[1].train_targets, m2.train_targets[1]))
 
     def test_nested_model_list_gp(self) -> None:

--- a/ax/generators/tests/test_utils.py
+++ b/ax/generators/tests/test_utils.py
@@ -224,7 +224,6 @@ class UtilsTest(TestCase):
                 n: int,
                 d: int,
                 tunable_feature_indices: npt.NDArray[np.intp],
-                # pyrefly: ignore [bad-specialization]
                 fixed_features: dict[int, float] | None,
                 # pyrefly: ignore [bad-specialization]
             ) -> npt.NDArray[np.floating[Any]]:
@@ -233,9 +232,6 @@ class UtilsTest(TestCase):
                 call_count += 1
                 return result
 
-            # pyrefly: ignore [bad-specialization]
-
-            # pyrefly: ignore [bad-specialization]
             def rounding_func(
                 # pyrefly: ignore [bad-specialization]
                 point: npt.NDArray[np.floating[Any]],

--- a/ax/generators/torch/botorch_modular/acquisition.py
+++ b/ax/generators/torch/botorch_modular/acquisition.py
@@ -134,7 +134,6 @@ def determine_optimizer(
             # the remaining parameters.
             cardinalities = [len(c) for c in discrete_choices.values()]
             max_cardinality = max(cardinalities)
-            # pyrefly: ignore [incompatible-overload-residual]
             total_discrete_choices = reduce(operator.mul, cardinalities)
             if total_discrete_choices > MAX_CHOICES_ENUMERATE:
                 if max_cardinality <= MAX_CARDINALITY_FOR_LOCAL_SEARCH:
@@ -381,7 +380,7 @@ class Acquisition(Base):
         ) and ("pref_model" in botorch_acqf_options or model.num_outputs == 1):
             input_constructor = get_acqf_input_constructor(botorch_acqf_class)
             acqf_inputs = input_constructor(model=model, **botorch_acqf_options)
-            return botorch_acqf_class(**acqf_inputs)  # pyre-ignore [45]
+            return botorch_acqf_class(**acqf_inputs)
 
         objective, posterior_transform = self.get_botorch_objective_and_transform(
             botorch_acqf_class=botorch_acqf_class,
@@ -451,7 +450,7 @@ class Acquisition(Base):
             bounds=self.search_space_digest.bounds,
             **{k: v for k, v in input_constructor_kwargs.items() if v is not None},
         )
-        return botorch_acqf_class(**acqf_inputs)  # pyre-ignore [45]
+        return botorch_acqf_class(**acqf_inputs)
 
     @property
     def botorch_acqf_class(self) -> type[AcquisitionFunction]:

--- a/ax/generators/torch/botorch_modular/surrogate.py
+++ b/ax/generators/torch/botorch_modular/surrogate.py
@@ -216,7 +216,6 @@ def _construct_specified_input_transforms(
     ]
 
     return [
-        # pyre-ignore[45]: Concrete subclasses are passed at runtime.
         transform_class(**single_input_transform_kwargs)
         for transform_class, single_input_transform_kwargs in zip(
             input_transform_classes, input_transform_kwargs
@@ -286,7 +285,6 @@ def _make_botorch_outcome_transform(
     ]
 
     outcome_transforms = [
-        # pyre-ignore[45]: Concrete subclasses are passed at runtime.
         transform_class(**single_outcome_transform_kwargs)
         for transform_class, single_outcome_transform_kwargs in zip(
             outcome_transform_classes, outcome_transform_kwargs
@@ -335,12 +333,10 @@ def _construct_submodules(
             botorch_model_class=botorch_model_class,
             **deepcopy(model_config.covar_module_options),
         )
-        # pyre-ignore[45]: Concrete subclasses are passed at runtime.
         submodules["covar_module"] = covar_class(**covar_module_kwargs)
 
     if (likelihood_class := model_config.likelihood_class) is not None:
         _error_if_arg_not_supported("likelihood")
-        # pyre-ignore[45]: Concrete subclasses are passed at runtime.
         submodules["likelihood"] = likelihood_class(
             **deepcopy(model_config.likelihood_options)
         )
@@ -565,7 +561,6 @@ class Surrogate(Base):
             search_space_digest=search_space_digest,
             surrogate=self,
         )
-        # pyre-ignore[45]: Concrete subclasses are passed at runtime.
         model = botorch_model_class(**formatted_model_inputs)
         if state_dict is not None and (not refit or self.warm_start_refit):
             model.load_state_dict(state_dict)

--- a/ax/generators/torch/randomforest.py
+++ b/ax/generators/torch/randomforest.py
@@ -146,7 +146,6 @@ def _rf_predict(
     f = np.zeros((X.shape[0], len(models)))
     cov = np.zeros((X.shape[0], len(models), len(models)))
     for i, m in enumerate(models):
-        # pyre-fixme[16]: `RandomForestRegressor` has no attribute `estimators_`.
         preds = np.vstack([tree.predict(X.numpy()) for tree in m.estimators_])
         f[:, i] = preds.mean(0)
         cov[:, i, i] = preds.var(0)

--- a/ax/generators/torch/tests/test_acquisition.py
+++ b/ax/generators/torch/tests/test_acquisition.py
@@ -87,7 +87,6 @@ SURROGATE_PATH: str = Surrogate.__module__
 # Used to avoid going through BoTorch `Acquisition.__init__` which
 # requires valid kwargs (correct sizes and lengths of tensors, etc).
 class DummyAcquisitionFunction(AcquisitionFunction):
-    # pyrefly: ignore [bad-override-mutable-attribute]
     X_pending: Tensor | None = None
 
     def __init__(self, eta: float = 1e-3, model: Any = None, **kwargs: Any) -> None:
@@ -104,9 +103,6 @@ class DummyAcquisitionFunction(AcquisitionFunction):
             res = torch.linalg.norm(X, dim=-1).squeeze(-1)
         # At least 1d is required for sequential optimize_acqf.
         return torch.atleast_1d(res)
-
-
-# pyrefly: ignore [inconsistent-inheritance]
 
 
 # pyrefly: ignore [inconsistent-inheritance]
@@ -366,7 +362,6 @@ class AcquisitionTest(TestCase):
                 ) as mock_prune_irrelevant_parameters,
             ):
                 acquisition.optimize(
-                    # pyrefly: ignore [bad-argument-type]
                     n=n,
                     search_space_digest=self.search_space_digest,
                     # pyrefly: ignore [bad-argument-type]
@@ -824,11 +819,9 @@ class AcquisitionTest(TestCase):
             mock.patch(
                 f"{ACQUISITION_PATH}.optimizer_argparse", wraps=optimizer_argparse
             ) as mock_optimizer_argparse,
-            # pyrefly: ignore [bad-argument-type]
         ):
             acquisition.optimize(
                 n=3,
-                # pyrefly: ignore [bad-argument-type]
                 search_space_digest=ssd,
                 # pyrefly: ignore [bad-argument-type]
                 inequality_constraints=self.inequality_constraints,
@@ -857,22 +850,18 @@ class AcquisitionTest(TestCase):
                 },
                 set(kwargs.keys()),
             )
-            # pyrefly: ignore [bad-index]
             self.assertEqual(kwargs["acq_function"], acquisition.acqf)
             self.assertEqual(kwargs["q"], 3)
             self.assertEqual(
-                # pyrefly: ignore [bad-index]
                 kwargs["inequality_constraints"],
                 self.inequality_constraints,
             )
             self.assertEqual(
-                # pyrefly: ignore [bad-index]
                 kwargs["num_restarts"],
                 # pyrefly: ignore [bad-index]
                 self.optimizer_options["num_restarts"],
             )
             self.assertEqual(
-                # pyrefly: ignore [bad-index]
                 kwargs["raw_samples"],
                 # pyrefly: ignore [bad-index]
                 self.optimizer_options["raw_samples"],
@@ -983,11 +972,9 @@ class AcquisitionTest(TestCase):
                 mock.patch(
                     f"{ACQUISITION_PATH}.optimizer_argparse", wraps=optimizer_argparse
                 ) as mock_optimizer_argparse,
-                # pyrefly: ignore [bad-argument-type]
                 mock.patch(
                     f"{ACQUISITION_PATH}.optimize_acqf_discrete_local_search",
                     return_value=(valid_candidates, torch.rand(3)),
-                    # pyrefly: ignore [bad-argument-type]
                 ),
                 mock.patch(
                     f"{ACQUISITION_PATH}.optimize_acqf_mixed_alternating",
@@ -1011,11 +998,9 @@ class AcquisitionTest(TestCase):
             )
 
     @mock_botorch_optimize
-    # pyrefly: ignore [bad-argument-type]
     def test_optimize_mixed(self) -> None:
         ssd = SearchSpaceDigest(
             feature_names=["a", "b"],
-            # pyrefly: ignore [bad-argument-type]
             bounds=[(0, 1), (0, 2)],
             categorical_features=[1],
             discrete_choices={1: [0, 1, 2]},
@@ -1056,7 +1041,6 @@ class AcquisitionTest(TestCase):
     @mock_botorch_optimize
     def test_optimize_acqf_mixed_alternating(self) -> None:
         b_upper_bound = 15
-        # pyrefly: ignore [bad-argument-type]
         ssd = SearchSpaceDigest(
             feature_names=["a", "b", "c"],
             bounds=[(0, 1), (0, b_upper_bound), (0, 5)],
@@ -1101,7 +1085,6 @@ class AcquisitionTest(TestCase):
             num_restarts=2,
             raw_samples=4,
         )
-        # pyrefly: ignore [bad-argument-type]
 
         # Check with cateogrial features but no non-integer features.
         ssd_categorical = dataclasses.replace(
@@ -1169,13 +1152,11 @@ class AcquisitionTest(TestCase):
         mock_alternating.assert_called()
 
         # Check if the `fixed_features` argument works for discrete features.
-        # pyrefly: ignore [bad-argument-type]
         ub = 10
         ssd_many_combinations = SearchSpaceDigest(
             feature_names=["a", "b", "c"],
             bounds=[(0, 1), (0, ub), (0, ub)],
             ordinal_features=[1, 2],
-            # pyrefly: ignore [bad-argument-type]
             discrete_choices={1: list(range(ub + 1)), 2: list(range(ub + 1))},
         )
         dict_args = {
@@ -1219,7 +1200,7 @@ class AcquisitionTest(TestCase):
         mock_evaluate.assert_called_with(X=self.X)
 
     @mock_botorch_optimize
-    @mock.patch(  # pyre-ignore
+    @mock.patch(
         "ax.generators.torch.botorch_moo_utils._check_posterior_type",
         wraps=lambda y: y,
     )
@@ -1531,7 +1512,6 @@ class AcquisitionTest(TestCase):
         # inputs. After subsetting (weights=[1,1,0], constraint on m3),
         # all 3 outputs are kept.
         Y_test = torch.tensor([[1.0, 2.0, 0.3]], **self.tkwargs)
-        # pyre-ignore[6]: _constraints is typed as Union[Tensor, Module].
         constraints = acquisition.acqf._constraints
         # Constraint 0 (outcome constraint): m3 <= 0.5 → Y[2] - 0.5
         # = 0.3 - 0.5 = -0.2 (feasible)
@@ -1594,7 +1574,6 @@ class AcquisitionTest(TestCase):
         # Verify constraint values: model is subsetted to 2 outputs (m1, m2)
         # since there are no outcome constraints referencing m3.
         Y_test_2d = torch.tensor([[1.0, 2.0]], **self.tkwargs)
-        # pyre-ignore[6]: _constraints is typed as Union[Tensor, Module].
         constraints_no_oc = acquisition_no_oc.acqf._constraints
         # Threshold for m1 (maximize): -Y[0] + 0.5 = -1.0 + 0.5 = -0.5
         # pyre-ignore[29]: _constraints elements are callables at runtime.
@@ -2328,11 +2307,9 @@ class AcquisitionTest(TestCase):
         acquisition = self.get_acquisition_function(
             fixed_features=self.fixed_features,
         )
-        # pyrefly: ignore [bad-argument-type]
         n = 1
         # Create valid mock candidates that satisfy:
         # - Bounds: [(0, 10), (0, 10), (0, 10)]
-        # pyrefly: ignore [bad-argument-type]
         # - Fixed features: x[1] = 2.0
         # - Inequality constraint: -x[0] + x[1] >= 1 => x[0] <= x[1] - 1 = 1.0
         valid_candidates = torch.tensor([[0.5, 2.0, 5.0]], **self.tkwargs)
@@ -2411,12 +2388,10 @@ class AcquisitionTest(TestCase):
         )
 
     @mock_botorch_optimize
-    # pyrefly: ignore [bad-argument-type]
     def test_optimize_with_equality_constraints(self) -> None:
         """Test that equality_constraints are forwarded to optimize_acqf."""
         acquisition = self.get_acquisition_function(
             fixed_features=self.fixed_features,
-            # pyrefly: ignore [bad-argument-type]
         )
         # Equality constraint: x[0] + x[2] = 4.0
         # Compatible with fixed_features={1: 2.0} and
@@ -2466,12 +2441,10 @@ class AcquisitionTest(TestCase):
         """Test that equality_constraints are forwarded to optimize_acqf_mixed."""
         ssd = SearchSpaceDigest(
             feature_names=["a", "b"],
-            # pyrefly: ignore [bad-argument-type]
             bounds=[(0, 1), (0, 2)],
             categorical_features=[1],
             discrete_choices={1: [0, 1, 2]},
         )
-        # pyrefly: ignore [bad-argument-type]
         acquisition = self.get_acquisition_function()
         equality_constraints = [
             (
@@ -2517,7 +2490,6 @@ class AcquisitionTest(TestCase):
         self,
     ) -> None:
         """Test equality_constraints forwarded to optimize_acqf_mixed_alternating."""
-        # pyrefly: ignore [bad-argument-type]
         ssd = SearchSpaceDigest(
             feature_names=["a", "b", "c"],
             bounds=[(0, 1), (0, 15), (0, 5)],
@@ -2699,7 +2671,6 @@ class MultiAcquisitionTest(AcquisitionTest):
         mock_get_objective_and_transform.return_value = (botorch_objective, None)
         mock_get_X.return_value = (self.pending_observations[0], self.X[:1])
         self.options[Keys.SUBSET_MODEL] = False
-        # pyrefly: ignore [bad-argument-type]
         with mock.patch(
             f"{ACQUISITION_PATH}.get_outcome_constraint_transforms",
             return_value=self.constraints,
@@ -2753,7 +2724,6 @@ class MultiAcquisitionTest(AcquisitionTest):
         acquisition = self.get_acquisition_function(fixed_features=self.fixed_features)
         n = 5
         # Use more generations and larger population to reliably find feasible
-        # pyrefly: ignore [bad-argument-type]
         # candidates that satisfy the inequality constraint
         optimizer_options = {"max_gen": 10, "population_size": 50}
         # Mock candidates that satisfy constraints:
@@ -2818,7 +2788,6 @@ class MultiAcquisitionTest(AcquisitionTest):
 
     @skip_if_import_error
     def test_optimize_with_nsgaii_features(self) -> None:
-        # pyrefly: ignore [bad-argument-type]
         """Test that optimize_with_nsgaii correctly handles all features.
 
         This tests that candidates generated by optimize_with_nsgaii:
@@ -2877,7 +2846,6 @@ class MultiAcquisitionTest(AcquisitionTest):
             )
 
         # 3. Verify discrete choices: dimension 0 should only have allowed values
-        # pyrefly: ignore [bad-argument-type]
         allowed_values = torch.tensor(
             discrete_search_space_digest.discrete_choices[0], **self.tkwargs
         )

--- a/ax/generators/torch/tests/test_generator.py
+++ b/ax/generators/torch/tests/test_generator.py
@@ -190,9 +190,7 @@ class BoTorchGeneratorTest(TestCase):
             self.torch_opt_config,
             objective_weights=self.moo_objective_weights,
             objective_thresholds=self.moo_objective_thresholds,
-            # pyrefly: ignore [bad-argument-type]
             outcome_constraints=self.moo_outcome_constraints,
-            # pyrefly: ignore [bad-argument-type]
             model_gen_options={
                 # pyrefly: ignore [bad-assignment]
                 Keys.OPTIMIZER_KWARGS: self.optimizer_options,
@@ -819,12 +817,11 @@ class BoTorchGeneratorTest(TestCase):
                 ),
             )
         )
-        # pyrefly: ignore [bad-argument-type]
         self.assertEqual(importances.shape, (2, 1, 3))
         # Add model we don't support
         # pyrefly: ignore [bad-argument-type]
         vanilla_model.covar_module = None
-        model.surrogate._model = vanilla_model  # pyre-ignore
+        model.surrogate._model = vanilla_model
         with self.assertRaisesRegex(
             NotImplementedError,
             "Failed to extract lengthscales from `m.covar_module` "
@@ -1108,7 +1105,6 @@ class BoTorchGeneratorTest(TestCase):
                 torch.cat([ds.Y for ds in self.moo_training_data], dim=-1),
             )
         )
-        # pyrefly: ignore [bad-argument-type]
         self.assertTrue(
             torch.equal(
                 training_data.Yvar,
@@ -1128,7 +1124,6 @@ class BoTorchGeneratorTest(TestCase):
         # gen_metadata stores maximization-aligned thresholds.
         obj_t = gen_results.gen_metadata["objective_thresholds"]
         self.assertTrue(torch.equal(obj_t, self.moo_objective_thresholds))
-        # pyrefly: ignore [bad-argument-type]
 
         self.assertIsInstance(ckwargs["objective"], WeightedMCMultiOutputObjective)
         self.assertTrue(
@@ -1224,7 +1219,6 @@ class BoTorchGeneratorTest(TestCase):
         botorch_acqf_classes_with_options = [
             (PosteriorMean, {}),
             (qLogNoisyExpectedImprovement, self.botorch_acqf_options),
-            # pyrefly: ignore [bad-argument-type]
         ]
         surrogate = Surrogate()
         model = BoTorchGenerator(

--- a/ax/generators/torch/tests/test_kernels.py
+++ b/ax/generators/torch/tests/test_kernels.py
@@ -301,7 +301,6 @@ class KernelsTest(TestCase):
                 batch_shape=torch.Size([3]),
                 mle=True,
             )
-            # pyrefly: ignore [not-callable]
             self.assertTrue((kernel.lengthscale == sqrt(2) / 10).all())
             self.assertEqual(kernel.lengthscale.shape, torch.Size([3, 1, 2]))
             self.assertFalse(hasattr(kernel, "lengthscale_prior"))

--- a/ax/generators/torch/tests/test_surrogate.py
+++ b/ax/generators/torch/tests/test_surrogate.py
@@ -412,10 +412,8 @@ class SurrogateTest(TestCase):
             fixed_features=self.fixed_features,
         )
         self.ds2 = SupervisedDataset(
-            # pyre-fixme[6]: For 1st argument expected `Union[BotorchContainer,
             #  Tensor]` but got `int`.
             X=2 * self.Xs,
-            # pyre-fixme[6]: For 2nd argument expected `Union[BotorchContainer,
             #  Tensor]` but got `int`.
             Y=2 * self.Ys,
             feature_names=self.feature_names,
@@ -436,7 +434,6 @@ class SurrogateTest(TestCase):
         if use_outcome_transform:
             outcome_transform_classes: list[type[OutcomeTransform]] = [Standardize]
             outcome_transform_options = {"Standardize": {"m": n_outcomes}}
-        # pyrefly: ignore [bad-assignment]
         else:
             # pyrefly: ignore [bad-assignment]
             outcome_transform_classes = None
@@ -532,7 +529,6 @@ class SurrogateTest(TestCase):
             refit=True,
         )
         models = assert_is_instance(surrogate.model.models, ModuleList)
-        # pyrefly: ignore [missing-attribute]
 
         model1_old_lengtscale = (
             # pyrefly: ignore [missing-attribute]
@@ -542,7 +538,6 @@ class SurrogateTest(TestCase):
         # pyrefly: ignore [missing-attribute]
         models[0].covar_module.base_kernel.lengthscale += 1
         self.assertAllClose(
-            # pyrefly: ignore [missing-attribute]
             model1_old_lengtscale,
             # pyrefly: ignore [missing-attribute]
             models[1].covar_module.base_kernel.lengthscale,
@@ -554,22 +549,18 @@ class SurrogateTest(TestCase):
             # pyrefly: ignore [missing-attribute]
             models[0].likelihood.noise_covar.raw_noise_constraint.lower_bound,
             1e-4,
-            # pyrefly: ignore [missing-attribute]
         )
         self.assertEqual(
             # pyrefly: ignore [missing-attribute]
             models[1].likelihood.noise_covar.raw_noise_constraint.lower_bound,
-            # pyrefly: ignore [missing-attribute]
             1e-3,
         )
         # Check input transform
 
         # bounds will be taken from the search space digest
-        # pyrefly: ignore [missing-attribute]
         self.assertAllClose(
             # pyrefly: ignore [missing-attribute]
             models[0].input_transform.offset,
-            # pyrefly: ignore [missing-attribute]
             torch.tensor([[0, 1, 2]], **self.tkwargs),
         )
         self.assertAllClose(
@@ -610,7 +601,6 @@ class SurrogateTest(TestCase):
         botorch_model = surrogate.model
         self.assertIsInstance(botorch_model.input_transform, Normalize)
         self.assertIsInstance(botorch_model.outcome_transform, Standardize)
-        # pyre-fixme[16]: Item `Tensor` of `Tensor | Module` has no attribute `_m`.
         self.assertEqual(botorch_model.outcome_transform._m, self.Ys.shape[-1])
 
         # Error handling if the model does not support transforms.
@@ -668,9 +658,7 @@ class SurrogateTest(TestCase):
         f"{SURROGATE_PATH}.submodel_input_constructor",
         wraps=submodel_input_constructor,
     )
-    # pyrefly: ignore [bad-index]
     @patch(f"{SURROGATE_PATH}.fit_botorch_model", wraps=fit_botorch_model)
-    # pyrefly: ignore [bad-index]
     def test_fit_model_reuse(self, mock_fit: Mock, mock_constructor: Mock) -> None:
         surrogate, _ = self._get_surrogate(
             botorch_model_class=SingleTaskGP, use_outcome_transform=False
@@ -683,7 +671,6 @@ class SurrogateTest(TestCase):
             datasets=self.training_data,
             search_space_digest=search_space_digest,
         )
-        # pyrefly: ignore [bad-index]
         mock_fit.assert_called_once()
         mock_constructor.assert_called_once()
         key = tuple(self.training_data[0].outcome_names)
@@ -768,9 +755,7 @@ class SurrogateTest(TestCase):
                     len(call_kwargs),
                     6 if botorch_model_class is SaasFullyBayesianSingleTaskGP else 4,
                 )
-                # pyrefly: ignore [unsupported-operation]
 
-                # pyrefly: ignore [unsupported-operation]
                 mock_construct_inputs.assert_called_with(
                     training_data=self.training_data[0],
                 )
@@ -957,14 +942,12 @@ class SurrogateTest(TestCase):
         # pyre-fixme[6]: For 1st argument expected
         #  `pyre_extensions.PyreReadOnly[Sized]` but got `Union[Tensor, Module]`.
         self.assertEqual(len(submodels), 4)
-        # pyre-fixme[29]: `Union[(self: Tensor) -> Any, Tensor, Module]` is not a
         #  function.
         for m in submodels:
             self.assertIsInstance(m, SingleTaskGP)
         # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[Any, A...
         self.assertIsInstance(surrogate.model.models[1].covar_module, ScaleKernel)
         self.assertIsInstance(
-            # pyre-fixme[29]: `Union[(self: TensorBase, indices: Union[None, slice[An...
             surrogate.model.models[1].covar_module.base_kernel,
             MaternKernel,
         )
@@ -1021,7 +1004,6 @@ class SurrogateTest(TestCase):
                 patch.object(
                     botorch_model_class, "__init__", return_value=None, autospec=True
                 ) as mock_init,
-                # pyrefly: ignore [bad-argument-type]
                 patch(f"{SURROGATE_PATH}.fit_botorch_model") as mock_fit,
             ):
                 surrogate._construct_model(
@@ -1068,7 +1050,6 @@ class SurrogateTest(TestCase):
         self, mock_diag_dict: Mock, mock_in_sample_metric: Mock
     ) -> None:
         # These mocks are used because we control which kernel is selected by
-        # pyrefly: ignore [unbound-name]
         # changing the values of model diagnostics
         side_effect_dict = {
             "MSE": [0.2, 0.1],
@@ -1190,7 +1171,6 @@ class SurrogateTest(TestCase):
                     warnings.filterwarnings("always")
                     surrogate.fit(
                         [dataset],
-                        # pyrefly: ignore [bad-index]
                         search_space_digest=search_space_digest,
                     )
 
@@ -2288,21 +2268,16 @@ class SurrogateWithModelListTest(TestCase):
                 model_configs=[
                     ModelConfig(
                         botorch_model_class=SingleTaskGP,
-                        # pyrefly: ignore [missing-attribute]
                         mll_class=ExactMarginalLogLikelihood,
-                        # pyrefly: ignore [missing-attribute]
                         input_transform_classes=[Normalize],
                         input_transform_options={
-                            # pyrefly: ignore [missing-attribute]
                             "Normalize": {"d": 3, "bounds": None, "indices": None}
                         },
                         outcome_transform_classes=[Standardize],
-                        # pyrefly: ignore [missing-attribute]
                         outcome_transform_options={"Standardize": {"m": 1}},
                     )
                 ]
             )
-            # pyrefly: ignore [missing-attribute]
         )
         surrogate.fit(
             datasets=self.supervised_training_data,

--- a/ax/generators/torch/tests/test_utils.py
+++ b/ax/generators/torch/tests/test_utils.py
@@ -786,7 +786,6 @@ class BoTorchGeneratorUtilsTest(TestCase):
             construct_acquisition_and_optimizer_options(
                 acqf_options=acqf_options,
                 botorch_acqf_options=botorch_acqf_options,
-                # pyrefly: ignore [bad-argument-type]
                 model_gen_options={**model_gen_options, "extra": "key"},
             )
 
@@ -1329,7 +1328,6 @@ class BoTorchGeneratorUtilsTest(TestCase):
         train_X = torch.rand(5, 3, **tkwargs)
         train_Y = train_X.sum(dim=-1, keepdim=True)
         simple_gp = SingleTaskGP(train_X=train_X, train_Y=train_Y)
-        # pyre-fixme[16]: `Module` has no attribute `lengthscale`.
         simple_gp.covar_module.lengthscale = torch.tensor([1, 3, 5], **tkwargs)
         importances = get_feature_importances_from_botorch_model(simple_gp)
         self.assertTrue(np.allclose(importances, np.array([15 / 23, 5 / 23, 3 / 23])))

--- a/ax/generators/utils.py
+++ b/ax/generators/utils.py
@@ -119,7 +119,6 @@ def rejection_sample(
 
     while points.shape[0] < n and attempted_draws < max_draws:
         # _gen_unconstrained returns points including fixed features.
-        # pyre-ignore[28]: Unexpected keyword argument to anonymous call.
         point = gen_unconstrained(
             # pyrefly: ignore [bad-argument-count, unexpected-keyword]
             n=1,
@@ -382,7 +381,6 @@ def best_observed_point(
         bounds=bounds,
         objective_weights=objective_weights,
         outcome_constraints=outcome_constraints,
-        # pyrefly: ignore [bad-return]
         linear_constraints=linear_constraints,
         fixed_features=fixed_features,
         options=options,
@@ -401,7 +399,6 @@ def best_in_sample_point(
     fixed_features: dict[int, float] | None = None,
     options: TConfig | None = None,
 ) -> tuple[TTensoray, float] | None:
-    # pyrefly: ignore [bad-assignment]
     """Select the best point that has been observed.
 
     Implements two approaches to selecting the best point.
@@ -453,9 +450,7 @@ def best_in_sample_point(
         - d-array of the best point,
         - utility at the best point.
     """
-    # pyrefly: ignore [bad-assignment]
     # Parse options
-    # pyrefly: ignore [bad-assignment]
     if options is None:
         options = {}
     # pyrefly: ignore [bad-assignment]
@@ -482,7 +477,6 @@ def best_in_sample_point(
         X=X_obs,
         bounds=bounds,
         linear_constraints=linear_constraints,
-        # pyrefly: ignore [bad-argument-type]
         fixed_features=fixed_features,
     )
     if len(X_obs) == 0:
@@ -513,7 +507,6 @@ def best_in_sample_point(
     if method == "feasible_threshold":
         utility = obj
         utility[pfeas < threshold] = -np.inf
-    # pyrefly: ignore [bad-return]
     elif method == "max_utility":
         if B is None:
             B = obj.min()

--- a/ax/metrics/branin_map.py
+++ b/ax/metrics/branin_map.py
@@ -68,7 +68,6 @@ class BraninTimestampMapMetric(NoisyFunctionMapMetric):
             decay_function_name
         ]
 
-        # pyre-fixme[4]: Attribute must be annotated.
         self._trial_index_to_timestamp = defaultdict(int)
 
         super().__init__(

--- a/ax/orchestration/orchestrator.py
+++ b/ax/orchestration/orchestrator.py
@@ -353,7 +353,7 @@ class Orchestrator(WithDBSettingsBase, BestPointMixin):
     @property
     def options(self) -> OrchestratorOptions:
         """Orchestrator options."""
-        return self._options  # pyre-ignore [16]
+        return self._options
 
     @options.setter
     def options(self, options: OrchestratorOptions) -> None:
@@ -842,8 +842,6 @@ class Orchestrator(WithDBSettingsBase, BestPointMixin):
         )
         self._log_next_no_trials_reason = True
         return metadata
-
-    # pyrefly: ignore [not-callable]
 
     # pyrefly: ignore [not-callable]
     @retry_on_exception(retries=3, no_retry_on_exception_types=NO_RETRY_EXCEPTIONS)
@@ -1839,7 +1837,6 @@ class Orchestrator(WithDBSettingsBase, BestPointMixin):
                     ttl_seconds=self.options.ttl_seconds_for_trials,
                     trial_type=self.trial_type,
                 )
-            # pyrefly: ignore [bad-return]
 
             trials.append(trial)
         # pyrefly: ignore [bad-return]

--- a/ax/orchestration/tests/test_orchestrator.py
+++ b/ax/orchestration/tests/test_orchestrator.py
@@ -133,7 +133,7 @@ class TestAxOrchestrator(TestCase):
     # TODO[@mgarrard]: Change this to `str(GenerationStrategy.__module__)`
     # once we are no longer splitting which `GS.gen` to call into based on
     # `Trial` vs. `BatchTrial`
-    PENDING_FEATURES_EXTRACTOR: tuple[  # pyre-ignore[8]
+    PENDING_FEATURES_EXTRACTOR: tuple[
         str,
         Callable[
             # pyrefly: ignore [invalid-argument]
@@ -145,7 +145,7 @@ class TestAxOrchestrator(TestCase):
         + "get_pending_observation_features_based_on_trial_status",
         get_pending_observation_features_based_on_trial_status,
     )
-    PENDING_FEATURES_BATCH_EXTRACTOR: tuple[  # pyre-ignore[8]
+    PENDING_FEATURES_BATCH_EXTRACTOR: tuple[
         str,
         Callable[
             # pyrefly: ignore [invalid-argument]
@@ -560,9 +560,7 @@ class TestAxOrchestrator(TestCase):
         test_obj: list[int | str | None] = [0, 0]
 
         def _callback(orchestrator: Orchestrator) -> None:
-            # pyrefly: ignore [unsupported-operation]
             test_obj[0] = orchestrator._latest_optimization_start_timestamp
-            # pyrefly: ignore [unsupported-operation]
             test_obj[1] = "apple"
             return
 
@@ -3245,7 +3243,6 @@ class TestAxOrchestratorMultiTypeExperiment(TestAxOrchestrator):
     ) -> None:
         # add a tracking metric
         self.branin_timestamp_map_metric_experiment.add_tracking_metric(
-            # pyrefly: ignore [unexpected-keyword]
             BraninMetric("branin", ["x1", "x2"]),
             # pyrefly: ignore [unexpected-keyword]
             trial_type="type1",
@@ -3285,7 +3282,6 @@ class TestAxOrchestratorMultiTypeExperiment(TestAxOrchestrator):
         # pyrefly: ignore [missing-attribute]
         self.branin_experiment.update_runner("type1", InfinitePollRunner())
         self.branin_experiment.add_tracking_metric(
-            # pyrefly: ignore [unexpected-keyword]
             get_branin_metric(),
             # pyrefly: ignore [unexpected-keyword]
             trial_type="type1",

--- a/ax/plot/base.py
+++ b/ax/plot/base.py
@@ -52,7 +52,6 @@ class AxPlotConfig(_AxPlotConfigBase):
         dict_data = json.loads(
             json.dumps(named_tuple_to_dict(data), cls=utils.PlotlyJSONEncoder)
         )
-        # pyre-fixme[7]: Expected `AxPlotConfig` but got `NamedTuple`.
         return super().__new__(cls, dict_data, plot_type)
 
 

--- a/ax/plot/contour.py
+++ b/ax/plot/contour.py
@@ -32,7 +32,6 @@ from ax.plot.helper import (
 
 
 # type aliases
-# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 ContourPredictions = tuple[
     PlotData, np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict[str, bool]
 ]

--- a/ax/plot/diagnostic.py
+++ b/ax/plot/diagnostic.py
@@ -337,14 +337,12 @@ def _get_batch_comparison_plot_data(
             "context_stratum": None,
         }
         for i, mname in enumerate(x_observation_metric_names[arm_name]):
-            # pyre-fixme[16]: Optional type has no attribute `__setitem__`.
             arm_data["y"][mname] = x_observation.data.means[i]
             # pyre-fixme[16]: Item `None` of `Union[None, Dict[typing.Any,
             #  typing.Any], Dict[str, typing.Union[None, bool, float, int, str]], str]`
             #  has no attribute `__setitem__`.
             arm_data["se"][mname] = np.sqrt(x_observation.data.covariance[i][i])
         for i, mname in enumerate(y_observation_metric_names[arm_name]):
-            # pyre-fixme[16]: Item `None` of `Union[None, Dict[typing.Any,
             #  typing.Any], Dict[str, typing.Union[None, bool, float, int, str]], str]`
             #  has no attribute `__setitem__`.
             arm_data["y_hat"][mname] = y_observation.data.means[i]
@@ -407,14 +405,12 @@ def _get_cv_plot_data(
             "context_stratum": None,
         }
         for i, mname in enumerate(cv_result.observed.data.metric_signatures):
-            # pyre-fixme[16]: Optional type has no attribute `__setitem__`.
             arm_data["y"][mname] = cv_result.observed.data.means[i]
             # pyre-fixme[16]: Item `None` of `Union[None, Dict[typing.Any,
             #  typing.Any], Dict[str, typing.Union[None, bool, float, int, str]], str]`
             #  has no attribute `__setitem__`.
             arm_data["se"][mname] = np.sqrt(cv_result.observed.data.covariance[i][i])
         for i, mname in enumerate(cv_result.predicted.metric_signatures):
-            # pyre-fixme[16]: Item `None` of `Union[None, Dict[typing.Any,
             #  typing.Any], Dict[str, typing.Union[None, bool, float, int, str]], str]`
             #  has no attribute `__setitem__`.
             arm_data["y_hat"][mname] = cv_result.predicted.means[i]

--- a/ax/plot/feature_importances.py
+++ b/ax/plot/feature_importances.py
@@ -64,7 +64,7 @@ def plot_feature_importance_by_feature_plotly(
             )
 
     if label_dict is not None:
-        sensitivity_values = {  # pyre-ignore
+        sensitivity_values = {
             label_dict.get(metric_name, metric_name): v
             # pyrefly: ignore [missing-attribute]
             for metric_name, v in sensitivity_values.items()

--- a/ax/plot/pareto_utils.py
+++ b/ax/plot/pareto_utils.py
@@ -200,9 +200,7 @@ def get_observed_pareto_frontiers(
     adapter = get_tensor_converter_adapter(experiment=experiment, data=data)
     pareto_observations = observed_pareto_frontier(adapter=adapter)
     # Convert to ParetoFrontierResults
-    objective_metric_names = set(
-        experiment.optimization_config.objective.metric_names  # pyre-ignore
-    )
+    objective_metric_names = set(experiment.optimization_config.objective.metric_names)
     obj_metr_list = sorted(objective_metric_names)
     pfr_means = {name: [] for name in obj_metr_list}
     pfr_sems = {name: [] for name in obj_metr_list}
@@ -218,7 +216,7 @@ def get_observed_pareto_frontiers(
     # Get objective thresholds
     rel_objth = {}
     objective_thresholds = {}
-    if experiment.optimization_config.objective_thresholds is not None:  # pyre-ignore
+    if experiment.optimization_config.objective_thresholds is not None:
         for objth in experiment.optimization_config.objective_thresholds:
             rel_objth[objth.metric_names[0]] = objth.relative
             objective_thresholds[objth.metric_names[0]] = objth.bound
@@ -471,7 +469,6 @@ def _extract_pareto_frontier_results(
     return ParetoFrontierResults(
         param_dicts=param_dicts,
         means=means_out,
-        # pyre-fixme[6]: For 3rd argument expected `Dict[str, List[float]]` but got
         #  `Dict[str, ndarray[typing.Any, dtype[typing.Any]]]`.
         sems=sems_out,
         primary_metric=primary_metric,

--- a/ax/plot/scatter.py
+++ b/ax/plot/scatter.py
@@ -244,7 +244,6 @@ def _error_scatter_trace(
         )
         i += 1
 
-    # pyrefly: ignore [bad-argument-type]
     if color_metric or color_parameter:
         # pyrefly: ignore [bad-argument-type]
         rgba_blue_scale = [rgba(c) for c in BLUE_SCALE]
@@ -253,7 +252,6 @@ def _error_scatter_trace(
             "colorscale": rgba_blue_scale,
             "colorbar": {"title": color_metric or color_parameter},
             "showscale": True,
-            # pyrefly: ignore [bad-argument-type]
         }
     else:
         # pyrefly: ignore [bad-argument-type]
@@ -272,7 +270,6 @@ def _error_scatter_trace(
     if show_CI:
         if x_se is not None:
             trace.update(
-                # pyrefly: ignore [bad-argument-type]
                 error_x={
                     "type": "data",
                     "array": np.multiply(x_se, Z),
@@ -281,7 +278,6 @@ def _error_scatter_trace(
                 }
             )
         if y_se is not None:
-            # pyrefly: ignore [bad-argument-type]
             trace.update(
                 error_y={
                     "type": "data",

--- a/ax/plot/slice.py
+++ b/ax/plot/slice.py
@@ -29,7 +29,6 @@ from pyre_extensions import none_throws
 
 
 # type aliases
-# pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
 SlicePredictions = tuple[
     PlotData,
     list[dict[str, str | float]],
@@ -479,7 +478,6 @@ def interact_slice_plotly(
     for i, metric in enumerate(metrics):
         # pyre-fixme[61]: `arm_data` is undefined, or not always defined.
         trace_cnt = 3 + len(arm_data[metric]["out_of_sample"].keys())
-        # pyre-fixme[61]: `metrics` is undefined, or not always defined.
         visible = [False] * (len(metrics) * trace_cnt)
         for j in range(i * trace_cnt, (i + 1) * trace_cnt):
             visible[j] = True
@@ -540,7 +538,6 @@ def interact_slice_plotly(
             "autorange": True,
             "tickfont": {"size": 11},
             "tickmode": "auto",
-            # pyre-fixme[61]: `metrics` is undefined, or not always defined.
             "title": metrics[0],
         },
     }

--- a/ax/plot/tests/test_feature_importances.py
+++ b/ax/plot/tests/test_feature_importances.py
@@ -50,7 +50,6 @@ def get_sensitivity_values(ax_model: Adapter) -> dict:
         ls = model.covar_module.lengthscale.squeeze()
     if len(ls.shape) > 1:
         ls = ls.mean(dim=0)
-    # pyre-fixme[16]: `float` has no attribute `detach`.
     importances_tensor = torch.stack([(1 / ls).detach().cpu()])
     importances_dict = dict(zip(ax_model.outcomes, importances_tensor))
     res = {}

--- a/ax/service/tests/test_interactive_loop.py
+++ b/ax/service/tests/test_interactive_loop.py
@@ -68,7 +68,6 @@ class TestInteractiveLoop(TestCase):
         parameterization, trial_index = parameterization_with_trial_index
         x = np.array([parameterization.get(f"x{i + 1}") for i in range(6)])
 
-        # pyrefly: ignore [bad-return]
         return (
             trial_index,
             {
@@ -142,7 +141,6 @@ class TestInteractiveLoop(TestCase):
 
             x = np.array([parameterization.get(f"x{i + 1}") for i in range(6)])
 
-            # pyrefly: ignore [bad-return]
             return (
                 trial_index,
                 {

--- a/ax/service/tests/test_managed_loop.py
+++ b/ax/service/tests/test_managed_loop.py
@@ -58,7 +58,7 @@ class TestOptimize(TestCase):
                 # pyrefly: ignore [unsupported-operation]
                 evaluation_function=lambda p: (p["x1"] + 2 * p["x2"] - 7) ** 2
                 + (2 * p["x1"] + p["x2"] - 5)  # pyrefly: ignore [unsupported-operation]
-                ** 2,  # pyrefly: ignore [unsupported-operation]
+                ** 2,
                 minimize=True,
                 total_trials=5,
             )
@@ -73,7 +73,7 @@ class TestOptimize(TestCase):
             # pyrefly: ignore [unsupported-operation]
             evaluation_function=lambda p: (p["x1"] + 2 * p["x2"] - 7) ** 2
             + (2 * p["x1"] + p["x2"] - 5)  # pyrefly: ignore [unsupported-operation]
-            ** 2,  # pyrefly: ignore [unsupported-operation]
+            ** 2,
             minimize=True,
             total_trials=5,
         )
@@ -150,7 +150,7 @@ class TestOptimize(TestCase):
             # pyrefly: ignore [unsupported-operation]
             evaluation_function=lambda p: (p["x1"] + 2 * p["x2"] - 7) ** 2
             + (2 * p["x1"] + p["x2"] - 5)  # pyrefly: ignore [unsupported-operation]
-            ** 2,  # pyrefly: ignore [unsupported-operation]
+            ** 2,
             minimize=True,
             parameter_constraints=["x1 + x2 <= 5"],
             total_trials=5,
@@ -278,7 +278,7 @@ class TestOptimize(TestCase):
             # pyrefly: ignore [unsupported-operation]
             evaluation_function=lambda p: (p["x1"] + 2 * p["x2"] - 7) ** 2
             + (2 * p["x1"] + p["x2"] - 5)  # pyrefly: ignore [unsupported-operation]
-            ** 2,  # pyrefly: ignore [unsupported-operation]
+            ** 2,
             minimize=True,
             total_trials=5,
             generation_strategy=gs,

--- a/ax/service/utils/analysis_base.py
+++ b/ax/service/utils/analysis_base.py
@@ -20,10 +20,8 @@ class AnalysisBase(WithDBSettingsBase):
     Base class for analysis functionality shared between AxClient and orchestrator.
     """
 
-    # pyre-fixme[13]: Attribute `experiment` is declared in class
     # `AnalysisBase` to have type `Experiment` but is never initialized
     experiment: Experiment
-    # pyre-fixme[13]: Attribute `generation_strategy` is declared in class
     # `AnalysisBase` to have type `GenerationStrategy` but
     # is never initialized
     generation_strategy: GenerationStrategy

--- a/ax/service/utils/instantiation.py
+++ b/ax/service/utils/instantiation.py
@@ -604,7 +604,6 @@ class InstantiationBase:
         status_quo_defined: bool,
         metric_definitions: dict[str, dict[str, Any]] | None = None,
     ) -> list[OutcomeConstraint]:
-        # pyre-ignore[9]: ObjectiveThreshold is a subclass of OutcomeConstraint;
         # list invariance prevents direct assignment.
         typed_objective_thresholds: list[OutcomeConstraint] = (
             [

--- a/ax/service/utils/report_utils.py
+++ b/ax/service/utils/report_utils.py
@@ -1118,7 +1118,6 @@ def get_figure_and_callback(
     """
     fig = go.FigureWidget(layout=go.Layout())
 
-    # pyre-fixme[53]: Captured variable `fig` is not annotated.
     def _update_fig_in_place(orchestrator: Orchestrator) -> None:
         try:
             new_fig = plot_fn(orchestrator)

--- a/ax/storage/json_store/decoder.py
+++ b/ax/storage/json_store/decoder.py
@@ -373,7 +373,6 @@ def object_from_json(
 
 
 def ax_class_from_json_dict(
-    # pyre-fixme[24]: Generic type `type` expects 1 type parameter, use
     #  `typing.Type` to avoid runtime subscripting errors.
     _class: type,
     object_json: dict[str, Any],

--- a/ax/storage/sqa_store/decoder.py
+++ b/ax/storage/sqa_store/decoder.py
@@ -228,7 +228,6 @@ class Decoder:
         # so need to convert it to regular dict.
         properties = dict(experiment_sqa.properties or {})
         if Keys.LLM_MESSAGES in properties:
-            # pyre-ignore[6]: SA 2.0 properties values are ColumnElement; runtime list.
             properties[Keys.LLM_MESSAGES] = [
                 LLMMessage(**m) for m in properties[Keys.LLM_MESSAGES]
             ]
@@ -297,7 +296,6 @@ class Decoder:
         """First step of conversion within experiment_from_sqa."""
         properties = dict(experiment_sqa.properties or {})
         if Keys.LLM_MESSAGES in properties:
-            # pyre-ignore[6]: SA 2.0 properties values are ColumnElement; runtime list.
             properties[Keys.LLM_MESSAGES] = [
                 LLMMessage(**m) for m in properties[Keys.LLM_MESSAGES]
             ]
@@ -328,13 +326,11 @@ class Decoder:
         )
 
         default_trial_type = none_throws(experiment_sqa.default_trial_type)
-        # pyre-ignore[9]: SA 2.0 Column[Optional[str]] keys; runtime str.
         trial_type_to_runner: dict[str, Runner | None] = {
             none_throws(sqa_runner.trial_type): self.runner_from_sqa(sqa_runner)
             for sqa_runner in experiment_sqa.runners
         }
         if len(trial_type_to_runner) == 0:
-            # pyre-ignore[9]: SA 2.0 Column[Optional[str]] keys; runtime str.
             trial_type_to_runner = {default_trial_type: None}
             trial_types_with_metrics = {
                 metric.trial_type
@@ -344,7 +340,6 @@ class Decoder:
             # trial_type_to_runner is instantiated to map all trial types to None,
             # so the trial types are associated with the experiment. This is
             # important for adding metrics.
-            # pyre-ignore[6]: SA 2.0 Column[T] keys vs str keys.
             trial_type_to_runner.update(dict.fromkeys(trial_types_with_metrics))
 
         experiment = MultiTypeExperiment(
@@ -1051,7 +1046,6 @@ class Decoder:
             decoder_registry=self.config.json_decoder_registry,
             class_decoder_registry=self.config.json_class_decoder_registry,
         )
-        # pyre-fixme[45]: `runner_class` is always a concrete subclass at runtime,
         #  but pyre sees `Runner` (abstract) from the reverse_runner_registry type.
         runner = runner_class(**args)
         runner.db_id = runner_sqa.id

--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -262,7 +262,7 @@ class Encoder:
             Experiment
         ]
         exp_sqa = experiment_class(
-            id=experiment.db_id,  # pyre-ignore
+            id=experiment.db_id,
             description=experiment.description,
             is_test=experiment.is_test,
             name=experiment.name,
@@ -1206,7 +1206,6 @@ class Encoder:
     ) -> list[SQAAuxiliaryExperiment]:
         """Convert Ax auxiliary experiments by purpose to SQLAlchemy."""
 
-        # pyre-fixme: Expected `Base` for 1st...ot `typing.Type[AuxiliaryExperiment]`.
         auxiliary_experiment_class: SQAAuxiliaryExperiment = (
             # pyrefly: ignore [bad-assignment]
             self.config.class_to_sqa_class[AuxiliaryExperiment]

--- a/ax/storage/sqa_store/json.py
+++ b/ax/storage/sqa_store/json.py
@@ -47,7 +47,6 @@ class JSONEncodedObject(TypeDecorator):
     def process_result_value(self, value: Any, dialect: Any) -> Any:
         if value is not None:
             try:  # TODO T61331534: revert this; just a hotfix for AutoML
-                # pyre-fixme[6]: `object_pairs_hook` expects a callable but
                 #  `type[Any] | None` is stored; compatible at runtime.
                 return json.loads(value, object_pairs_hook=self.object_pairs_hook)
             except JSONDecodeError:

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -804,7 +804,6 @@ class SQAStoreTest(TestCase):
         f"{Decoder.__module__}.Decoder.trial_from_sqa",
         side_effect=Decoder(SQAConfig()).trial_from_sqa,
     )
-    # pyre-fixme[56]: Pyre was not able to infer the type of argument `ax.storage.sqa...
     @patch(
         f"{Decoder.__module__}.Decoder.experiment_from_sqa",
         side_effect=Decoder(SQAConfig()).experiment_from_sqa,
@@ -1943,7 +1942,6 @@ class SQAStoreTest(TestCase):
         )
         with self.assertRaises(SQADecodeError):
             self.decoder.parameter_constraint_from_sqa(
-                # pyrefly: ignore [bad-argument-type]
                 sqa_parameter,
                 # pyrefly: ignore [bad-argument-type]
                 self.dummy_parameters,
@@ -1957,7 +1955,6 @@ class SQAStoreTest(TestCase):
         )
         with self.assertRaises(SQADecodeError):
             self.decoder.parameter_constraint_from_sqa(
-                # pyrefly: ignore [bad-argument-type]
                 sqa_parameter,
                 # pyrefly: ignore [bad-argument-type]
                 self.dummy_parameters,
@@ -2822,7 +2819,6 @@ class SQAStoreTest(TestCase):
         )
         self.assertTrue(immutable)
 
-    # pyre-fixme[56]: Pyre was not able to infer the type of argument `ax.storage.sqa...
     @patch(
         f"{Decoder.__module__}.Decoder.generator_run_from_sqa",
         side_effect=Decoder(SQAConfig()).generator_run_from_sqa,

--- a/ax/storage/sqa_store/tests/test_with_db_settings_base.py
+++ b/ax/storage/sqa_store/tests/test_with_db_settings_base.py
@@ -124,7 +124,6 @@ class TestWithDBSettingsBase(TestCase):
         saved = self.with_db_settings._save_experiment_to_db_if_possible(experiment)
         self.assertTrue(saved)
         loaded_experiment = _load_experiment(
-            # pyrefly: ignore [missing-attribute]
             experiment.name,
             # pyrefly: ignore [missing-attribute]
             decoder=self.with_db_settings.db_settings.decoder,
@@ -220,7 +219,6 @@ class TestWithDBSettingsBase(TestCase):
         )
 
         exp = _load_experiment(
-            # pyrefly: ignore [missing-attribute]
             experiment.name,
             # pyrefly: ignore [missing-attribute]
             decoder=self.with_db_settings.db_settings.decoder,
@@ -231,7 +229,6 @@ class TestWithDBSettingsBase(TestCase):
         )
         self.assertTrue(saved)
         exp = _load_experiment(
-            # pyrefly: ignore [missing-attribute]
             experiment.name,
             # pyrefly: ignore [missing-attribute]
             decoder=self.with_db_settings.db_settings.decoder,
@@ -245,7 +242,6 @@ class TestWithDBSettingsBase(TestCase):
         )
 
         exp = _load_experiment(
-            # pyrefly: ignore [missing-attribute]
             experiment.name,
             # pyrefly: ignore [missing-attribute]
             decoder=self.with_db_settings.db_settings.decoder,
@@ -267,7 +263,6 @@ class TestWithDBSettingsBase(TestCase):
         )
         self.assertTrue(saved)
         exp = _load_experiment(
-            # pyrefly: ignore [missing-attribute]
             experiment.name,
             # pyrefly: ignore [missing-attribute]
             decoder=self.with_db_settings.db_settings.decoder,
@@ -289,7 +284,6 @@ class TestWithDBSettingsBase(TestCase):
             trials=[trial],
         )
         loaded_experiment = _load_experiment(
-            # pyrefly: ignore [missing-attribute]
             experiment.name,
             # pyrefly: ignore [missing-attribute]
             decoder=self.with_db_settings.db_settings.decoder,
@@ -313,7 +307,6 @@ class TestWithDBSettingsBase(TestCase):
             trials=trials,
         )
         loaded_experiment = _load_experiment(
-            # pyrefly: ignore [missing-attribute]
             experiment.name,
             # pyrefly: ignore [missing-attribute]
             decoder=self.with_db_settings.db_settings.decoder,
@@ -347,7 +340,6 @@ class TestWithDBSettingsBase(TestCase):
         )
 
         loaded_experiment = _load_experiment(
-            # pyrefly: ignore [missing-attribute]
             experiment.name,
             # pyrefly: ignore [missing-attribute]
             decoder=self.with_db_settings.db_settings.decoder,
@@ -365,7 +357,6 @@ class TestWithDBSettingsBase(TestCase):
                     self.assertIsNotNone(getattr(t.generator_run, python_attr_name))
 
         loaded_generation_strategy = _load_generation_strategy_by_experiment_name(
-            # pyrefly: ignore [missing-attribute]
             experiment.name,
             # pyrefly: ignore [missing-attribute]
             decoder=self.with_db_settings.db_settings.decoder,
@@ -390,7 +381,6 @@ class TestWithDBSettingsBase(TestCase):
             experiment_with_updated_properties=experiment
         )
         loaded_experiment = _load_experiment(
-            # pyrefly: ignore [missing-attribute]
             experiment.name,
             # pyrefly: ignore [missing-attribute]
             decoder=self.with_db_settings.db_settings.decoder,
@@ -458,7 +448,6 @@ class TestSQLAlchemyDualVersionCompat(TestCase):
         type when SQLAlchemy is importable. Uses getattr because DBSettings is
         conditionally defined in a try/except in with_db_settings_base.
         """
-        # pyre-ignore[16]: DBSettings is conditionally defined in with_db_settings_base.
         module_dbsettings = getattr(_wdb_module, "DBSettings", None)
         self.assertIsNotNone(
             module_dbsettings,
@@ -477,7 +466,6 @@ class TestSQLAlchemyDualVersionCompat(TestCase):
                 "EXPECTED_SA_MAJOR not set; only enforced under the dual-version "
                 "BUCK targets that pin SQLAlchemy via constraint_overrides"
             )
-        # pyre-ignore[16]: Module `sqlalchemy` has no attribute `__version__`.
         actual_version = sqlalchemy.__version__
         actual_major = int(actual_version.split(".")[0])
         self.assertEqual(

--- a/ax/storage/sqa_store/tests/utils.py
+++ b/ax/storage/sqa_store/tests/utils.py
@@ -46,7 +46,6 @@ from ax.utils.testing.core_stubs import (
 )
 
 
-# pyre-fixme[5]: Global expression must be annotated.
 TEST_CASES = [
     (
         "AbandonedArm",

--- a/ax/storage/sqa_store/with_db_settings_base.py
+++ b/ax/storage/sqa_store/with_db_settings_base.py
@@ -27,11 +27,9 @@ RETRY_EXCEPTION_TYPES: tuple[type[Exception], ...] = ()
 logger: Logger = get_logger(__name__)
 
 try:  # We don't require SQLAlchemy by default.
-    # pyre-fixme[21]: Could not find a name `__version__` defined in module
     # `sqlalchemy`.
     from sqlalchemy import __version__ as sqa_version
 
-    # pyre-fixme[16]: Module `sqlalchemy` has no attribute `__version__`.
     logger.info(f"Ax SQL storage initialized with SQLAlchemy {sqa_version}")
 
     from ax.storage.sqa_store.db import init_engine_and_session_factory
@@ -136,7 +134,6 @@ class WithDBSettingsBase:
             return None, None
 
         exp_id = _get_experiment_id(
-            # pyrefly: ignore [missing-attribute]
             experiment_name=experiment_name,
             # pyrefly: ignore [missing-attribute]
             config=self.db_settings.decoder.config,
@@ -144,7 +141,6 @@ class WithDBSettingsBase:
         if not exp_id:
             return None, None
         gs_id = get_generation_strategy_id(
-            # pyrefly: ignore [missing-attribute]
             experiment_name=experiment_name,
             # pyrefly: ignore [missing-attribute]
             decoder=self.db_settings.decoder,
@@ -637,7 +633,6 @@ def _update_runner_on_experiment_in_db_if_possible(
     suppress_all_errors: bool,  # Used by the decorator.
 ) -> None:
     update_runner_on_experiment(
-        # pyrefly: ignore [bad-argument-type]
         experiment=experiment,
         runner=runner,
         # pyrefly: ignore [bad-argument-type]

--- a/ax/utils/common/logger.py
+++ b/ax/utils/common/logger.py
@@ -27,7 +27,6 @@ class AxOutputNameFilter(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         if not hasattr(record, "output_name"):
-            # pyre-ignore[16]: Record supports arbitrary attributes
             record.output_name = record.name
         return True
 

--- a/ax/utils/common/random.py
+++ b/ax/utils/common/random.py
@@ -22,7 +22,6 @@ def set_rng_seed(seed: int) -> None:
         seed: The random number generator seed.
     """
     random.seed(seed)
-    # pyrefly: ignore [bad-argument-type]
     np.random.seed(seed)
     torch.manual_seed(seed)
 

--- a/ax/utils/common/tests/test_random.py
+++ b/ax/utils/common/tests/test_random.py
@@ -19,7 +19,6 @@ class TestRandom(TestCase):
         # Set the seeds manually & using the helper, and compares the random numbers.
         seed = 0
         random.seed(seed)
-        # pyrefly: ignore [bad-argument-type]
         np.random.seed(seed)
         torch.manual_seed(seed)
         native_rand = random.random()

--- a/ax/utils/common/testutils.py
+++ b/ax/utils/common/testutils.py
@@ -343,7 +343,6 @@ class TestCase(fake_filesystem_unittest.TestCase):
         )
 
     def run(
-        # pyrefly: ignore [bad-function-definition]
         self,
         # pyrefly: ignore [bad-function-definition]
         result: unittest.result.TestResult | None = ...,

--- a/ax/utils/measurement/tests/test_synthetic_functions.py
+++ b/ax/utils/measurement/tests/test_synthetic_functions.py
@@ -21,13 +21,10 @@ from botorch.test_functions import synthetic as botorch_synthetic
 class TestSyntheticFunctions(TestCase):
     def test_branin(self) -> None:
         self.assertEqual(branin.name, "Branin")
-        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
         #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(branin(1, 2), 21.62763539206238)
-        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
         #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(branin(x1=1, x2=2), 21.62763539206238)
-        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
         #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(branin(np.array([1, 2])), 21.62763539206238)
         # pyre-fixme[16]: Item `float` of `Union[float, ndarray]` has no attribute
@@ -36,7 +33,6 @@ class TestSyntheticFunctions(TestCase):
         self.assertAlmostEqual(branin.minimums[0][0], -np.pi)
         self.assertAlmostEqual(branin.fmin, 0.397887, places=6)
         self.assertAlmostEqual(branin.fmax, 308.129, places=3)
-        # pyre-fixme[6]: For 2nd argument expected `_T` but got
         #  `Union[ndarray[typing.Any, typing.Any], float]`.
         self.assertAlmostEqual(branin.fmax, branin(-5, 0), places=3)
         self.assertEqual(branin.domain[0], (-5, 10))
@@ -48,13 +44,10 @@ class TestSyntheticFunctions(TestCase):
 
     def test_hartmann6(self) -> None:
         self.assertEqual(hartmann6.name, "Hartmann6")
-        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
         #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(hartmann6(1, 2, 3, 4, 5, 6), 0.0)
-        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
         #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(hartmann6(x1=1, x2=2, x3=3, x4=4, x5=5, x6=6), 0.0)
-        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
         #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(hartmann6(np.array([1, 2, 3, 4, 5, 6])), 0.0)
         self.assertAlmostEqual(
@@ -73,16 +66,13 @@ class TestSyntheticFunctions(TestCase):
 
     def test_aug_hartmann6(self) -> None:
         self.assertEqual(aug_hartmann6.name, "Aug_Hartmann6")
-        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
         #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(aug_hartmann6(1, 2, 3, 4, 5, 6, 1), 0.0)
         self.assertAlmostEqual(
             aug_hartmann6(x1=1, x2=2, x3=3, x4=4, x5=5, x6=6, x7=1),
-            # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
             #  SupportsAbs[SupportsRound[object]]]` but got `float`.
             0.0,
         )
-        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
         #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(aug_hartmann6(np.array([1, 2, 3, 4, 5, 6, 1])), 0.0)
         self.assertAlmostEqual(
@@ -103,13 +93,10 @@ class TestSyntheticFunctions(TestCase):
 
     def test_aug_branin(self) -> None:
         self.assertEqual(aug_branin.name, "Aug_Branin")
-        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
         #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(aug_branin(1, 2, 1), 21.62763539206238)
-        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
         #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(aug_branin(x1=1, x2=2, x3=1), 21.62763539206238)
-        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
         #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(aug_branin(np.array([1, 2, 1])), 21.62763539206238)
         self.assertAlmostEqual(
@@ -132,13 +119,10 @@ class TestSyntheticFunctions(TestCase):
     def test_botorch_ackley(self) -> None:
         ackley = FromBotorch(botorch_synthetic_function=botorch_synthetic.Ackley())
         self.assertEqual(ackley.name, "FromBotorch_Ackley")
-        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
         #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(ackley(1.0, 2.0), 5.422131717799505)
-        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
         #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(ackley(x1=1.0, x2=2.0), 5.422131717799505)
-        # pyre-fixme[6]: For 2nd argument expected `SupportsRSub[Variable[_T],
         #  SupportsAbs[SupportsRound[object]]]` but got `float`.
         self.assertAlmostEqual(ackley(np.array([1, 2])), 5.422131717799505)
         # pyre-fixme[16]: Item `float` of `Union[float, ndarray]` has no attribute

--- a/ax/utils/stats/tests/test_model_fit_stats.py
+++ b/ax/utils/stats/tests/test_model_fit_stats.py
@@ -53,7 +53,6 @@ class TestModelFitStats(TestCase):
         self.assertAlmostEqual(ax_result, -1.0)
 
     def test_entropy_of_observations(self) -> None:
-        # pyrefly: ignore [bad-argument-type]
         np.random.seed(1234)
         n = 16
         yc = np.ones(n)

--- a/ax/utils/testing/core_stubs.py
+++ b/ax/utils/testing/core_stubs.py
@@ -557,8 +557,6 @@ def get_branin_experiment_with_timestamp_map_metric(
             for m in range(num_objectives)
         ]
         # Add objective metrics so the Experiment owns the real metric types.
-        # pyre-ignore[6]: Covariance issue with list[T]
-        # pyrefly: ignore [bad-argument-type]
         tracking_metrics.extend(
             # pyrefly: ignore [bad-argument-type]
             local_get_map_metric(f"branin_map_{m}")
@@ -980,7 +978,7 @@ def get_branin_with_multi_task(with_multi_objective: bool = False) -> Experiment
             if with_multi_objective
             else get_branin_optimization_config()
         ),
-        tracking_metrics=branin_tracking,  # pyre-ignore[6] covariance
+        tracking_metrics=branin_tracking,
         runner=SyntheticRunner(),
         is_test=True,
     )
@@ -1894,7 +1892,6 @@ class TestTrial(BaseTrial):
 
     def _get_candidate_metadata_from_all_generator_runs(
         self,
-        # pyrefly: ignore [bad-override]
     ) -> dict[str, dict[str, Any] | None]:
         return {"test": None}
 
@@ -1906,12 +1903,9 @@ class TestTrial(BaseTrial):
     def arms(self) -> list[Arm]:
         return self._arms
 
-    # pyrefly: ignore [bad-override]
     @arms.setter
     def arms(self, val: list[Arm]) -> None:
         self._arms = val
-
-    # pyrefly: ignore [bad-override]
 
     # pyrefly: ignore [bad-override]
     def arms_by_name(self) -> str:
@@ -2397,7 +2391,6 @@ def get_branin_multi_objective_optimization_config(
             objective_thresholds.append(
                 ObjectiveThreshold(
                     metric=get_branin_metric(name="branin_c"),
-                    # pyrefly: ignore [bad-assignment]
                     bound=5.0,
                     op=ComparisonOp.LEQ,
                     relative=False,
@@ -2483,15 +2476,11 @@ def get_arms() -> list[Arm]:
     return list(get_arm_weights1().keys())
 
 
-# pyrefly: ignore [bad-argument-type]
-
-
 def get_weights() -> list[float]:
     return list(get_arm_weights1().values())
 
 
 def get_branin_arms(n: int, seed: int) -> list[Arm]:
-    # pyrefly: ignore [bad-argument-type]
     np.random.seed(seed)
     x1_raw = np.random.rand(n)
     x2_raw = np.random.rand(n)
@@ -2707,7 +2696,6 @@ def get_branin_data_batch(
     fill_vals = fill_vals or {}
     metrics = metrics or ["branin"]
     for arm in batch.arms:
-        # pyrefly: ignore [bad-argument-type]
         params = arm.parameters
         for k, v in fill_vals.items():
             if params.get(k, None) is None:


### PR DESCRIPTION
Summary:
This diff was automatically generated by the Pyre per-target upgrade tool.

It removes `# pyre-fixme` or `pyrefly: ignore` comments that are no longer needed because the underlying type errors have been resolved.
Note that it will also aim to ensure type checking runs cleanly, and will add suppressions to existing type errors.

#pyreupgrade

Differential Revision: D116358917
