### PR TITLE
Populate analysis card TTL timestamps

### DIFF
--- a/ax/storage/sqa_store/encoder.py
+++ b/ax/storage/sqa_store/encoder.py
@@ -1255,6 +1255,8 @@ class Encoder:
     ) -> SQAAnalysisCard:
         """Convert Ax analysis to SQLAlchemy."""
 
+        ttl_timestamp = int(analysis_card._timestamp.timestamp())
+
         # pyre-fixme: Expected `Base` for 1st...ot `typing.Type[BaseAnalysis]`.
         analysis_card_class: SQAAnalysisCard = self.config.class_to_sqa_class[
             AnalysisCard
@@ -1267,6 +1269,7 @@ class Encoder:
                 experiment_id=experiment_id,
                 name=analysis_card.name,
                 timestamp=analysis_card._timestamp,
+                ttl_timestamp=ttl_timestamp,
                 order=order,
                 title=analysis_card.title,
                 subtitle=analysis_card.subtitle,
@@ -1307,6 +1310,7 @@ class Encoder:
             experiment_id=experiment_id,
             name=card.name,
             timestamp=card._timestamp,
+            ttl_timestamp=ttl_timestamp,
             order=order,
             title=card.title,
             subtitle=card.subtitle,

--- a/ax/storage/sqa_store/sqa_classes.py
+++ b/ax/storage/sqa_store/sqa_classes.py
@@ -470,6 +470,9 @@ class SQAAnalysisCard(Base):
     )
     name: Mapped[str] = Column(String(NAME_OR_TYPE_FIELD_LENGTH), nullable=False)
     timestamp: Mapped[datetime] = Column(IntTimestamp, nullable=False)
+    ttl_timestamp: Mapped[int] = Column(
+        BigInteger, nullable=False, server_default="18446744073709551615"
+    )
 
     parent_id: Mapped[int | None] = Column(
         Integer,

--- a/ax/storage/sqa_store/tests/test_sqa_store.py
+++ b/ax/storage/sqa_store/tests/test_sqa_store.py
@@ -128,6 +128,7 @@ from ax.storage.sqa_store.save import (
 )
 from ax.storage.sqa_store.sqa_classes import (
     SQAAbandonedArm,
+    SQAAnalysisCard,
     SQAArm,
     SQAExperiment,
     SQAGeneratorRun,
@@ -3085,6 +3086,11 @@ class SQAStoreTest(TestCase):
                 big_group,
                 self.experiment,
             )
+            for saved_card in get_session().query(SQAAnalysisCard).all():
+                self.assertEqual(
+                    saved_card.ttl_timestamp,
+                    int(saved_card.timestamp.timestamp()),
+                )
 
         with self.subTest("test_load_analysis_cards"):
             loaded_analysis_cards = load_analysis_cards_by_experiment_name(


### PR DESCRIPTION
Summary:
- map the sentinel-backed `analysis_card_v2.ttl_timestamp` column in SQA
- copy each group and leaf card creation timestamp into the TTL column
- verify persisted TTL timestamps match the existing card timestamp

Differential Revision: D117531053


