### PR TITLE
Speed up test_ax_sweep_impl_minimal by mocking Sobol sensitivity MC samples

### DIFF
--- a/ax/utils/testing/mock.py
+++ b/ax/utils/testing/mock.py
@@ -11,6 +11,7 @@ from functools import wraps
 from typing import Any
 from unittest import mock
 
+from ax.utils.sensitivity import sobol_measures
 from botorch.fit import fit_fully_bayesian_model_nuts
 from botorch.optim.optimize_mixed import optimize_acqf_mixed_alternating
 from botorch.test_utils.mock import mock_optimize_context_manager
@@ -130,6 +131,58 @@ def mock_botorch_optimize(f: Callable) -> Callable:
     @wraps(f)
     def inner(*args: Any, **kwargs: Any) -> Any:
         with mock_botorch_optimize_context_manager():
+            return f(*args, **kwargs)
+
+    return inner
+
+
+@contextmanager
+def mock_sensitivity_analysis_context_manager(
+    num_mc_samples: int = 32,
+) -> Generator[None, None, None]:
+    """A context manager that shrinks the Monte-Carlo sample count used by
+    variance-based sensitivity analysis (Sobol indices).
+
+    ``ax_parameter_sens`` defaults to ``num_mc_samples=10**4``, which means
+    ``O(num_mc_samples * num_params)`` posterior-mean evaluations per call. On a
+    fully Bayesian model each of those is multiplied by the number of MCMC
+    samples, so a single call can take tens of seconds even on a handful of
+    training points. Tests that exercise reporting/analysis code paths
+    (``get_standard_plots``, ``SensitivityAnalysisPlot``, ``OverviewAnalysis``)
+    pay this cost once per call and are dominated by it.
+
+    Note that ``mock_botorch_optimize`` does not help here: it makes *fitting*
+    cheap, not posterior evaluation.
+
+    Do not use this in tests that assert on sensitivity values, since a small
+    sample count makes the estimates noisy.
+
+    Args:
+        num_mc_samples: The Monte-Carlo sample count to force.
+    """
+    with ExitStack() as es:
+        for fn_name in (
+            "compute_sobol_indices_from_model_list",
+            "compute_derivatives_from_model_list",
+        ):
+            original = getattr(sobol_measures, fn_name)
+
+            def few_samples(
+                *args: Any, __original: Any = original, **kwargs: Any
+            ) -> Tensor:
+                kwargs.setdefault("num_mc_samples", num_mc_samples)
+                return __original(*args, **kwargs)
+
+            es.enter_context(mock.patch.object(sobol_measures, fn_name, few_samples))
+        yield
+
+
+def mock_sensitivity_analysis(f: Callable) -> Callable:
+    """Wraps `f` in `mock_sensitivity_analysis_context_manager` as a decorator."""
+
+    @wraps(f)
+    def inner(*args: Any, **kwargs: Any) -> Any:
+        with mock_sensitivity_analysis_context_manager():
             return f(*args, **kwargs)
 
     return inner


### PR DESCRIPTION
Summary:
`automl.internal.ax.ax_sweep.tests.test_ax_sweep_feature_matrix.TestAxSweepFeatureMatrix.test_ax_sweep_impl_minimal` (T562950220699357) has been timing out on stress runs against TPX's 600s limit. Profiling shows the runtime is dominated by variance-based (Sobol) sensitivity analysis, not by the number of analysis cards:

- `AxSweepOrchestrator.report_results` is called 4x and accounts for 110.2s of a 127.2s local run (87%): `_compute_and_save_analysis_cards` 67.3s, legacy `get_standard_plots` 38.5s.
- Exclusive per-`Analysis` accounting: `SensitivityAnalysisPlot` 65.9s over 2 calls; every other analysis is under 0.5s.
- `ax_parameter_sens` defaults to `num_mc_samples = 10**4`, so each call is O(num_mc_samples * num_params) posterior-mean evaluations, multiplied by the MCMC sample count on this test's fully Bayesian (SAASBO) model. `mock_botorch_optimize` does not help, since it cheapens fitting, not posterior evaluation.
- It runs 4x per test: twice via `get_standard_plots` -> `ax_parameter_sens(order="total")` and twice via `OverviewAnalysis` -> `InsightsAnalysis` -> `TopSurfacesAnalysis` -> `SensitivityAnalysisPlot`, where `_choose_sensitivity_order(3)` selects the most expensive `"second"` order.

This adds an opt-in `mock_sensitivity_analysis` decorator / context manager to `ax/utils/testing/mock.py` that forces `num_mc_samples=32` in `compute_sobol_indices_from_model_list` and `compute_derivatives_from_model_list`, and applies it to `execute_ax_sweep_and_make_assertions`. Nothing in that test asserts on sensitivity values -- only that the expected number of plots is produced -- so the reduced sample count is safe here.

Note that Ax's own `TestCase.MAX_TEST_SECONDS = 120` guard does fire on this test, but the resulting `TimeoutError` is swallowed by `Analysis.compute_result`'s broad `except Exception` (surfacing only as a "Failed to compute SensitivityAnalysisPlot" error card) and by `report_results`' broad handlers, so the test still reported ok. That is worth fixing separately.

Differential Revision: D118535425


