### PR TITLE
Clarify objective signs in getting started guide

### DIFF
--- a/tutorials/getting_started/getting_started.ipynb
+++ b/tutorials/getting_started/getting_started.ipynb
@@ -124,9 +124,12 @@
         "This method expects a string `objective`, an expression containing either a single metric to maximize, a linear combination of metrics to maximize, or a tuple of multiple metrics to jointly maximize.\n",
         "These expressions are parsed using [SymPy](https://www.sympy.org/en/index.html). For example:\n",
         "* `\"score\"` would direct Ax to maximize a metric named score\n",
-        "* `\"-loss\"` would direct Ax to Ax to minimize a metric named loss\n",
+        "* `\"-loss\"` would direct Ax to minimize a metric named loss\n",
         "* `\"task_0 + 0.5 * task_1\"` would direct Ax to maximize the sum of two task scores, downweighting task_1 by a factor of 0.5\n",
         "* `\"score, -flops\"` would direct Ax to simultaneously maximize score while minimizing flops\n",
+        "\n",
+        "The signs in the objective expression specify optimization direction; they do not transform the observed metric data. \n",
+        "Report each metric's original evaluation value to `Client.complete_trial`. For example, with `objective=\"-loss\"`, an observed loss of `2.5` should be reported as `raw_data={\"loss\": 2.5}`. \n",
         "\n",
         "See these recipes for more information on configuring [objectives](../../recipes/multi-objective-optimization) and [outcome constraints](../../recipes/outcome-constraints)."
       ]
@@ -150,7 +153,9 @@
         "## Step 5: Run Trials\n",
         "Here, we will configure the ask-tell loop.\n",
         "\n",
-        "We begin by defining the Hartmann6 function as written above.\n",
+        "We begin by defining the Hartmann6 function as written above. \n",
+        "The leading negative sign in its definition is intrinsic to the Hartmann6 function; ",
+        "it is separate from the negative sign in the objective expression that tells Ax to minimize the metric.\n",
         "Remember, this is just an example problem and any Python function can be substituted here."
       ]
     },
@@ -218,7 +223,7 @@
         "\n",
         "        result = hartmann6(x1, x2, x3, x4, x5, x6)\n",
         "\n",
-        "        # Set raw_data as a dictionary with metric names as keys and results as values\n",
+        "        # Report the original function value; the objective expression controls direction\n",
         "        raw_data = {metric_name: result}\n",
         "\n",
         "        # Complete the trial with the result\n",


### PR DESCRIPTION
Summary:
Clarify that objective-expression signs control optimization direction while `raw_data` should contain the original observed metric values. Distinguish the negative sign intrinsic to Hartmann6 from the negative objective sign used to minimize it.

Resolves https://github.com/facebook/Ax/issues/5283.

Differential Revision: D119166605


