### PR TITLE
Decode graphviz SVG bytes in analysis card HTML body

### DIFF
--- a/ax/analysis/graphviz/graphviz_analysis.py
+++ b/ax/analysis/graphviz/graphviz_analysis.py
@@ -20,6 +20,8 @@ class GraphvizAnalysisCard(AnalysisCard):
         Return the a HTML div with the Graphviz figure as an SVG.
         """
         svg = self.get_digraph().pipe(format="svg")
+        if isinstance(svg, bytes):
+            svg = svg.decode("utf-8")
 
         return f"<div>{svg}</div>"
 

--- a/ax/analysis/graphviz/tests/test_generation_strategy_graph.py
+++ b/ax/analysis/graphviz/tests/test_generation_strategy_graph.py
@@ -5,6 +5,8 @@
 
 # pyre-strict
 
+from unittest.mock import patch
+
 from ax.adapter.registry import Generators
 from ax.analysis.graphviz.generation_strategy_graph import (
     _add_edges_for_node,
@@ -25,7 +27,7 @@ from ax.generation_strategy.transition_criterion import (
     MinTrials,
 )
 from ax.utils.common.testutils import TestCase
-from graphviz import Digraph
+from graphviz import Digraph, Source
 
 
 class TestGenerationStrategyGraph(TestCase):
@@ -280,3 +282,21 @@ class TestGenerationStrategyGraph(TestCase):
         # First node should be current
         self.assertTrue(df.iloc[0]["is_current"])
         self.assertFalse(df.iloc[1]["is_current"])
+
+    def test_body_html_decodes_pipe_output(self) -> None:
+        """Test that the card body contains SVG markup, not a bytes literal.
+
+        ``graphviz.Source.pipe`` returns ``bytes`` when no encoding is given,
+        so the SVG has to be decoded before it is embedded in the card's HTML.
+        """
+        analysis = GenerationStrategyGraph()
+        card = analysis.compute(generation_strategy=self.node_gs)
+
+        svg_bytes = b'<svg xmlns="http://www.w3.org/2000/svg"><g/></svg>'
+        with patch.object(Source, "pipe", return_value=svg_bytes) as mock_pipe:
+            body_html = card._body_html(depth=0)
+
+        mock_pipe.assert_called_once_with(format="svg")
+        self.assertNotIn("b'", body_html)
+        self.assertIn("<svg", body_html)
+        self.assertTrue(body_html.startswith("<div>"))


### PR DESCRIPTION
Graphviz cards (the Generation Strategy Graph you get from compute_analyses, and the hierarchical search space one) were showing a wall of raw text instead of a graph in notebooks.

graphviz's Source.pipe returns bytes unless you pass an encoding, and the card was embedding that bytes object straight into its HTML div - so the browser got something like b'<?xml ...' as text rather than an <svg> element to render.

Decode the pipe output to a string before putting it in the HTML. Also added a small regression test that mocks pipe to return bytes and checks the body actually contains an <svg> tag.